### PR TITLE
autogen: discover image encoders instead of declaring them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Go module (`go.mod`). `Makefile` at root. Build binaries into `./build/`. Window
 
 - Summaries: only include details needing further action; else "Done."
 - PRs (`gh` CLI): short, focused on changes, no test plan, summary in commit-message style.
+- Branches: features go on `<dev_name>/<feature>` (e.g. `radu0120/encoder-pool`), one branch per feature, opened as a PR against `main`. Never commit a feature straight to `main`.
 - Commit format:
 
   ```

--- a/internal/autogen/CLAUDE.md
+++ b/internal/autogen/CLAUDE.md
@@ -45,6 +45,7 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
 | `liveoffload.go` | Spawn-time placement recompute (`LiveOffloadArgs`). → `liveoffload.md` |
 | `vllm.go` | Backend selection (`resolveBackend`, `resolveBackendPreferring`, `kindClass`) + the vllm emitter. → `backends.md` |
 | `rope.go` | `ropeCeiling`/`ropeFactor` — the only path that lifts the trained-ctx ceiling. → `sizing.md` |
+| `encoderpool.go` | Diffusion component auto-discovery: classifies every VAE / CLIP / T5 / text-encoder LLM on disk from its header (safetensors tensor table or gguf metadata), pairs each encoder with the mmproj beside it, and fills the blanks in `settings.encoders`. Matched to a DiT by `Metadata.CondHidden`. -> `classes.md` |
 | `audio.go`, `asr.go`, `sam.go`, `image.go`, `embedding.go` | Non-LLM class emitters. → `classes.md` |
 
 ## Important types & functions
@@ -185,6 +186,15 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
   opt-out is the existing spec override (no `draft-*` → no `-md`) and marking the vision twin
   unlisted. `ModelBaseKey`/`FamilyKey` mirror `baseKey`/`familyOf` in
   `ui-svelte/src/lib/modelTable.ts` — change one, change both.
+- **`settings.encoders` is now a PIN, not the source.** Diffusion component paths are
+  discovered structurally (`encoderpool.go`, see `classes.md`), and `fillEncoderSet` fills only
+  the roles left blank, so a declared path always wins and no existing config changes behaviour.
+  Two consequences worth remembering: the pool holds every ordinary chat gguf too (any decoder
+  can be a text encoder), so a change to how candidates are ranked can silently re-point a
+  working image model, and `resolveComponents` therefore takes both the pool and the DiT's
+  `CondHidden` - a caller that passes 0 gets the declared-only behaviour, which is exactly what
+  the older tests assert.
+
 - **A new quant type needs THREE tables, and the header gate is why.** `quantRe` (`discover.go`)
   names it in a FILENAME, `ggmlTypeSize` (`gguf.go`) sizes its tensors, `ggmlTypeName`
   (`quantlabel.go`) names the TYPE id (a type that can be weighed but not named makes every file

--- a/internal/autogen/classes.md
+++ b/internal/autogen/classes.md
@@ -43,8 +43,8 @@ Per-model image knobs live on `Override` (`VaePath`/`ClipLPath`/`ClipGPath`/`T5P
 
 ### Diffusion encoders/VAEs are dropped at discovery, not paired
 
-A T5-XXL / UMT5 / CLIP-L/G / VAE gguf is a *component* of an image model —
-`image.go`'s `resolveComponents` wires it in by explicit path from `settings.encoders`, so
+A T5-XXL / UMT5 / CLIP-L/G / VAE gguf is a *component* of an image model:
+`image.go`'s `resolveComponents` wires it in as a `--vae`/`--clip_l`/`--t5xxl`/`--llm` path, so
 discovery has nothing to pair it to. Left alone it parses as an ordinary gguf, gets emitted as
 a llama-server row and shows up in the UI as an LLM ("T5 V1 1 Xxl Encoder") — an encoder-only
 stack with no decoder and no chat template, which can't generate.
@@ -54,6 +54,51 @@ stack with no decoder and no chat template, which can't generate.
 header arch. **Both rules are deliberately narrow on `t5`**: bare arch `t5` and a name like
 `flan-t5-large` are a real seq2seq LLM llama.cpp serves, so only `t5encoder`/`umt5` and the
 encoder-shaped names are excluded.
+
+### Components are DISCOVERED, not declared (`encoderpool.go`)
+
+`settings.encoders` used to be the only source of those paths: one hand-written path per role,
+per machine, which broke on every models-tree move and made a newly downloaded diffusion model
+a config chore. `ScanEncoderPool` now classifies every component on disk from its header, and
+`fillEncoderSet` fills only the roles the user left blank (**a declared path always wins**, so
+existing configs are untouched).
+
+Everything it keys on is structural, because filenames are not: three unrelated files on the
+dev box are all named `ae.safetensors`, and two of those are byte-identical copies.
+
+| Role | Signal | What it separates |
+|---|---|---|
+| VAE | `decoder.conv_in.weight` shape[1] | latent channels: 4 = SD/SDXL, 16 = flux.1 `ae`, 32 = flux.2/ERNIE |
+| VAE (3D) | `conv1.weight` is 5-dim | the Wan-2.1 causal VAE (Wan / Krea / Qwen-Image) |
+| CLIP | `text_model.embeddings.token_embedding.weight` shape[1] | 768 = CLIP-L, 1280 = CLIP-G |
+| T5 | `encoder.block.0.layer.0.SelfAttention.q.weight` | widest wins (T5-XXL is 4096) |
+| LLM | gguf `embedding_length` / `model.embed_tokens` shape[1] | matched against the DiT (below) |
+
+`.safetensors` costs one header read (8-byte LE length + JSON table at offset 0), so the price
+is independent of file size; ggufs come through `ReadGgufMetadataCached`. Scans are cached per
+root set for 30s (`encoderPoolFor`), since a regen runs on every settings save and watcher tick.
+
+**The DiT states the encoder it wants.** `Metadata.CondHidden` (`quantlabel.go`'s
+`condTensorOrder`, filled by the tensor walk) is `ne[0]` of the caption projection —
+`txt_in.weight`, `cap_embedder.1.weight`, `text_proj.weight`, `context_embedder.weight` or
+LongCat's `txtfusion...prenorm.scale`, in that order. Matching it to an encoder's hidden width
+picks the right file with no name table: 3584 = Qwen2.5-VL-7B (LongCat, Qwen-Image-Edit),
+2560 = Qwen3-4B (Z-Image, Krea), 3072 = Ministral-3B (ERNIE), 4096 = T5-XXL (flux).
+
+Width is **not** an identity on its own (five unrelated 2560-wide models are installed here), so
+ties break on `encoderArchRank` first: Qwen > Mistral > Gemma/Llama > unknown. That table is
+shipped knowledge about what DiTs are trained against, not per-machine tuning. Drafter sidecars
+(`mtp-*`, dflash) and pooled embedders are excluded outright: their widths collide with real
+encoders and neither can condition anything.
+
+**`--llm_vision` pairs by directory.** `pairProjectors` attaches each encoder gguf to the
+`mmproj-*` beside it, the same convention `inheritSidecars` uses for vision LLMs, so the
+projector for a chosen `--llm` is simply its neighbour. Whether a model *wants* one is the one
+thing that cannot be read off the weights: LongCat-Image-Edit and plain LongCat-Image have
+identical `img_in`/`txt_in` shapes (the reference image enters as extra sequence tokens, not
+extra input channels), so `editModelRe` name-detects it, with `llmVision: on|off` and
+`llmVisionPath` as the escape hatches. Sampling knobs stay hand-wired: LongCat-Edit still wants
+`extraArgs: "--flow-shift 3"`, which has no structural tell.
 
 ## Embedding (`embedding.go`)
 

--- a/internal/autogen/encoderpool.go
+++ b/internal/autogen/encoderpool.go
@@ -1,0 +1,531 @@
+package autogen
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/quartermaster-labs/quartermaster/internal/config"
+)
+
+// Diffusion component auto-discovery.
+//
+// A bare --diffusion-model GGUF carries no VAE and no text encoder, so sd-server
+// needs those wired as separate files. They used to come exclusively from
+// settings.encoders: a hand-written path per role, per machine, which is the
+// opposite of this project's "no hand tuning" goal and silently broke whenever
+// the models tree moved.
+//
+// Every one of those files announces what it is, structurally, in its header, so
+// the pool is discovered instead of declared:
+//
+//   - a VAE has an encoder/decoder conv stack, and the thing that makes two VAEs
+//     incompatible (latent channel count) is literally decoder.conv_in's input
+//     width: 4 = SD/SDXL, 16 = flux.1 "ae", 32 = flux.2. Filenames cannot do
+//     this job: three unrelated files on the dev box are all "ae.safetensors",
+//     and two of those turned out to be byte-identical copies.
+//   - a CLIP has text_model.embeddings.token_embedding, whose width separates
+//     CLIP-L (768) from CLIP-G (1280).
+//   - a text-encoder LLM reports its own hidden width (gguf embedding_length, or
+//     safetensors model.embed_tokens), and the DiT that needs it states the width
+//     it expects in its caption-projection tensor (Metadata.CondHidden). Matching
+//     those two numbers picks the right encoder with no name table: verified
+//     against LongCat and Qwen-Image-Edit (3584 = Qwen2.5-VL-7B), Z-Image and
+//     Krea2 (2560 = Qwen3-4B / Qwen3-VL-4B), ERNIE (3072 = Ministral-3B) and
+//     flux (4096 = T5-XXL).
+//
+// settings.encoders still wins wherever it is set, so an existing config keeps
+// working and an odd pick stays overridable.
+
+// ComponentRole is what a discovered component file is FOR. One file has exactly
+// one role; the family/width fields below say which models can use it.
+type ComponentRole string
+
+const (
+	RoleNone ComponentRole = ""
+	RoleVae  ComponentRole = "vae"
+	RoleClip ComponentRole = "clip"
+	RoleT5   ComponentRole = "t5"
+	RoleLlm  ComponentRole = "llm"
+	// roleProj is a vision projector: paired to an llm, never picked alone.
+	roleProj ComponentRole = "mmproj"
+)
+
+// VAE families, keyed by latent channel count (decoder.conv_in input width).
+// The count IS the compatibility class: a 16-channel model cannot decode a
+// 4-channel latent, so a family mismatch is a broken image, not a quality knob.
+const (
+	VaeFamilySD    = "sd"    // 4 ch: SD1/SD2/SDXL
+	VaeFamilyFlux  = "flux"  // 16 ch: flux.1 "ae", and every model that reuses it
+	VaeFamilyFlux2 = "flux2" // 32 ch: flux.2 / ERNIE (AutoencoderKLFlux2)
+	VaeFamilyWan3D = "wan3d" // Wan 2.1-derived 3D causal VAE (conv1 is 5-dim)
+)
+
+// ComponentFile is one classified file on disk.
+type ComponentFile struct {
+	Path   string
+	Role   ComponentRole
+	Family string // VAE family, or the gguf arch for an llm/t5
+	Width  int64  // hidden width: clip 768/1280, llm/t5 embedding length
+	SizeGB float64
+	Mmproj string // llm only: the vision projector paired to it (see pairProjectors)
+	Vision bool   // llm only: carries (or is paired to) a vision tower
+}
+
+// EncoderPool is the discovered set of component files.
+type EncoderPool struct {
+	Files []ComponentFile
+}
+
+// safetensorsHeaderCap bounds the JSON header read. Real headers are tens of KB
+// (a few hundred for a full checkpoint); anything past this is a corrupt or
+// hostile length field, not a model.
+const safetensorsHeaderCap = 64 << 20
+
+type stTensor struct {
+	DType string  `json:"dtype"`
+	Shape []int64 `json:"shape"`
+}
+
+// readSafetensorsHeader parses the tensor table at the head of a .safetensors
+// file: an 8-byte little-endian JSON length, then that many bytes of JSON. Only
+// the header is read, so the cost is independent of the file size.
+func readSafetensorsHeader(path string) (map[string]stTensor, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var n uint64
+	if err := binary.Read(f, binary.LittleEndian, &n); err != nil {
+		return nil, err
+	}
+	if n == 0 || n > safetensorsHeaderCap {
+		return nil, io.ErrUnexpectedEOF
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return nil, err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(buf, &raw); err != nil {
+		return nil, err
+	}
+	out := make(map[string]stTensor, len(raw))
+	for k, v := range raw {
+		if k == "__metadata__" {
+			continue
+		}
+		var t stTensor
+		if json.Unmarshal(v, &t) == nil {
+			out[k] = t
+		}
+	}
+	return out, nil
+}
+
+// classifySafetensors identifies a .safetensors component from its tensor table.
+// Returns RoleNone for anything that is not a component (a DiT, a LoRA, a full
+// checkpoint) so the caller can ignore it.
+func classifySafetensors(h map[string]stTensor, sizeGB float64, path string) ComponentFile {
+	c := ComponentFile{Path: path, SizeGB: sizeGB}
+	dim := func(name string, i int) int64 {
+		t, ok := h[name]
+		if !ok || i >= len(t.Shape) {
+			return 0
+		}
+		return t.Shape[i]
+	}
+	switch {
+	// 2D AE (SD / flux lineage). decoder.conv_in.weight is [out, latent, 3, 3],
+	// so shape[1] is the latent channel count = the compatibility family.
+	case dim("decoder.conv_in.weight", 1) > 0:
+		c.Role = RoleVae
+		switch dim("decoder.conv_in.weight", 1) {
+		case 4:
+			c.Family = VaeFamilySD
+		case 16:
+			c.Family = VaeFamilyFlux
+		case 32:
+			c.Family = VaeFamilyFlux2
+		default:
+			return ComponentFile{}
+		}
+	// Wan 2.1-derived 3D causal VAE: conv1.weight is 5-dim. Qwen-Image's VAE has
+	// the identical shape table, so this family needs a path hint to pick between
+	// two files (see EncoderPool.Vae).
+	case len(h["conv1.weight"].Shape) == 5:
+		c.Role = RoleVae
+		c.Family = VaeFamilyWan3D
+	// CLIP text tower. token_embedding is [vocab, width]; 768 = CLIP-L, 1280 = G.
+	case dim("text_model.embeddings.token_embedding.weight", 1) > 0:
+		c.Role = RoleClip
+		c.Width = dim("text_model.embeddings.token_embedding.weight", 1)
+	// A plain decoder LLM used as a text encoder (ERNIE takes Ministral-3 this
+	// way). Hidden width comes from the embedding table; a vision_tower prefix
+	// means it can also condition on a reference image.
+	case dim("model.embed_tokens.weight", 1) > 0:
+		c.Role = RoleLlm
+		c.Width = dim("model.embed_tokens.weight", 1)
+		for k := range h {
+			if strings.HasPrefix(k, "vision_tower.") || strings.HasPrefix(k, "visual.") {
+				c.Vision = true
+				break
+			}
+		}
+	// T5 encoder stack.
+	case dim("encoder.block.0.layer.0.SelfAttention.q.weight", 0) > 0:
+		c.Role = RoleT5
+		c.Width = dim("encoder.block.0.layer.0.SelfAttention.q.weight", 0)
+	default:
+		return ComponentFile{}
+	}
+	return c
+}
+
+// ScanEncoderPool walks the model roots and classifies every diffusion component
+// it finds. GGUF headers come from the shared metadata cache, so a component
+// GGUF is not parsed twice when discovery has already read it.
+func ScanEncoderPool(roots []string) *EncoderPool {
+	p := &EncoderPool{}
+	projByDir := map[string]ComponentFile{}
+	seen := map[string]bool{}
+	for _, root := range roots {
+		if strings.TrimSpace(root) == "" {
+			continue
+		}
+		abs, err := filepath.Abs(root)
+		if err != nil {
+			continue
+		}
+		filepath.WalkDir(abs, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			key := config.PathKey(path)
+			if seen[key] {
+				return nil
+			}
+			fi, e := d.Info()
+			if e != nil {
+				return nil
+			}
+			sizeGB := round(float64(fi.Size())/gib, 2)
+			switch strings.ToLower(filepath.Ext(path)) {
+			case ".safetensors":
+				h, e := readSafetensorsHeader(path)
+				if e != nil {
+					return nil
+				}
+				if c := classifySafetensors(h, sizeGB, path); c.Role != RoleNone {
+					seen[key] = true
+					p.Files = append(p.Files, c)
+				}
+			case ".gguf":
+				meta, e := ReadGgufMetadataCached(path)
+				if e != nil {
+					return nil
+				}
+				arch := strings.ToLower(strings.TrimSpace(meta.Architecture))
+				switch {
+				case arch == "clip":
+					// A vision projector is never a standalone encoder: it is
+					// paired to the LLM gguf sitting beside it.
+					projByDir[config.PathKey(filepath.Dir(path))] = ComponentFile{
+						Path: path, Role: roleProj, SizeGB: sizeGB,
+					}
+				case encoderArch[arch]:
+					seen[key] = true
+					p.Files = append(p.Files, ComponentFile{
+						Path: path, Role: RoleT5, Family: arch,
+						Width: meta.EmbeddingLength, SizeGB: sizeGB,
+					})
+				case isImageArch(effectiveImageArch(meta)) || meta.EmbeddingLength == 0:
+					// A diffusion model, or something with no hidden width:
+					// not usable as a text encoder.
+				case isDraftSidecar(filepath.Base(path)):
+					// A drafter is a reduced head, not an encoder. Its width
+					// can coincide with a real encoder's (the Gemma-4 MTP
+					// sidecars are the case), so leaving it in the pool risks
+					// conditioning a diffusion model on a speculation head.
+				case IsEmbeddingModel(meta):
+					// A pooled embedder emits one vector for the whole prompt,
+					// not the per-token sequence a DiT cross-attends to.
+				default:
+					seen[key] = true
+					p.Files = append(p.Files, ComponentFile{
+						Path: path, Role: RoleLlm, Family: arch,
+						Width: meta.EmbeddingLength, SizeGB: sizeGB,
+					})
+				}
+			}
+			return nil
+		})
+	}
+	p.pairProjectors(projByDir)
+	sort.Slice(p.Files, func(i, j int) bool { return p.Files[i].Path < p.Files[j].Path })
+	return p
+}
+
+// isDraftSidecar reports whether a gguf filename is one of the speculation
+// sidecars discovery already refuses to serve on its own. The pool reuses the
+// same patterns so a drafter never becomes a text encoder.
+func isDraftSidecar(base string) bool {
+	return mtpFileRe.MatchString(base) || fastMtpFileRe.MatchString(base) || dflashFileRe.MatchString(base)
+}
+
+// pairProjectors attaches each LLM gguf to the vision projector in its own
+// directory, reusing the convention discovery already relies on for vision LLMs
+// (publishers ship "mmproj-*.gguf" beside the model). This is what makes
+// --llm_vision free: the projector for a chosen --llm is simply its neighbour.
+func (p *EncoderPool) pairProjectors(projByDir map[string]ComponentFile) {
+	for i := range p.Files {
+		if p.Files[i].Role != RoleLlm {
+			continue
+		}
+		if proj, ok := projByDir[config.PathKey(filepath.Dir(p.Files[i].Path))]; ok {
+			p.Files[i].Mmproj = proj.Path
+			p.Files[i].Vision = true
+		}
+	}
+}
+
+// Vae returns the discovered VAE of a family, or "" when none is on disk. hints
+// are path substrings preferred when a family holds more than one file: the
+// Wan-2.1 and Qwen-Image VAEs have the same shape table (same 194 tensors, every
+// dimension equal), so nothing but the path distinguishes them. With several
+// candidates and no hint match the pick is the first path in sorted order, which
+// is at least stable across regens.
+func (p *EncoderPool) Vae(family string, hints ...string) string {
+	if p == nil {
+		return ""
+	}
+	var cands []ComponentFile
+	for _, f := range p.Files {
+		if f.Role == RoleVae && f.Family == family {
+			cands = append(cands, f)
+		}
+	}
+	if len(cands) == 0 {
+		return ""
+	}
+	for _, h := range hints {
+		h = strings.ToLower(h)
+		if h == "" {
+			continue
+		}
+		for _, c := range cands {
+			if strings.Contains(strings.ToLower(filepath.ToSlash(c.Path)), h) {
+				return c.Path
+			}
+		}
+	}
+	return cands[0].Path
+}
+
+// Clip returns the discovered CLIP tower of a given width (768 = L, 1280 = G).
+func (p *EncoderPool) Clip(width int64) string {
+	if p == nil {
+		return ""
+	}
+	for _, f := range p.Files {
+		if f.Role == RoleClip && f.Width == width {
+			return f.Path
+		}
+	}
+	return ""
+}
+
+// T5 returns the discovered T5/UMT5 encoder, preferring the widest: T5-XXL is
+// 4096, and a stray smaller T5 would condition a flux model into mush.
+func (p *EncoderPool) T5() string {
+	if p == nil {
+		return ""
+	}
+	best := ComponentFile{}
+	for _, f := range p.Files {
+		if f.Role == RoleT5 && f.Width >= best.Width {
+			best = f
+		}
+	}
+	return best.Path
+}
+
+// encoderArchRank ranks a candidate text encoder by how likely its arch is to be
+// the one a diffusion model was trained against. Hidden width alone is NOT an
+// identity: on the dev box FIVE unrelated 2560-wide models are installed (Qwen3-4B,
+// Qwen3.5-4B, Qwen3-VL-4B, Granite-4.2-3B, Gemma-4-E4B), and picking the wrong one
+// produces confident garbage rather than an error, so a size tiebreak alone was
+// wiring Z-Image to Gemma.
+//
+// The ranking is shipped knowledge, not per-machine tuning: essentially every
+// LLM-conditioned DiT in circulation (Qwen-Image, Z-Image, LongCat, Krea,
+// Flux.2-Klein) conditions on a Qwen, and the Mistral rung covers ERNIE-Image and
+// Flux.2-dev. Lumina-Image-2.0 proper is the known exception (it conditions on
+// Gemma-2), which is why Gemma is ranked rather than excluded, and why
+// settings.encoders / textEncoderPath still win outright.
+func encoderArchRank(arch string) int {
+	a := strings.ToLower(arch)
+	switch {
+	case strings.HasPrefix(a, "qwen"):
+		return 3
+	case strings.HasPrefix(a, "mistral") || strings.HasPrefix(a, "ministral"):
+		return 2
+	case strings.HasPrefix(a, "gemma") || strings.HasPrefix(a, "llama"):
+		return 1
+	}
+	return 0
+}
+
+// better orders two same-width candidates: known encoder arch first, then the
+// larger file (the encoder runs once per generation, usually on the CPU, so a
+// higher quant is nearly free), then the path so a regen is reproducible.
+func better(f, best ComponentFile) bool {
+	if r, br := encoderArchRank(f.Family), encoderArchRank(best.Family); r != br {
+		return r > br
+	}
+	if f.SizeGB != best.SizeGB {
+		return f.SizeGB > best.SizeGB
+	}
+	return f.Path < best.Path
+}
+
+// Llm returns the text-encoder LLM whose hidden width matches what the DiT's
+// caption projection expects, plus its vision projector when one is paired.
+// wantVision restricts the pick to encoders that have one: an edit model without
+// its vision tower does not fail, it silently conditions on nothing and emits an
+// unrelated image, which is worse than not starting at all.
+//
+// Ties break by encoderArchRank, then file size, then path (see better).
+func (p *EncoderPool) Llm(hidden int64, wantVision bool) (path, mmproj string) {
+	if p == nil {
+		return "", ""
+	}
+	if hidden <= 0 {
+		return "", ""
+	}
+	var best ComponentFile
+	for _, f := range p.Files {
+		if f.Role != RoleLlm || f.Width != hidden {
+			continue
+		}
+		if wantVision && !f.Vision {
+			continue
+		}
+		if best.Path == "" || better(f, best) {
+			best = f
+		}
+	}
+	return best.Path, best.Mmproj
+}
+
+// Pool scans are cached per root set: a regen happens on every settings save and
+// on every models-watcher tick, and re-walking the tree (plus re-reading every
+// safetensors header) each time would dominate. The TTL keeps a freshly
+// downloaded encoder from needing a restart to be seen.
+var (
+	poolCacheMu sync.Mutex
+	poolCache   = map[string]*cachedPool{}
+)
+
+const poolCacheTTL = 30 * time.Second
+
+type cachedPool struct {
+	pool *EncoderPool
+	at   time.Time
+}
+
+func encoderPoolFor(roots []string) *EncoderPool {
+	key := strings.Join(roots, "\x00")
+	poolCacheMu.Lock()
+	e, ok := poolCache[key]
+	poolCacheMu.Unlock()
+	if ok && time.Since(e.at) < poolCacheTTL {
+		return e.pool
+	}
+	p := ScanEncoderPool(roots)
+	poolCacheMu.Lock()
+	poolCache[key] = &cachedPool{pool: p, at: time.Now()}
+	poolCacheMu.Unlock()
+	return p
+}
+
+// fillEncoderSet returns declared with every blank field filled from what the
+// scan actually found on disk. Declared paths always win: an explicit setting is
+// a deliberate statement about a machine, and silently second-guessing it would
+// make a working config drift.
+//
+// The hints exist because a family can hold more than one file (see Vae).
+func fillEncoderSet(declared EncoderSet, p *EncoderPool) EncoderSet {
+	if p == nil {
+		return declared
+	}
+	fill := func(dst *string, v string) {
+		if strings.TrimSpace(*dst) == "" {
+			*dst = v
+		}
+	}
+	fill(&declared.FluxVae, p.Vae(VaeFamilyFlux, "flux", "/ae."))
+	fill(&declared.Flux2Vae, p.Vae(VaeFamilyFlux2))
+	fill(&declared.SdxlVae, p.Vae(VaeFamilySD, "sdxl"))
+	// Z-Image ships "its own" ae.safetensors that is byte-for-byte the flux.1
+	// AE (verified: same size, same hash), so the flux pick is the correct
+	// fallback and one copy on disk serves both.
+	fill(&declared.ZimageVae, p.Vae(VaeFamilyFlux, "z-image", "zimage"))
+	fill(&declared.ZimageVae, declared.FluxVae)
+	fill(&declared.ClipL, p.Clip(768))
+	fill(&declared.ClipG, p.Clip(1280))
+	fill(&declared.T5, p.T5())
+	return declared
+}
+
+// projectorBeside returns the vision projector paired to a given text-encoder
+// gguf, i.e. the mmproj the pool found in that file's own directory. Empty for a
+// safetensors encoder (its vision tower, if any, is inside the same file) or
+// when the encoder ships without one.
+func projectorBeside(llmPath string, p *EncoderPool) string {
+	if p == nil || strings.TrimSpace(llmPath) == "" {
+		return ""
+	}
+	key := config.PathKey(llmPath)
+	for _, f := range p.Files {
+		if f.Role == RoleLlm && config.PathKey(f.Path) == key {
+			return f.Mmproj
+		}
+	}
+	return ""
+}
+
+// editModelRe marks a diffusion model whose pipeline conditions on a REFERENCE
+// IMAGE and therefore needs the text encoder's vision tower (--llm_vision).
+//
+// This one genuinely cannot be read off the weights. The obvious structural
+// tells do not hold: LongCat-Image-Edit and plain LongCat-Image have identical
+// img_in/txt_in shapes and differ by two unrelated norm tensors, because the
+// reference image enters as extra SEQUENCE tokens rather than extra input
+// channels. So the model name is the signal, with an explicit llmVision
+// override as the escape hatch when a publisher names something unhelpfully.
+var editModelRe = regexp.MustCompile(`(?i)(^|[-_. ])(edit|rapid|kontext|instruct[-_]?pix2pix|inpaint|redux)([-_. ]|$)`)
+
+// wantsVisionEncoder reports whether this model should get --llm_vision. Only
+// llm-conditioned families are candidates: flux.1 edit models condition through
+// T5, which has no vision tower at all.
+func wantsVisionEncoder(arch, name string, ov *Override) bool {
+	if ov != nil {
+		switch ov.LlmVision {
+		case "on":
+			return true
+		case "off":
+			return false
+		}
+	}
+	return editModelRe.MatchString(name)
+}

--- a/internal/autogen/encoderpool_test.go
+++ b/internal/autogen/encoderpool_test.go
@@ -1,0 +1,299 @@
+package autogen
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSafetensors lays down a real .safetensors container carrying only the
+// header (8-byte LE length + JSON table). Classification never reads past it, so
+// a synthetic file with no payload exercises the same path as a 10 GB encoder.
+func writeSafetensors(t *testing.T, path string, shapes map[string][]int64) {
+	t.Helper()
+	tbl := map[string]stTensor{}
+	for k, v := range shapes {
+		tbl[k] = stTensor{DType: "F16", Shape: v}
+	}
+	j, err := json.Marshal(tbl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := binary.Write(f, binary.LittleEndian, uint64(len(j))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(j); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAutogen_classifySafetensors(t *testing.T) {
+	cases := []struct {
+		name       string
+		shapes     map[string][]int64
+		wantRole   ComponentRole
+		wantFamily string
+		wantWidth  int64
+		wantVision bool
+	}{
+		{
+			name:       "sd vae",
+			shapes:     map[string][]int64{"decoder.conv_in.weight": {512, 4, 3, 3}},
+			wantRole:   RoleVae,
+			wantFamily: VaeFamilySD,
+		},
+		{
+			name:       "flux ae",
+			shapes:     map[string][]int64{"decoder.conv_in.weight": {512, 16, 3, 3}},
+			wantRole:   RoleVae,
+			wantFamily: VaeFamilyFlux,
+		},
+		{
+			name:       "flux2 ae",
+			shapes:     map[string][]int64{"decoder.conv_in.weight": {512, 32, 3, 3}},
+			wantRole:   RoleVae,
+			wantFamily: VaeFamilyFlux2,
+		},
+		{
+			name:       "wan 3d causal vae",
+			shapes:     map[string][]int64{"conv1.weight": {96, 3, 3, 3, 3}},
+			wantRole:   RoleVae,
+			wantFamily: VaeFamilyWan3D,
+		},
+		{
+			name:      "clip-l",
+			shapes:    map[string][]int64{"text_model.embeddings.token_embedding.weight": {49408, 768}},
+			wantRole:  RoleClip,
+			wantWidth: 768,
+		},
+		{
+			name:      "clip-g",
+			shapes:    map[string][]int64{"text_model.embeddings.token_embedding.weight": {49408, 1280}},
+			wantRole:  RoleClip,
+			wantWidth: 1280,
+		},
+		{
+			name:      "t5xxl",
+			shapes:    map[string][]int64{"encoder.block.0.layer.0.SelfAttention.q.weight": {4096, 4096}},
+			wantRole:  RoleT5,
+			wantWidth: 4096,
+		},
+		{
+			name:      "plain decoder llm",
+			shapes:    map[string][]int64{"model.embed_tokens.weight": {131072, 3072}},
+			wantRole:  RoleLlm,
+			wantWidth: 3072,
+		},
+		{
+			name: "vision llm",
+			shapes: map[string][]int64{
+				"model.embed_tokens.weight":      {152064, 3584},
+				"visual.patch_embed.proj.weight": {1280, 3, 2, 14, 14},
+			},
+			wantRole:   RoleLlm,
+			wantWidth:  3584,
+			wantVision: true,
+		},
+		{
+			// A DiT is not a component: it must not land in the pool, or the
+			// diffusion model would be offered as its own text encoder.
+			name:     "dit is not a component",
+			shapes:   map[string][]int64{"double_blocks.0.img_attn.qkv.weight": {9216, 3072}},
+			wantRole: RoleNone,
+		},
+		{
+			// An unknown latent width is a VAE we cannot vouch for; wiring it
+			// would produce a broken decode, so it is dropped entirely.
+			name:     "unknown latent width dropped",
+			shapes:   map[string][]int64{"decoder.conv_in.weight": {512, 7, 3, 3}},
+			wantRole: RoleNone,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tbl := map[string]stTensor{}
+			for k, v := range tc.shapes {
+				tbl[k] = stTensor{Shape: v}
+			}
+			got := classifySafetensors(tbl, 1.0, "x.safetensors")
+			if got.Role != tc.wantRole {
+				t.Fatalf("role = %q, want %q", got.Role, tc.wantRole)
+			}
+			if got.Family != tc.wantFamily {
+				t.Errorf("family = %q, want %q", got.Family, tc.wantFamily)
+			}
+			if got.Width != tc.wantWidth {
+				t.Errorf("width = %d, want %d", got.Width, tc.wantWidth)
+			}
+			if got.Vision != tc.wantVision {
+				t.Errorf("vision = %v, want %v", got.Vision, tc.wantVision)
+			}
+		})
+	}
+}
+
+func TestAutogen_ScanEncoderPool(t *testing.T) {
+	root := t.TempDir()
+	writeSafetensors(t, filepath.Join(root, "vae", "ae.safetensors"),
+		map[string][]int64{"decoder.conv_in.weight": {512, 16, 3, 3}})
+	writeSafetensors(t, filepath.Join(root, "vae", "sdxl_vae.safetensors"),
+		map[string][]int64{"decoder.conv_in.weight": {512, 4, 3, 3}})
+	writeSafetensors(t, filepath.Join(root, "clip", "clip_l.safetensors"),
+		map[string][]int64{"text_model.embeddings.token_embedding.weight": {49408, 768}})
+	writeSafetensors(t, filepath.Join(root, "clip", "clip_g.safetensors"),
+		map[string][]int64{"text_model.embeddings.token_embedding.weight": {49408, 1280}})
+	writeSafetensors(t, filepath.Join(root, "junk", "readme.safetensors"),
+		map[string][]int64{"nothing.weight": {1, 1}})
+	// Not a safetensors container at all: must be skipped, not fatal.
+	if err := os.WriteFile(filepath.Join(root, "junk", "half.safetensors"), []byte("no"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := ScanEncoderPool([]string{root})
+	if len(p.Files) != 4 {
+		t.Fatalf("files = %d, want 4: %+v", len(p.Files), p.Files)
+	}
+	if got := p.Vae(VaeFamilyFlux); !strings.HasSuffix(got, "ae.safetensors") {
+		t.Errorf("flux vae = %q", got)
+	}
+	if got := p.Vae(VaeFamilySD, "sdxl"); !strings.Contains(got, "sdxl") {
+		t.Errorf("sdxl vae = %q", got)
+	}
+	if got := p.Clip(768); !strings.Contains(got, "clip_l") {
+		t.Errorf("clip-l = %q", got)
+	}
+	if got := p.Clip(1280); !strings.Contains(got, "clip_g") {
+		t.Errorf("clip-g = %q", got)
+	}
+	if got := p.T5(); got != "" {
+		t.Errorf("t5 = %q, want none", got)
+	}
+	// A hint that matches nothing still yields a stable pick, never a blank.
+	if got := p.Vae(VaeFamilyFlux, "no-such-thing"); got == "" {
+		t.Error("hint miss should fall back to the sorted-first candidate")
+	}
+}
+
+func TestAutogen_EncoderPoolLlm(t *testing.T) {
+	p := &EncoderPool{Files: []ComponentFile{
+		{Path: "/m/qwen25vl-q4.gguf", Role: RoleLlm, Width: 3584, SizeGB: 4, Mmproj: "/m/mmproj.gguf", Vision: true},
+		{Path: "/m/qwen25vl-q8.gguf", Role: RoleLlm, Width: 3584, SizeGB: 8, Mmproj: "/m/mmproj.gguf", Vision: true},
+		{Path: "/m/qwen25-7b.gguf", Role: RoleLlm, Width: 3584, SizeGB: 9},
+		{Path: "/m/qwen3-4b.gguf", Role: RoleLlm, Width: 2560, SizeGB: 3},
+		{Path: "/m/t5.gguf", Role: RoleT5, Width: 4096, SizeGB: 5},
+	}}
+	// Widest file wins at equal width...
+	if got, _ := p.Llm(3584, false); got != "/m/qwen25-7b.gguf" {
+		t.Errorf("llm(3584) = %q, want the largest", got)
+	}
+	// ...unless a vision tower is required, which excludes the bigger text-only
+	// file and drags the paired projector along.
+	got, proj := p.Llm(3584, true)
+	if got != "/m/qwen25vl-q8.gguf" || proj != "/m/mmproj.gguf" {
+		t.Errorf("llm(3584, vision) = %q/%q", got, proj)
+	}
+	if got, _ := p.Llm(2560, false); got != "/m/qwen3-4b.gguf" {
+		t.Errorf("llm(2560) = %q", got)
+	}
+	// An unmatched width picks nothing rather than the closest: a mismatched
+	// encoder does not degrade, it fails to load.
+	if got, _ := p.Llm(4096, false); got != "" {
+		t.Errorf("llm(4096) = %q, want none (t5 is not an llm)", got)
+	}
+	if got, _ := p.Llm(0, false); got != "" {
+		t.Errorf("llm(0) = %q, want none", got)
+	}
+	var nilPool *EncoderPool
+	if got, _ := nilPool.Llm(3584, true); got != "" {
+		t.Error("nil pool must be inert")
+	}
+	if nilPool.Vae(VaeFamilyFlux) != "" || nilPool.Clip(768) != "" || nilPool.T5() != "" {
+		t.Error("nil pool must be inert for every getter")
+	}
+}
+
+func TestAutogen_fillEncoderSet(t *testing.T) {
+	p := &EncoderPool{Files: []ComponentFile{
+		{Path: "/m/ae.safetensors", Role: RoleVae, Family: VaeFamilyFlux},
+		{Path: "/m/flux2-ae.safetensors", Role: RoleVae, Family: VaeFamilyFlux2},
+		{Path: "/m/clip_l.safetensors", Role: RoleClip, Width: 768},
+		{Path: "/m/t5xxl.gguf", Role: RoleT5, Width: 4096},
+	}}
+	got := fillEncoderSet(EncoderSet{ClipL: "/hand/clip_l.safetensors"}, p)
+	if got.ClipL != "/hand/clip_l.safetensors" {
+		t.Errorf("declared ClipL was overwritten: %q", got.ClipL)
+	}
+	if got.FluxVae != "/m/ae.safetensors" || got.Flux2Vae != "/m/flux2-ae.safetensors" {
+		t.Errorf("vae fill = %q / %q", got.FluxVae, got.Flux2Vae)
+	}
+	// Z-Image ships an AE byte-identical to flux.1's, so it falls back to it.
+	if got.ZimageVae != "/m/ae.safetensors" {
+		t.Errorf("zimage vae = %q", got.ZimageVae)
+	}
+	if got.T5 != "/m/t5xxl.gguf" {
+		t.Errorf("t5 = %q", got.T5)
+	}
+	if got.SdxlVae != "" {
+		t.Errorf("sdxl vae = %q, want blank (none on disk)", got.SdxlVae)
+	}
+	// A nil pool must leave a hand-written set exactly as it was.
+	in := EncoderSet{FluxVae: "a", ClipL: "b"}
+	if fillEncoderSet(in, nil) != in {
+		t.Error("nil pool must not alter the declared set")
+	}
+}
+
+func TestAutogen_wantsVisionEncoder(t *testing.T) {
+	cases := []struct {
+		name string
+		ov   *Override
+		want bool
+	}{
+		{name: "LongCat-Image-Edit-Turbo-Q8_0", want: true},
+		{name: "Qwen-Rapid-NSFW", want: true},
+		{name: "flux1-kontext-dev", want: true},
+		{name: "sd15-inpaint", want: true},
+		{name: "LongCat-Image-Q8_0", want: false},
+		{name: "Z-Image-Turbo", want: false},
+		// "edit" only counts as its own token: "credit" is not an edit model.
+		{name: "credit-model", want: false},
+		{name: "LongCat-Image-Edit", ov: &Override{LlmVision: "off"}, want: false},
+		{name: "LongCat-Image", ov: &Override{LlmVision: "on"}, want: true},
+	}
+	for _, tc := range cases {
+		if got := wantsVisionEncoder("flux", tc.name, tc.ov); got != tc.want {
+			t.Errorf("wantsVisionEncoder(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestAutogen_condHiddenFrom(t *testing.T) {
+	if got := condHiddenFrom(nil); got != 0 {
+		t.Errorf("empty = %d, want 0", got)
+	}
+	if got := condHiddenFrom(map[string]int64{"txt_in.weight": 3584}); got != 3584 {
+		t.Errorf("txt_in = %d", got)
+	}
+	// Highest-ranked present tensor wins when a model carries several.
+	dims := map[string]int64{
+		"context_embedder.weight": 4096,
+		"txt_in.weight":           3584,
+	}
+	if got := condHiddenFrom(dims); got != 3584 {
+		t.Errorf("ranked pick = %d, want 3584", got)
+	}
+	if got := condHiddenFrom(map[string]int64{"unrelated.weight": 99}); got != 0 {
+		t.Errorf("unrelated = %d, want 0", got)
+	}
+}

--- a/internal/autogen/generate.go
+++ b/internal/autogen/generate.go
@@ -163,7 +163,7 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 	// reveals the real arch name to add to imageArchs.
 	imgArch := effectiveImageArch(meta)
 	if isImageArch(imgArch) {
-		emitImageModel(b, s, row, ov, name, imgArch, meta.HasBakedEncoders, emitted)
+		emitImageModel(b, s, row, ov, name, imgArch, meta.HasBakedEncoders, meta.CondHidden, emitted)
 		// Named variants are emitted as separate "<name>-<variant>" sd-server
 		// entries. Each inherits the model's component paths/placement and overrides
 		// only its own generation preset. Fleet-wide defaultVariants are llama-shaped
@@ -174,7 +174,7 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 					continue
 				}
 				vov := mergeImageVariant(*ov, v)
-				emitImageModel(b, s, row, &vov, name+"-"+v.Name, imgArch, meta.HasBakedEncoders, emitted)
+				emitImageModel(b, s, row, &vov, name+"-"+v.Name, imgArch, meta.HasBakedEncoders, meta.CondHidden, emitted)
 			}
 		}
 		return nil

--- a/internal/autogen/generate_cmd.go
+++ b/internal/autogen/generate_cmd.go
@@ -581,7 +581,7 @@ func RenderSoloCmd(s Settings, meta Metadata, row GgufRow, ov Override) (string,
 	}
 	// Diffusion models render an sd-server command, not a llama-server one.
 	if imgArch := effectiveImageArch(meta); isImageArch(imgArch) {
-		lines, _, _, _ := imageCmdLines(s, row, &ov, imgArch, row.FullPath)
+		lines, _, _, _ := imageCmdLines(s, row, &ov, imgArch, row.FullPath, meta.CondHidden)
 		return strings.Join(lines, " "), nil
 	}
 	// Embedders render a minimal --embeddings command (no KV/spec sizing).

--- a/internal/autogen/gguf.go
+++ b/internal/autogen/gguf.go
@@ -79,7 +79,12 @@ type Metadata struct {
 	// the arch tag doesn't self-identify. See effectiveImageArch.
 	GeneralType string
 
-	// DiffusionKind is a tensor-name-sniffed diffusion arch ("sdxl"/"sd1") for a
+	// CondHidden is the hidden width of the text encoder a diffusion transformer
+	// expects (see tensorScan.condHidden). 0 for anything that is not a DiT with
+	// a recognised caption projection.
+	CondHidden int64
+
+	// DiffusionKind is a tensor-name-sniffed diffusion arch ("sdxl"/"sd1"/"flux") for a
 	// UNet gguf that carries no general.architecture — stable-diffusion.cpp's
 	// `convert` strips the metadata KVs, so a converted SDXL UNet reports
 	// Architecture="" but still has input_blocks/label_emb tensors. Empty when the
@@ -984,6 +989,7 @@ func ReadGgufMetadataFrom(rs io.ReadSeeker, path string, sizeBytes int64) (Metad
 		FineTune:          fineTune,
 		GeneralName:       generalName,
 		DiffusionKind:     diffKind,
+		CondHidden:        scan.condHidden,
 		HasBakedEncoders:  bakedEnc,
 		PoolingType:       deref(poolingType),
 		IsMoE:             expertCount != nil && *expertCount > 0,
@@ -1007,8 +1013,9 @@ func ReadGgufMetadataFrom(rs io.ReadSeeker, path string, sizeBytes int64) (Metad
 // count of the token_embd.weight (or output.weight) tensor (= n_embd*n_vocab,
 // for vocab sizing). Share is 0 when no expert tensors are found or any tensor
 // uses an unknown ggml type; vocabElems is 0 when neither tensor is present.
-// diffKind is "sdxl"/"sd1" when the tensor names mark a diffusion UNet (a
-// metadata-stripped converted model), else "". bakedEnc is true when the file
+// diffKind is "sdxl"/"sd1" when the tensor names mark a diffusion UNet, or
+// "flux" when they mark a BFL-format MMDiT (double_blocks), for a
+// metadata-stripped converted model; else "". bakedEnc is true when the file
 // also carries its text encoder(s) (conditioner.embedders/cond_stage_model),
 // i.e. it's a full checkpoint rather than a bare UNet.
 func readTensorScan(r *ggufReader, tensorCount uint64) (scan tensorScan, err error) {
@@ -1017,10 +1024,11 @@ func readTensorScan(r *ggufReader, tensorCount uint64) (scan tensorScan, err err
 	var diffKind string
 	var bakedEnc bool
 	var expertBytes, totalBytes int64
-	var sawExpert, sawInputBlocks, sawLabelEmb, unknownType bool
+	var sawExpert, sawInputBlocks, sawLabelEmb, sawDoubleBlocks, unknownType bool
+	condDims := map[string]int64{}
 	typeBytes := map[uint32]int64{}
 	out := func() tensorScan {
-		return tensorScan{expertShare: share, vocabElems: vocabElems, diffKind: diffKind, bakedEnc: bakedEnc, typeBytes: typeBytes}
+		return tensorScan{expertShare: share, vocabElems: vocabElems, diffKind: diffKind, bakedEnc: bakedEnc, condHidden: condHiddenFrom(condDims), typeBytes: typeBytes}
 	}
 	for i := uint64(0); i < tensorCount; i++ {
 		name, err := r.str()
@@ -1032,10 +1040,14 @@ func readTensorScan(r *ggufReader, tensorCount uint64) (scan tensorScan, err err
 			return out(), err
 		}
 		elems := int64(1)
+		var firstDim int64
 		for d := uint32(0); d < nDims; d++ {
 			dim, err := r.u64()
 			if err != nil {
 				return out(), err
+			}
+			if d == 0 {
+				firstDim = int64(dim)
 			}
 			elems *= int64(dim)
 		}
@@ -1080,18 +1092,34 @@ func readTensorScan(r *ggufReader, tensorCount uint64) (scan tensorScan, err err
 		if strings.Contains(name, "label_emb.") {
 			sawLabelEmb = true
 		}
+		// BFL-format MMDiT marker (flux.1, chroma, LongCat-Image). Some
+		// publishers convert with the KVs stripped, so this is the only signal
+		// that the file is a diffusion transformer at all. It says "flux tensor
+		// layout", not "is flux.1": resolveComponents still name-detects the
+		// families that share the layout but not the encoders.
+		if strings.Contains(name, "double_blocks.") {
+			sawDoubleBlocks = true
+		}
+		// Caption-projection width: the hidden size of the text encoder this DiT
+		// was trained against. Recorded by name here, ranked in condHiddenFrom.
+		if _, want := condTensors[name]; want && nDims > 0 {
+			condDims[name] = firstDim
+		}
 		// Baked text encoder = full checkpoint. SDXL bakes both encoders under
 		// conditioner.embedders.{0,1}; older SD1 checkpoints use cond_stage_model.
 		if strings.Contains(name, "conditioner.embedders.") || strings.Contains(name, "cond_stage_model.") {
 			bakedEnc = true
 		}
 	}
-	if sawInputBlocks {
+	switch {
+	case sawInputBlocks:
 		if sawLabelEmb {
 			diffKind = "sdxl"
 		} else {
 			diffKind = "sd1"
 		}
+	case sawDoubleBlocks:
+		diffKind = "flux"
 	}
 	// An untabulated type makes the ratio meaningless (the missing tensors are
 	// exactly the ones whose share we would be reporting), so the share alone

--- a/internal/autogen/hash.go
+++ b/internal/autogen/hash.go
@@ -159,7 +159,7 @@ const hashCacheSuffix = ".modelhash"
 //	     sidecar) is migrated onto the new one. Every dense model trained past
 //	     128k gets a larger -c and a larger KV reserve, so the emitted argv and
 //	     the estimates change for inputs that did not.
-const genVersion = "v57"
+const genVersion = "v58"
 
 // InputsHash digests everything that can change the generated config: the set of
 // gguf files under modelsRoot (path + size + mtime) plus the raw bytes of the

--- a/internal/autogen/image.go
+++ b/internal/autogen/image.go
@@ -178,7 +178,7 @@ func resolveLoraDir(s Settings, ovDir, modelPath string) string {
 // imageComponents are the resolved VAE / text-encoder file paths for one
 // diffusion model. Empty = not attached (the family doesn't need it, or it's
 // missing from the pool — see resolveComponents' missing list).
-type imageComponents struct{ vae, clipL, clipG, t5, llm string }
+type imageComponents struct{ vae, clipL, clipG, t5, llm, llmVision string }
 
 // resolveComponents decides which component files a bare diffusion GGUF needs
 // from its architecture, draws them from the shared Settings.Encoders pool, then
@@ -194,9 +194,34 @@ type imageComponents struct{ vae, clipL, clipG, t5, llm string }
 // ponytail: sd3 / qwen_image arms omitted — no such model on disk yet. Add an arm
 // (and any new EncoderSet field) when one lands; the "# arch=..." YAML comment on
 // the fallthrough names the arch to wire.
-func resolveComponents(enc EncoderSet, ov *Override, arch, name string) (c imageComponents, missing []string) {
+func resolveComponents(enc EncoderSet, ov *Override, arch, name string, pool *EncoderPool, condHidden int64) (c imageComponents, missing []string) {
 	a := strings.ToLower(strings.TrimSpace(arch))
 	n := strings.ToLower(name)
+	// Fill every blank pool field from what is actually on disk before the arch
+	// arms read it, so a machine that declared no settings.encoders at all still
+	// wires a complete command.
+	enc = fillEncoderSet(enc, pool)
+	// The text encoder is picked by MATCHING WIDTHS, not by name: the DiT states
+	// the encoder hidden size it was trained against, and each candidate reports
+	// its own. That beats the single global EncoderSet.QwenLlm field, which
+	// cannot be right for two models that want different encoders (Z-Image wants
+	// Qwen3-4B where LongCat wants Qwen2.5-VL-7B), so a structural match wins
+	// over the declared field. A per-model Override still wins over both, below.
+	wantVision := wantsVisionEncoder(a, n, ov)
+	autoLlm, autoVision := pool.Llm(condHidden, wantVision)
+	if autoLlm == "" && wantVision {
+		// No vision-capable encoder of that width: fall back to a text-only one
+		// rather than emitting nothing, and let the missing projector show up as
+		// the model producing unconditioned output rather than as a dead server.
+		autoLlm, autoVision = pool.Llm(condHidden, false)
+	}
+	llmDefault := autoLlm
+	if llmDefault == "" {
+		llmDefault = enc.QwenLlm
+	}
+	if wantVision {
+		c.llmVision = autoVision
+	}
 	req := func(role, path string) string {
 		if path == "" {
 			missing = append(missing, role)
@@ -216,7 +241,20 @@ func resolveComponents(enc EncoderSet, ov *Override, arch, name string) (c image
 	// disk yet; add a case here (and an EncoderSet field) when one lands.
 	case strings.Contains(n, "klein") || strings.Contains(n, "flux2") || strings.Contains(n, "flux-2"):
 		c.vae = req("vae", enc.Flux2Vae)
-		c.llm = req("llm", enc.QwenLlm)
+		c.llm = req("llm", llmDefault)
+	// LongCat-Image / LongCat-Image-Edit ship their DiT in BFL (flux) tensor
+	// layout, so every converter tags them general.architecture "flux" (and
+	// stduhpf's quants carry no KVs at all: the double_blocks sniff in
+	// readTensorScan lands them here too). They are not flux.1: clip_l/t5 are
+	// gone in favour of a Qwen2.5-VL LLM encoder, while the VAE IS flux.1's ae.
+	// Name-detect like chroma. The encoder and (for the edit variant) its vision
+	// projector come from the scan, matched on the caption width the DiT states
+	// (condHidden 3584 = Qwen2.5-VL-7B). --flow-shift is NOT wired: it is a
+	// sampling knob with no structural tell, so LongCat-Edit still wants
+	// `extraArgs: "--flow-shift 3"` on its override row.
+	case strings.Contains(n, "longcat"):
+		c.vae = req("vae", enc.FluxVae)
+		c.llm = req("llm", llmDefault)
 	case a == "flux" || strings.HasPrefix(a, "flux"):
 		c.vae = req("vae", enc.FluxVae)
 		c.clipL = req("clip_l", enc.ClipL)
@@ -226,7 +264,30 @@ func resolveComponents(enc EncoderSet, ov *Override, arch, name string) (c image
 	// them — sd.cpp can't version-detect a split SDXL (bare UNet + external CLIPs).
 	case strings.HasPrefix(a, "lumina") || a == "z_image" || strings.Contains(n, "z-image"):
 		c.vae = req("vae", enc.ZimageVae)
-		c.llm = req("llm", enc.QwenLlm)
+		c.llm = req("llm", llmDefault)
+	// Qwen-Image lineage (Qwen-Image / Qwen-Image-Edit / Qwen-Rapid) and the
+	// Wan-derived DiTs (Krea, ERNIE-Image) condition on an LLM and carry no
+	// CLIP/T5 at all. Their VAEs split by arch: the wan/qwen_image 3D causal VAE
+	// for the former, flux.2's 32-channel AE for ERNIE.
+	//
+	// The Wan-2.1 and Qwen-Image VAEs are structurally IDENTICAL (same 194
+	// tensors, every dimension equal), so nothing in either file distinguishes
+	// them and the model name is the only signal available: hence the hints.
+	// Wrong pick here is a colour-shifted decode, not a crash.
+	case a == "qwen_image" || a == "wan" || strings.Contains(n, "qwen-image") || strings.Contains(n, "qwen_image"):
+		if a == "wan" && !strings.Contains(n, "wan") {
+			// ERNIE-Image reports arch "wan" but is a flux.2-latent model.
+			c.vae = req("vae", firstNonEmpty(enc.Flux2Vae, pool.Vae(VaeFamilyFlux2)))
+		} else {
+			c.vae = req("vae", pool.Vae(VaeFamilyWan3D, wan3dHints(n)...))
+		}
+		c.llm = req("llm", llmDefault)
+	}
+	// A projector with no encoder to attach it to is incoherent argv: sd-server
+	// would take --llm_vision with no --llm. Only the arms above decide whether
+	// this model has an LLM encoder at all.
+	if c.llm == "" {
+		c.llmVision = ""
 	}
 	// Explicit per-model override wins over the arch-wired pool default, and clears
 	// the role from the missing list (an override can supply what the pool lacks).
@@ -248,6 +309,21 @@ func resolveComponents(enc EncoderSet, ov *Override, arch, name string) (c image
 		set("clip_g", ov.ClipGPath, &c.clipG)
 		set("t5xxl", ov.T5Path, &c.t5)
 		set("llm", ov.TextEncoderPath, &c.llm)
+		// An explicit projector path always wins; when the encoder itself was
+		// overridden the auto-paired projector belonged to a DIFFERENT file, so
+		// drop it unless the override supplies its own.
+		if ov.TextEncoderPath != "" && ov.LlmVisionPath == "" {
+			c.llmVision = projectorBeside(ov.TextEncoderPath, pool)
+		}
+		if ov.LlmVisionPath != "" {
+			c.llmVision = ov.LlmVisionPath
+		}
+		if ov.LlmVision == "off" {
+			c.llmVision = ""
+		}
+		if ov.LlmVision == "on" && c.llmVision == "" {
+			c.llmVision = projectorBeside(c.llm, pool)
+		}
 	}
 	return c, missing
 }
@@ -257,7 +333,7 @@ func resolveComponents(enc EncoderSet, ov *Override, arch, name string) (c image
 // by emitImageModel (YAML emit) and RenderSoloCmd (editor launch-parameters
 // preview), so the box matches a save. Also returns the resolved VRAM budget and
 // offload decision for the YAML comment, and any required-but-missing encoder roles.
-func imageCmdLines(s Settings, row GgufRow, ov *Override, arch, name string) (lines []string, budget float64, offload bool, missing []string) {
+func imageCmdLines(s Settings, row GgufRow, ov *Override, arch, name string, condHidden int64) (lines []string, budget float64, offload bool, missing []string) {
 	modelPath := strings.ReplaceAll(row.FullPath, "\\", "/")
 
 	// Budget mirrors the LLM sizer: target minus headroom. A per-model
@@ -317,7 +393,7 @@ func imageCmdLines(s Settings, row GgufRow, ov *Override, arch, name string) (li
 	// Split archs draw component files from the shared pool (per-model override wins).
 	var comp imageComponents
 	if !fullCkpt {
-		comp, missing = resolveComponents(s.Encoders, ov, arch, name)
+		comp, missing = resolveComponents(s.Encoders, ov, arch, name, encoderPoolFor(s.RootList()), condHidden)
 	}
 	if p := imageArg(comp.vae); p != "" {
 		lines = append(lines, "--vae "+p)
@@ -333,6 +409,14 @@ func imageCmdLines(s Settings, row GgufRow, ov *Override, arch, name string) (li
 	}
 	if p := imageArg(comp.llm); p != "" {
 		lines = append(lines, "--llm "+p)
+	}
+	// The vision tower of the text encoder, needed by edit pipelines that
+	// condition on a reference image. Auto-paired to the chosen --llm (its
+	// sibling mmproj), never hand-typed. Without it an edit model does not
+	// error: it reports "vision disabled" and emits an image unrelated to the
+	// reference, so a wrong-looking result is the only symptom.
+	if p := imageArg(comp.llmVision); p != "" {
+		lines = append(lines, "--llm_vision "+p)
 	}
 	var ovLoraDir string
 	if ov != nil {
@@ -432,6 +516,12 @@ func mergeImageVariant(base Override, v VariantSpec) Override {
 	}
 	if v.TextEncoderPath != "" {
 		o.TextEncoderPath = v.TextEncoderPath
+	}
+	if v.LlmVision != "" {
+		o.LlmVision = v.LlmVision
+	}
+	if v.LlmVisionPath != "" {
+		o.LlmVisionPath = v.LlmVisionPath
 	}
 	if v.LoraDir != "" {
 		o.LoraDir = v.LoraDir
@@ -694,8 +784,8 @@ func emitExtraImageModels(b *strings.Builder, s Settings, overrides []Override, 
 	}
 }
 
-func emitImageModel(b *strings.Builder, s Settings, row GgufRow, ov *Override, name, arch string, bakedEnc bool, emitted *[]string) {
-	lines, budget, offload, missing := imageCmdLines(s, row, ov, arch, name)
+func emitImageModel(b *strings.Builder, s Settings, row GgufRow, ov *Override, name, arch string, bakedEnc bool, condHidden int64, emitted *[]string) {
+	lines, budget, offload, missing := imageCmdLines(s, row, ov, arch, name, condHidden)
 
 	fmt.Fprintf(b, "\n  # arch=%s size=%gGB (image model, sd-server, max-vram=%gGB, offload=%t)\n", arch, row.SizeGB, budget, offload)
 	// SD/SDXL served as -m full checkpoints: if this gguf has no baked encoders it
@@ -728,4 +818,24 @@ func emitImageModel(b *strings.Builder, s Settings, row GgufRow, ov *Override, n
 	b.WriteString("      out: [image]\n")
 	writeDisplayName(b, s, name)
 	*emitted = append(*emitted, name)
+}
+
+// wan3dHints orders the two indistinguishable 3D causal VAEs by what the model
+// name says its lineage is. Wan/Krea take wan_2.1_vae, everything else in the
+// Qwen-Image family takes qwen_image_vae.
+func wan3dHints(name string) []string {
+	if strings.Contains(name, "krea") || strings.Contains(name, "wan") {
+		return []string{"wan_2.1", "wan2.1", "wan"}
+	}
+	return []string{"qwen_image", "qwen-image"}
+}
+
+// firstNonEmpty returns the first non-blank of its arguments.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
 }

--- a/internal/autogen/image_test.go
+++ b/internal/autogen/image_test.go
@@ -27,7 +27,7 @@ func TestEmitImageModel(t *testing.T) {
 	// Big model (6.5GB + 1.5 compute > 6.5 budget) → offload path. No per-model
 	// override: VAE + CLIP-L + T5 must be auto-attached from the arch (flux) pool.
 	big := GgufRow{FullPath: `C:\models\flux.gguf`, SizeGB: 6.5}
-	emitImageModel(&b, s, big, &Override{}, "flux-q4", "flux", false, &emitted)
+	emitImageModel(&b, s, big, &Override{}, "flux-q4", "flux", false, 0, &emitted)
 	out := b.String()
 	for _, want := range []string{"sd-server", "--diffusion-model C:/models/flux.gguf", "--listen-port ${PORT}", "--max-vram 6.5", "--vae ae.safetensors", "--clip_l clip_l.safetensors", "--t5xxl t5xxl.gguf", "--diffusion-fa", "--vae-tiling", "--offload-to-cpu", "--vae-on-cpu", "--backend te=cpu", "offload=true", "checkEndpoint: /", "out: [image]", "in: [text]", "ttl: 600"} {
 		if !strings.Contains(out, want) {
@@ -51,7 +51,7 @@ func TestEmitImageModel(t *testing.T) {
 		OffloadToCpu: "off", DefaultSteps: 8, DefaultCfg: 1.0, DefaultSampler: "euler",
 		DefaultWidth: 768, DefaultHeight: 512, ExtraArgs: "--clip-on-cpu",
 	}
-	emitImageModel(&b3, s, big, ov, "flux-tuned", "flux", false, &em3)
+	emitImageModel(&b3, s, big, ov, "flux-tuned", "flux", false, 0, &em3)
 	out3 := b3.String()
 	for _, want := range []string{"--vae C:/models/ae.safetensors", "--clip_l clip_l.gguf", "--t5xxl t5xxl.gguf", "--llm qwen3.gguf", "--steps 8", "--cfg-scale 1", "--sampling-method euler", "--width 768", "--height 512", "--clip-on-cpu", "offload=false"} {
 		if !strings.Contains(out3, want) {
@@ -68,7 +68,7 @@ func TestEmitImageModel(t *testing.T) {
 	var b2 strings.Builder
 	var em2 []string
 	small := GgufRow{FullPath: `C:\models\sd15.gguf`, SizeGB: 2.0}
-	emitImageModel(&b2, s, small, &Override{}, "sd15-q4", "sd1", true, &em2)
+	emitImageModel(&b2, s, small, &Override{}, "sd15-q4", "sd1", true, 0, &em2)
 	out2 := b2.String()
 	// SD1 is a full-checkpoint arch → -m, no external components.
 	if !strings.Contains(out2, "-m C:/models/sd15.gguf") || strings.Contains(out2, "--diffusion-model") {
@@ -113,30 +113,90 @@ func TestResolveComponents(t *testing.T) {
 	pool := EncoderSet{FluxVae: "ae", ClipL: "cl", ClipG: "cg", T5: "t5", ZimageVae: "zae", QwenLlm: "qwen"}
 
 	// flux: vae + clip_l + t5, nothing missing.
-	if c, m := resolveComponents(pool, nil, "flux", "flux1-schnell"); c.vae != "ae" || c.clipL != "cl" || c.t5 != "t5" || c.clipG != "" || c.llm != "" || len(m) != 0 {
+	if c, m := resolveComponents(pool, nil, "flux", "flux1-schnell", nil, 0); c.vae != "ae" || c.clipL != "cl" || c.t5 != "t5" || c.clipG != "" || c.llm != "" || len(m) != 0 {
 		t.Errorf("flux: got %+v missing=%v", c, m)
 	}
 	// chroma (arch flux, name-detected): vae + t5, NO clip_l.
-	if c, m := resolveComponents(pool, nil, "flux", "Chroma1-HD-Q5_K_M"); c.vae != "ae" || c.t5 != "t5" || c.clipL != "" || len(m) != 0 {
+	if c, m := resolveComponents(pool, nil, "flux", "Chroma1-HD-Q5_K_M", nil, 0); c.vae != "ae" || c.t5 != "t5" || c.clipL != "" || len(m) != 0 {
 		t.Errorf("chroma should be vae+t5 only: got %+v missing=%v", c, m)
 	}
 	// z-image (arch lumina2): vae + llm.
-	if c, m := resolveComponents(pool, nil, "lumina2", "Z-Image-Turbo"); c.vae != "zae" || c.llm != "qwen" || c.clipL != "" || len(m) != 0 {
+	if c, m := resolveComponents(pool, nil, "lumina2", "Z-Image-Turbo", nil, 0); c.vae != "zae" || c.llm != "qwen" || c.clipL != "" || len(m) != 0 {
 		t.Errorf("z-image should be vae+llm: got %+v missing=%v", c, m)
 	}
 	// sdxl: full-checkpoint arch → never resolves external components (loads via -m).
 	// resolveComponents isn't called for it in emit, and falls through to attach nothing.
-	if c, m := resolveComponents(pool, nil, "sdxl", "animagineXLV31"); c.vae != "" || c.clipL != "" || c.clipG != "" || len(m) != 0 {
+	if c, m := resolveComponents(pool, nil, "sdxl", "animagineXLV31", nil, 0); c.vae != "" || c.clipL != "" || c.clipG != "" || len(m) != 0 {
 		t.Errorf("sdxl should attach nothing (served via -m): got %+v missing=%v", c, m)
 	}
 	// empty pool: flux reports every required role missing.
-	if _, m := resolveComponents(EncoderSet{}, nil, "flux", "flux1-fill-dev"); len(m) != 3 {
+	if _, m := resolveComponents(EncoderSet{}, nil, "flux", "flux1-fill-dev", nil, 0); len(m) != 3 {
 		t.Errorf("empty-pool flux should miss 3 roles, got %v", m)
 	}
 	// override supplies what the pool lacks → wins and clears the missing role.
 	ov := &Override{VaePath: "ov-ae", ClipLPath: "ov-cl", T5Path: "ov-t5"}
-	if c, m := resolveComponents(EncoderSet{}, ov, "flux", "flux1-fill-dev"); c.vae != "ov-ae" || c.clipL != "ov-cl" || c.t5 != "ov-t5" || len(m) != 0 {
+	if c, m := resolveComponents(EncoderSet{}, ov, "flux", "flux1-fill-dev", nil, 0); c.vae != "ov-ae" || c.clipL != "ov-cl" || c.t5 != "ov-t5" || len(m) != 0 {
 		t.Errorf("override should win and clear missing: got %+v missing=%v", c, m)
+	}
+}
+
+// LongCat ships its DiT in BFL (flux) tensor layout, so it reports
+// general.architecture "flux" and would otherwise be wired like flux.1:
+// clip_l + t5xxl and no --llm. It actually wants flux.1's AE plus a Qwen2.5-VL
+// text encoder, and the edit variant additionally wants that encoder's vision
+// projector. Nothing here is declared: the components come from the scanned
+// pool, matched on the width the DiT itself asks for.
+func TestResolveComponents_LongCatFromPool(t *testing.T) {
+	pool := &EncoderPool{Files: []ComponentFile{
+		{Path: "/m/ae.safetensors", Role: RoleVae, Family: VaeFamilyFlux},
+		{Path: "/m/clip_l.safetensors", Role: RoleClip, Width: 768},
+		{Path: "/m/t5xxl.gguf", Role: RoleT5, Width: 4096},
+		{Path: "/m/qwen25vl/model-Q8_0.gguf", Role: RoleLlm, Width: 3584, SizeGB: 8,
+			Mmproj: "/m/qwen25vl/mmproj-F16.gguf", Vision: true},
+		{Path: "/m/qwen3-4b.gguf", Role: RoleLlm, Width: 2560, SizeGB: 3},
+	}}
+
+	// Edit variant: vae + llm + the paired projector, and NO clip_l/t5.
+	c, m := resolveComponents(EncoderSet{}, nil, "flux", "LongCat-Image-Edit-Turbo-Q8_0", pool, 3584)
+	if len(m) != 0 {
+		t.Fatalf("missing = %v, want none", m)
+	}
+	if c.vae != "/m/ae.safetensors" {
+		t.Errorf("vae = %q", c.vae)
+	}
+	if c.llm != "/m/qwen25vl/model-Q8_0.gguf" {
+		t.Errorf("llm = %q", c.llm)
+	}
+	if c.llmVision != "/m/qwen25vl/mmproj-F16.gguf" {
+		t.Errorf("llm_vision = %q", c.llmVision)
+	}
+	if c.clipL != "" || c.t5 != "" || c.clipG != "" {
+		t.Errorf("longcat must not take clip/t5: %+v", c)
+	}
+
+	// Base (non-edit) LongCat: same encoder, no projector.
+	c2, _ := resolveComponents(EncoderSet{}, nil, "flux", "LongCat-Image-Q8_0", pool, 3584)
+	if c2.llm != "/m/qwen25vl/model-Q8_0.gguf" || c2.llmVision != "" {
+		t.Errorf("base longcat: %+v", c2)
+	}
+
+	// A different caption width picks a different encoder with no name table.
+	c3, _ := resolveComponents(EncoderSet{}, nil, "lumina2", "Z-Image-Turbo", pool, 2560)
+	if c3.llm != "/m/qwen3-4b.gguf" {
+		t.Errorf("z-image llm = %q", c3.llm)
+	}
+
+	// A declared encoder still wins, and drags its own neighbour projector.
+	ov := &Override{TextEncoderPath: "/m/qwen25vl/model-Q8_0.gguf"}
+	c4, _ := resolveComponents(EncoderSet{}, ov, "flux", "LongCat-Image-Edit", pool, 3584)
+	if c4.llm != ov.TextEncoderPath || c4.llmVision != "/m/qwen25vl/mmproj-F16.gguf" {
+		t.Errorf("declared encoder: %+v", c4)
+	}
+
+	// llmVision "off" drops the projector without touching the encoder pick.
+	c5, _ := resolveComponents(EncoderSet{}, &Override{LlmVision: "off"}, "flux", "LongCat-Image-Edit", pool, 3584)
+	if c5.llm == "" || c5.llmVision != "" {
+		t.Errorf("llmVision off: %+v", c5)
 	}
 }
 

--- a/internal/autogen/overrides.go
+++ b/internal/autogen/overrides.go
@@ -651,6 +651,14 @@ type Override struct {
 	ClipGPath       string `yaml:"clipGPath"`       // --clip_g
 	T5Path          string `yaml:"t5Path"`          // --t5xxl
 	TextEncoderPath string `yaml:"textEncoderPath"` // --llm (Z-Image / Lumina text encoder)
+	// LlmVision gates --llm_vision, the vision projector (mmproj) that pairs with
+	// the --llm text encoder. "" => auto: edit/reference models (name-detected, see
+	// wantsVisionEncoder) get the projector found beside their encoder, everything
+	// else gets none. "on"/"off" pin it.
+	LlmVision string `yaml:"llmVision"`
+	// LlmVisionPath pins the --llm_vision projector file, winning over the
+	// directory pairing. Empty => auto (see LlmVision).
+	LlmVisionPath string `yaml:"llmVisionPath"`
 	// LoraDir is this model's `--lora-model-dir`. Empty => settings.loraDir, and
 	// if that is empty too, the directory the model gguf itself lives in.
 	LoraDir string `yaml:"loraDir"`
@@ -801,6 +809,8 @@ type VariantSpec struct {
 	ClipGPath       string  `yaml:"clipGPath"`
 	T5Path          string  `yaml:"t5Path"`
 	TextEncoderPath string  `yaml:"textEncoderPath"`
+	LlmVision       string  `yaml:"llmVision"`
+	LlmVisionPath   string  `yaml:"llmVisionPath"`
 	LoraDir         string  `yaml:"loraDir"`
 	OffloadToCpu    string  `yaml:"offloadToCpu"`
 	TeOnCpu         string  `yaml:"teOnCpu"`

--- a/internal/autogen/quantlabel.go
+++ b/internal/autogen/quantlabel.go
@@ -11,6 +11,13 @@ type tensorScan struct {
 	vocabElems  int64
 	diffKind    string
 	bakedEnc    bool
+	// condHidden is the hidden width of the TEXT ENCODER a diffusion transformer
+	// expects, read off the tensor that projects caption embeddings into the DiT
+	// (ne[0] is that projection input width). It is what lets the encoder pool
+	// pick the right --llm/--t5xxl with no per-model table: 4096 = T5-XXL,
+	// 3584 = Qwen2.5-VL-7B, 3072 = Ministral-3B, 2560 = Qwen3-4B. 0 for a file
+	// with no recognised projection (every non-diffusion model).
+	condHidden int64
 
 	// typeBytes is on-disk bytes per ggml type id. A type missing from
 	// ggmlTypeSize can't be weighed, so it is recorded with 0 bytes: its
@@ -108,4 +115,37 @@ func fillerLabel(typeBytes map[uint32]int64) string {
 		return ""
 	}
 	return ggmlTypeName[ids[0]]
+}
+
+// condTensors are the tensors that project text-encoder embeddings into a
+// diffusion transformer, ranked most to least specific. Their ne[0] is the
+// encoder hidden width the model was trained against, which is the only
+// machine-readable statement of "which text encoder do I need". Verified against
+// flux (txt_in 4096 = T5-XXL), LongCat and Qwen-Image-Edit (txt_in 3584 =
+// Qwen2.5-VL-7B), Z-Image (cap_embedder 2560 = Qwen3-4B), ERNIE (text_proj 3072
+// = Ministral-3B) and Krea2 (txtfusion 2560 = Qwen3-VL-4B).
+var condTensorOrder = []string{
+	"txt_in.weight",
+	"cap_embedder.1.weight",
+	"text_proj.weight",
+	"context_embedder.weight",
+	"txtfusion.layerwise_blocks.0.prenorm.scale",
+}
+
+var condTensors = func() map[string]struct{} {
+	m := make(map[string]struct{}, len(condTensorOrder))
+	for _, n := range condTensorOrder {
+		m[n] = struct{}{}
+	}
+	return m
+}()
+
+// condHiddenFrom picks the highest-ranked caption projection actually present.
+func condHiddenFrom(dims map[string]int64) int64 {
+	for _, n := range condTensorOrder {
+		if d := dims[n]; d > 0 {
+			return d
+		}
+	}
+	return 0
 }

--- a/internal/backends/CLAUDE.md
+++ b/internal/backends/CLAUDE.md
@@ -218,7 +218,22 @@ therefore *coexist* with hand-entered rows in one registry, distinguished by
   the missing library on `Job.Warning`; the same check runs per build in the
   catalog DTO, because a job scrolls away and the broken build does not. The
   install still succeeds — the bits are on disk and work the moment the runtime
-  sits beside them.
+  sits beside them, which is the user's job: we diagnose, we do not repair.
+  Completing the install automatically was tried and dropped, because there is
+  nothing dependable to complete it *from*. The obvious donor, the user's own
+  llama.cpp ROCm install, is not one: the published
+  `llama-*-bin-win-rocm-*-x64.zip` was read entry by entry (b10819) and carries
+  `amdhip64_7.dll`, `amd_comgr.dll` and `rocm_kpack.dll` but **no**
+  `hipblas.dll`, `rocblas.dll` or `libhipblaslt.dll`, and no Tensile kernel trees
+  at all, because its 939 MB `ggml-hip.dll` static-links rocBLAS and hipBLASLt.
+  Only a dynamically linked ROCm build (lemonade's llamacpp-rocm) has the files
+  to give, so any automatic copy would half-complete most machines and hand back
+  a build that still dies at load with evidence that something worked. Two more
+  traps for anyone reopening this: rocBLAS/hipBLASLt load per-gfx-target kernels
+  as *data*, so no import graph names them (upstream packaged gfx1151 only; an
+  RX 7900 XTX needs gfx1100 added beside them), and a backend's `hipblas.dll`
+  expects its own `rocblas.dll` exports, so half-replacing a matched set is its
+  own load failure.
 - **The newest release is not always installable.** Real-ESRGAN's latest tag is
   source-only. `pickRelease` takes an `installable` predicate and, for "latest",
   skips releases with no matching asset for the requested variant/OS.

--- a/internal/backends/backends_test.go
+++ b/internal/backends/backends_test.go
@@ -75,6 +75,63 @@ func TestBackends_MatchAssets(t *testing.T) {
 		t.Error("expected an error when no asset matches")
 	}
 
+	// Upstream renamed the Windows ROCm asset (hip-radeon -> rocm-<toolkit>) and
+	// added arm64 CUDA. Verbatim from b10819: with only the old pattern the rocm
+	// variant matched nothing here, which is how a live release went uninstallable
+	// while the b10240 list above still passed.
+	current := []string{
+		"cudart-llama-bin-win-cuda-12.4-x64.zip",
+		"cudart-llama-bin-win-cuda-13.3-x64.zip",
+		"cudart-llama-bin-win-cuda-13.4-arm64.zip",
+		"llama-b10819-bin-android-arm64.tar.gz",
+		"llama-b10819-bin-macos-arm64.tar.gz",
+		"llama-b10819-bin-macos-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-arm64.tar.gz",
+		"llama-b10819-bin-ubuntu-openvino-2026.3.1-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-rocm-10.0-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-s390x.tar.gz",
+		"llama-b10819-bin-ubuntu-sycl-fp16-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-sycl-fp32-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-vulkan-arm64.tar.gz",
+		"llama-b10819-bin-ubuntu-vulkan-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-x64.tar.gz",
+		"llama-b10819-bin-win-cpu-arm64.zip",
+		"llama-b10819-bin-win-cpu-x64.zip",
+		"llama-b10819-bin-win-cuda-12.4-x64.zip",
+		"llama-b10819-bin-win-cuda-13.3-x64.zip",
+		"llama-b10819-bin-win-cuda-13.4-arm64.zip",
+		"llama-b10819-bin-win-opencl-adreno-arm64.zip",
+		"llama-b10819-bin-win-openvino-2026.3.1-x64.zip",
+		"llama-b10819-bin-win-rocm-10.0-x64.zip",
+		"llama-b10819-bin-win-sycl-x64.zip",
+		"llama-b10819-bin-win-vulkan-x64.zip",
+		"llama-b10819-ui.tar.gz",
+		"llama-b10819-xcframework.zip",
+	}
+	currentCases := []struct {
+		variant, goos, want string
+		wantExtra           string
+	}{
+		{"rocm", osWin, "llama-b10819-bin-win-rocm-10.0-x64.zip", ""},
+		{"rocm", osLinux, "llama-b10819-bin-ubuntu-rocm-10.0-x64.tar.gz", ""},
+		{"vulkan", osWin, "llama-b10819-bin-win-vulkan-x64.zip", ""},
+		{"cuda", osWin, "llama-b10819-bin-win-cuda-13.3-x64.zip", "cudart-llama-bin-win-cuda-13.3-x64.zip"},
+		{"cpu", osWin, "llama-b10819-bin-win-cpu-x64.zip", ""},
+		{"metal", osMac, "llama-b10819-bin-macos-arm64.tar.gz", ""},
+	}
+	for _, c := range currentCases {
+		got, extra, err := llama.MatchAssets(c.variant, c.goos, current)
+		if err != nil {
+			t.Fatalf("b10819 %s/%s: %v", c.variant, c.goos, err)
+		}
+		if got != c.want {
+			t.Errorf("b10819 %s/%s: got %q want %q", c.variant, c.goos, got, c.want)
+		}
+		if c.wantExtra != "" && (len(extra) != 1 || extra[0] != c.wantExtra) {
+			t.Errorf("b10819 %s/%s: extras %v want [%s]", c.variant, c.goos, extra, c.wantExtra)
+		}
+	}
+
 	// stable-diffusion.cpp: capitalised platform segments, its own cudart zip,
 	// and an upstream ROCm build. Verbatim from release master-809-eb7f35c.
 	sd, _ := Find("sd-server")

--- a/internal/backends/catalog.go
+++ b/internal/backends/catalog.go
@@ -159,8 +159,14 @@ var catalog = []Component{
 			},
 			{
 				ID: "rocm", Label: "ROCm / HIP", Note: "AMD only. Usually faster than Vulkan on RDNA3, and not subject to Vulkan's 2 GB allocation cap.",
+				// Upstream renamed the Windows asset from -bin-win-hip-radeon-x64
+				// to -bin-win-rocm-<toolkit>-x64 (b10733 onwards); the old name is
+				// kept as a fallback for an older tag the user might pin, but it
+				// appears in none of the 60 newest releases. With only the old
+				// pattern this variant matched nothing on Windows at all - the
+				// picker offered ROCm and every install failed to resolve.
 				Patterns: map[string][]string{
-					osWin:   {`^llama-.*-bin-win-hip-radeon-x64\.zip$`, `^llama-.*-bin-win-hip-.*x64\.zip$`},
+					osWin:   {`^llama-.*-bin-win-rocm-.*x64\.zip$`, `^llama-.*-bin-win-hip-radeon-x64\.zip$`, `^llama-.*-bin-win-hip-.*x64\.zip$`},
 					osLinux: {`^llama-.*-bin-ubuntu-rocm-.*-x64\.tar\.gz$`, `^llama-.*-bin-ubuntu-rocm-.*-x64\.zip$`},
 				},
 			},

--- a/internal/peimports/peimports.go
+++ b/internal/peimports/peimports.go
@@ -219,7 +219,13 @@ func runtimeAdvice(names []string) string {
 	}
 	switch {
 	case hip:
-		return "this build needs the AMD ROCm/HIP runtime next to the executable or on PATH"
+		// Deliberately not "or on PATH", which is the advice that wastes the
+		// most time here: AMD's HIP SDK installs these libraries as
+		// libhipblas.dll while ROCm-pip-built binaries import hipblas.dll, so
+		// putting the SDK on PATH resolves nothing. The libraries have to sit
+		// beside the exe under the names the import table asks for, and the
+		// working copies come from a ROCm build that links them dynamically.
+		return "copy the AMD ROCm/HIP runtime libraries next to the executable (PATH does not help: the HIP SDK names them lib*.dll)"
 	case cuda:
 		return "this build needs the NVIDIA CUDA runtime next to the executable or on PATH"
 	case driver:

--- a/internal/server/backendsapi.go
+++ b/internal/server/backendsapi.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -287,11 +286,28 @@ func (s *Server) activeBuild(comp string, installed []backends.Installed) *backe
 // preflightCache memoises peimports.Hint per installed build. The catalog is
 // polled while the Backends tab is open and the walk opens every DLL beside the
 // exe, so recomputing it per request would turn an idle tab into steady disk
-// traffic. An install directory is immutable once committed (versioned dirs are
-// never written in place — a reinstall replaces the whole tree), and the exe's
-// modtime keys the entry so a replaced build is re-checked rather than
-// inheriting the old verdict.
-var preflightCache sync.Map // exePath+"\x00"+modtime -> string
+// traffic.
+//
+// The entry expires as well as being keyed by the exe modtime, because an
+// install directory is NOT immutable: completing a build means dropping the
+// missing libraries in beside an executable nobody touches, so its modtime is
+// unchanged. Keyed on modtime alone, a build the user had just fixed by hand
+// went on reporting the DLL it no longer lacked for as long as the process
+// lived, with the card's size figure (an uncached directory walk) updating
+// around it as the only sign anything had happened.
+var preflightCache sync.Map // exePath -> preflightEntry
+
+// preflightTTL is how long a verdict is trusted. Long enough that an open tab
+// polling every couple of seconds triggers one import walk a minute per build,
+// short enough that a hand-fixed build clears its warning while the user is
+// still looking at the page.
+const preflightTTL = 30 * time.Second
+
+type preflightEntry struct {
+	hint    string
+	modTime int64
+	at      time.Time
+}
 
 // buildWarning reports why an installed build cannot run, or "" when it looks
 // fine. Cached; see preflightCache.
@@ -300,12 +316,15 @@ func buildWarning(exe string) string {
 	if err != nil {
 		return ""
 	}
-	key := exe + "\x00" + strconv.FormatInt(st.ModTime().UnixNano(), 10)
-	if v, ok := preflightCache.Load(key); ok {
-		return v.(string)
+	mod := st.ModTime().UnixNano()
+	if v, ok := preflightCache.Load(exe); ok {
+		e := v.(preflightEntry)
+		if e.modTime == mod && time.Since(e.at) < preflightTTL {
+			return e.hint
+		}
 	}
 	hint := peimports.Hint(exe)
-	preflightCache.Store(key, hint)
+	preflightCache.Store(exe, preflightEntry{hint: hint, modTime: mod, at: time.Now()})
 	return hint
 }
 


### PR DESCRIPTION
Image models needed every component hand-wired: a per-machine `settings.encoders` block plus a `--llm_vision` mmproj path typed by path. New `encoderpool.go` scans the models tree and classifies each candidate from its own header, so a fresh install resolves vae / clip / t5 / llm / mmproj with no config at all. `settings.encoders` and the per-model `textEncoderPath` / `llmVision` / `llmVisionPath` stay as pins, and a declared value always wins.

- classify safetensors from the tensor table at offset 0 (8-byte LE length + JSON), so header cost is independent of file size
- key VAEs on latent channel count (4=sd/sdxl, 16=flux.1, 32=flux.2), CLIP towers on embedding width, and detect the Wan-2.1 3D VAE by its 5-dim `conv1.weight`
- match a DiT to its text encoder on the caption-projection width the DiT itself states (`Metadata.CondHidden`): 3584=Qwen2.5-VL-7B, 2560=Qwen3-4B, 3072=Ministral-3B, 4096=T5-XXL
- break width ties with `encoderArchRank`: five unrelated 2560-wide models coexist on one box, and a size-only tiebreak wired Z-Image to Gemma-4
- exclude drafter sidecars and pooled embedders from the pool
- pair `--llm_vision` by directory, gated on edit/reference name detection (edit-vs-base is not structurally detectable)
- wire the previously empty `qwen_image` / `wan` arms, and never emit a projector without an encoder
- bump `genVersion` v57 -> v58 to force one regen

Verified against the full local models tree (header reads only, no servers launched): all 8 discovered image models resolve correctly from zero declared config, matching every hand-wired override apart from two family-internal swaps that declared paths still win.

`--flow-shift` stays in an override row: it is a sampling constant with no structural tell.

Also adds the branch convention (`<dev_name>/<feature>`, PR against `main`) to AGENTS.md.