### PR TITLE
playground: seed image settings from the model's own launch defaults

### DIFF
--- a/internal/backends/CLAUDE.md
+++ b/internal/backends/CLAUDE.md
@@ -218,7 +218,22 @@ therefore *coexist* with hand-entered rows in one registry, distinguished by
   the missing library on `Job.Warning`; the same check runs per build in the
   catalog DTO, because a job scrolls away and the broken build does not. The
   install still succeeds — the bits are on disk and work the moment the runtime
-  sits beside them.
+  sits beside them, which is the user's job: we diagnose, we do not repair.
+  Completing the install automatically was tried and dropped, because there is
+  nothing dependable to complete it *from*. The obvious donor, the user's own
+  llama.cpp ROCm install, is not one: the published
+  `llama-*-bin-win-rocm-*-x64.zip` was read entry by entry (b10819) and carries
+  `amdhip64_7.dll`, `amd_comgr.dll` and `rocm_kpack.dll` but **no**
+  `hipblas.dll`, `rocblas.dll` or `libhipblaslt.dll`, and no Tensile kernel trees
+  at all, because its 939 MB `ggml-hip.dll` static-links rocBLAS and hipBLASLt.
+  Only a dynamically linked ROCm build (lemonade's llamacpp-rocm) has the files
+  to give, so any automatic copy would half-complete most machines and hand back
+  a build that still dies at load with evidence that something worked. Two more
+  traps for anyone reopening this: rocBLAS/hipBLASLt load per-gfx-target kernels
+  as *data*, so no import graph names them (upstream packaged gfx1151 only; an
+  RX 7900 XTX needs gfx1100 added beside them), and a backend's `hipblas.dll`
+  expects its own `rocblas.dll` exports, so half-replacing a matched set is its
+  own load failure.
 - **The newest release is not always installable.** Real-ESRGAN's latest tag is
   source-only. `pickRelease` takes an `installable` predicate and, for "latest",
   skips releases with no matching asset for the requested variant/OS.

--- a/internal/backends/backends_test.go
+++ b/internal/backends/backends_test.go
@@ -75,6 +75,63 @@ func TestBackends_MatchAssets(t *testing.T) {
 		t.Error("expected an error when no asset matches")
 	}
 
+	// Upstream renamed the Windows ROCm asset (hip-radeon -> rocm-<toolkit>) and
+	// added arm64 CUDA. Verbatim from b10819: with only the old pattern the rocm
+	// variant matched nothing here, which is how a live release went uninstallable
+	// while the b10240 list above still passed.
+	current := []string{
+		"cudart-llama-bin-win-cuda-12.4-x64.zip",
+		"cudart-llama-bin-win-cuda-13.3-x64.zip",
+		"cudart-llama-bin-win-cuda-13.4-arm64.zip",
+		"llama-b10819-bin-android-arm64.tar.gz",
+		"llama-b10819-bin-macos-arm64.tar.gz",
+		"llama-b10819-bin-macos-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-arm64.tar.gz",
+		"llama-b10819-bin-ubuntu-openvino-2026.3.1-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-rocm-10.0-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-s390x.tar.gz",
+		"llama-b10819-bin-ubuntu-sycl-fp16-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-sycl-fp32-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-vulkan-arm64.tar.gz",
+		"llama-b10819-bin-ubuntu-vulkan-x64.tar.gz",
+		"llama-b10819-bin-ubuntu-x64.tar.gz",
+		"llama-b10819-bin-win-cpu-arm64.zip",
+		"llama-b10819-bin-win-cpu-x64.zip",
+		"llama-b10819-bin-win-cuda-12.4-x64.zip",
+		"llama-b10819-bin-win-cuda-13.3-x64.zip",
+		"llama-b10819-bin-win-cuda-13.4-arm64.zip",
+		"llama-b10819-bin-win-opencl-adreno-arm64.zip",
+		"llama-b10819-bin-win-openvino-2026.3.1-x64.zip",
+		"llama-b10819-bin-win-rocm-10.0-x64.zip",
+		"llama-b10819-bin-win-sycl-x64.zip",
+		"llama-b10819-bin-win-vulkan-x64.zip",
+		"llama-b10819-ui.tar.gz",
+		"llama-b10819-xcframework.zip",
+	}
+	currentCases := []struct {
+		variant, goos, want string
+		wantExtra           string
+	}{
+		{"rocm", osWin, "llama-b10819-bin-win-rocm-10.0-x64.zip", ""},
+		{"rocm", osLinux, "llama-b10819-bin-ubuntu-rocm-10.0-x64.tar.gz", ""},
+		{"vulkan", osWin, "llama-b10819-bin-win-vulkan-x64.zip", ""},
+		{"cuda", osWin, "llama-b10819-bin-win-cuda-13.3-x64.zip", "cudart-llama-bin-win-cuda-13.3-x64.zip"},
+		{"cpu", osWin, "llama-b10819-bin-win-cpu-x64.zip", ""},
+		{"metal", osMac, "llama-b10819-bin-macos-arm64.tar.gz", ""},
+	}
+	for _, c := range currentCases {
+		got, extra, err := llama.MatchAssets(c.variant, c.goos, current)
+		if err != nil {
+			t.Fatalf("b10819 %s/%s: %v", c.variant, c.goos, err)
+		}
+		if got != c.want {
+			t.Errorf("b10819 %s/%s: got %q want %q", c.variant, c.goos, got, c.want)
+		}
+		if c.wantExtra != "" && (len(extra) != 1 || extra[0] != c.wantExtra) {
+			t.Errorf("b10819 %s/%s: extras %v want [%s]", c.variant, c.goos, extra, c.wantExtra)
+		}
+	}
+
 	// stable-diffusion.cpp: capitalised platform segments, its own cudart zip,
 	// and an upstream ROCm build. Verbatim from release master-809-eb7f35c.
 	sd, _ := Find("sd-server")

--- a/internal/backends/catalog.go
+++ b/internal/backends/catalog.go
@@ -159,8 +159,14 @@ var catalog = []Component{
 			},
 			{
 				ID: "rocm", Label: "ROCm / HIP", Note: "AMD only. Usually faster than Vulkan on RDNA3, and not subject to Vulkan's 2 GB allocation cap.",
+				// Upstream renamed the Windows asset from -bin-win-hip-radeon-x64
+				// to -bin-win-rocm-<toolkit>-x64 (b10733 onwards); the old name is
+				// kept as a fallback for an older tag the user might pin, but it
+				// appears in none of the 60 newest releases. With only the old
+				// pattern this variant matched nothing on Windows at all - the
+				// picker offered ROCm and every install failed to resolve.
 				Patterns: map[string][]string{
-					osWin:   {`^llama-.*-bin-win-hip-radeon-x64\.zip$`, `^llama-.*-bin-win-hip-.*x64\.zip$`},
+					osWin:   {`^llama-.*-bin-win-rocm-.*x64\.zip$`, `^llama-.*-bin-win-hip-radeon-x64\.zip$`, `^llama-.*-bin-win-hip-.*x64\.zip$`},
 					osLinux: {`^llama-.*-bin-ubuntu-rocm-.*-x64\.tar\.gz$`, `^llama-.*-bin-ubuntu-rocm-.*-x64\.zip$`},
 				},
 			},

--- a/internal/peimports/peimports.go
+++ b/internal/peimports/peimports.go
@@ -219,7 +219,13 @@ func runtimeAdvice(names []string) string {
 	}
 	switch {
 	case hip:
-		return "this build needs the AMD ROCm/HIP runtime next to the executable or on PATH"
+		// Deliberately not "or on PATH", which is the advice that wastes the
+		// most time here: AMD's HIP SDK installs these libraries as
+		// libhipblas.dll while ROCm-pip-built binaries import hipblas.dll, so
+		// putting the SDK on PATH resolves nothing. The libraries have to sit
+		// beside the exe under the names the import table asks for, and the
+		// working copies come from a ROCm build that links them dynamically.
+		return "copy the AMD ROCm/HIP runtime libraries next to the executable (PATH does not help: the HIP SDK names them lib*.dll)"
 	case cuda:
 		return "this build needs the NVIDIA CUDA runtime next to the executable or on PATH"
 	case driver:

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -68,11 +68,56 @@ type apiModel struct {
 	// admission input; EstRamGB is non-zero only when weights are CPU-offloaded.
 	EstVramGB float64 `json:"estVramGB,omitempty"`
 	EstRamGB  float64 `json:"estRamGB,omitempty"`
+	// GenDefaults are the image-generation defaults this model is launched with,
+	// read back off its own command line (--steps/--cfg-scale/...). The playground
+	// sends an explicit value on EVERY /sdapi request, so those launch flags are
+	// otherwise dead: a per-request field always wins. Surfacing them lets the UI
+	// seed its panel from the model's real configuration instead of a hardcoded
+	// substring table. nil for anything that is not an image model.
+	GenDefaults *apiGenDefaults `json:"genDefaults,omitempty"`
 	// RunningCmd is the actual argv the process spawned with, set only while the
 	// model is running. It differs from the config command after a live config
 	// edit (new args apply on next load) or a spawn-time offload rewrite, so the
 	// UI shows what the model is REALLY loaded with, not the pending config.
 	RunningCmd string `json:"runningCmd,omitempty"`
+}
+
+// apiGenDefaults is the sd-server generation defaults carried on a model's
+// launch line. Zero/empty fields mean the flag is absent, i.e. the model states
+// no opinion and the client should keep its own default.
+type apiGenDefaults struct {
+	Steps   int     `json:"steps,omitempty"`
+	Cfg     float64 `json:"cfg,omitempty"`
+	Sampler string  `json:"sampler,omitempty"`
+	Width   int     `json:"width,omitempty"`
+	Height  int     `json:"height,omitempty"`
+}
+
+// genDefaults reads the generation flags autogen emitted onto an image model's
+// command line. It is deliberately parsed from the command rather than carried
+// as separate config fields: the command is what the process actually runs
+// with, so a hand-edited cmd cannot drift from what the UI reports.
+func genDefaults(info *config.CmdInfo) *apiGenDefaults {
+	g := &apiGenDefaults{}
+	if v, ok := info.Value("--steps"); ok {
+		g.Steps, _ = strconv.Atoi(strings.TrimSpace(v))
+	}
+	if v, ok := info.Value("--cfg-scale"); ok {
+		g.Cfg, _ = strconv.ParseFloat(strings.TrimSpace(v), 64)
+	}
+	if v, ok := info.Value("--sampling-method"); ok {
+		g.Sampler = strings.TrimSpace(v)
+	}
+	if v, ok := info.Value("--width", "-W"); ok {
+		g.Width, _ = strconv.Atoi(strings.TrimSpace(v))
+	}
+	if v, ok := info.Value("--height", "-H"); ok {
+		g.Height, _ = strconv.Atoi(strings.TrimSpace(v))
+	}
+	if *g == (apiGenDefaults{}) {
+		return nil
+	}
+	return g
 }
 
 // groupIndex maps each model ID to its group name (first group listing it as a
@@ -159,6 +204,7 @@ func (s *Server) modelStatus() []apiModel {
 			Quant:        quantName,
 			QuantLabel:   quantLabel,
 			SizeGB:       fileSizeGB(family),
+			GenDefaults:  genDefaults(info),
 			EstVramGB:    mc.EstVramGB,
 			EstRamGB:     mc.EstRamGB,
 			RunningCmd:   runningCmd,

--- a/internal/server/backendsapi.go
+++ b/internal/server/backendsapi.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -287,11 +286,28 @@ func (s *Server) activeBuild(comp string, installed []backends.Installed) *backe
 // preflightCache memoises peimports.Hint per installed build. The catalog is
 // polled while the Backends tab is open and the walk opens every DLL beside the
 // exe, so recomputing it per request would turn an idle tab into steady disk
-// traffic. An install directory is immutable once committed (versioned dirs are
-// never written in place — a reinstall replaces the whole tree), and the exe's
-// modtime keys the entry so a replaced build is re-checked rather than
-// inheriting the old verdict.
-var preflightCache sync.Map // exePath+"\x00"+modtime -> string
+// traffic.
+//
+// The entry expires as well as being keyed by the exe modtime, because an
+// install directory is NOT immutable: completing a build means dropping the
+// missing libraries in beside an executable nobody touches, so its modtime is
+// unchanged. Keyed on modtime alone, a build the user had just fixed by hand
+// went on reporting the DLL it no longer lacked for as long as the process
+// lived, with the card's size figure (an uncached directory walk) updating
+// around it as the only sign anything had happened.
+var preflightCache sync.Map // exePath -> preflightEntry
+
+// preflightTTL is how long a verdict is trusted. Long enough that an open tab
+// polling every couple of seconds triggers one import walk a minute per build,
+// short enough that a hand-fixed build clears its warning while the user is
+// still looking at the page.
+const preflightTTL = 30 * time.Second
+
+type preflightEntry struct {
+	hint    string
+	modTime int64
+	at      time.Time
+}
 
 // buildWarning reports why an installed build cannot run, or "" when it looks
 // fine. Cached; see preflightCache.
@@ -300,12 +316,15 @@ func buildWarning(exe string) string {
 	if err != nil {
 		return ""
 	}
-	key := exe + "\x00" + strconv.FormatInt(st.ModTime().UnixNano(), 10)
-	if v, ok := preflightCache.Load(key); ok {
-		return v.(string)
+	mod := st.ModTime().UnixNano()
+	if v, ok := preflightCache.Load(exe); ok {
+		e := v.(preflightEntry)
+		if e.modTime == mod && time.Since(e.at) < preflightTTL {
+			return e.hint
+		}
 	}
 	hint := peimports.Hint(exe)
-	preflightCache.Store(key, hint)
+	preflightCache.Store(exe, preflightEntry{hint: hint, modTime: mod, at: time.Now()})
 	return hint
 }
 

--- a/ui-svelte/src/components/playground/ImageInterface.svelte
+++ b/ui-svelte/src/components/playground/ImageInterface.svelte
@@ -274,7 +274,7 @@
     const id = $selectedModelStore;
     if (!id || id === $defaultsModelStore) return;
     $defaultsModelStore = id;
-    const d = settingsFor(id);
+    const d = settingsFor(id, $models.find((m) => m.id === id)?.genDefaults);
     $sdStepsStore = d.steps;
     $sdCfgScaleStore = d.cfg;
     $sdSamplerStore = d.sampler;
@@ -362,9 +362,16 @@
   // Clamp the persisted batch pref — a hand-edited pref (or an old value) must not
   // queue 200 renders behind one prompt.
   let batchCount = $derived(Math.min(MAX_BATCH, Math.max(1, Math.round($sdBatchStore || 1))));
-  let modelDefaults = $derived(defaultsFor($selectedModelStore));
+  // The hint line under the settings panel shows the SAME resolution the reset
+  // effect applies, so what it claims is the model default is what a switch
+  // actually sets. maxDim has no launch-line equivalent, so it stays table-only.
+  let modelGen = $derived($models.find((m) => m.id === $selectedModelStore)?.genDefaults);
+  let modelPreset = $derived(defaultsFor($selectedModelStore));
+  let modelDefaults = $derived(
+    modelPreset || modelGen ? settingsFor($selectedModelStore, modelGen) : undefined
+  );
   // Largest long edge the current model handles (tiers above are greyed out).
-  let modelMax = $derived(modelDefaults?.maxDim ?? DEFAULT_MAX_DIM);
+  let modelMax = $derived(modelPreset?.maxDim ?? DEFAULT_MAX_DIM);
   let aspectOptions = $derived(ASPECTS.map((a) => ({ value: a.value, label: a.label })));
   // Size tiers for the chosen aspect, labelled with the concrete WxH; tiers over
   // the model's cap are disabled.
@@ -1106,7 +1113,7 @@
               </div>
             </div>
             {#if modelDefaults}
-              <p class="text-xs text-txtsecondary -mt-1">Model default · {modelDefaults.steps} steps · cfg {modelDefaults.cfg} · {modelDefaults.sampler}</p>
+              <p class="text-xs text-txtsecondary -mt-1">Model default · {modelDefaults.steps} steps · cfg {modelDefaults.cfg}{modelDefaults.sampler ? ` · ${modelDefaults.sampler}` : ""}</p>
             {/if}
             <div class="flex flex-col gap-1">
               <span class="text-xs uppercase tracking-wide text-txtsecondary flex items-center gap-1">

--- a/ui-svelte/src/components/playground/imageGen.test.ts
+++ b/ui-svelte/src/components/playground/imageGen.test.ts
@@ -98,4 +98,27 @@ describe("settingsFor", () => {
     expect(settingsFor("illustrious-xl").size).toBe("1024x1024");
     expect(settingsFor("z-image-turbo").size).toBeUndefined();
   });
+
+  it("lets the model's own launch defaults win over the table", () => {
+    // The whole point: a model configured with defaultCfg/defaultSteps must not
+    // be reset to the generic 20/7 just because it has no preset row.
+    const d = settingsFor("longcat-image-edit-turbo", { steps: 12, cfg: 1 });
+    expect(d.steps).toBe(12);
+    expect(d.cfg).toBe(1);
+    // Even a model WITH a preset defers to what it is actually launched with.
+    expect(settingsFor("animagine-xl-3.1", { cfg: 4.5 }).cfg).toBe(4.5);
+  });
+
+  it("keeps the preset for fields the launch line does not state", () => {
+    const d = settingsFor("animagine-xl-3.1", { cfg: 4.5 });
+    expect(d.steps).toBe(28);
+    expect(d.sampler).toBe("euler_a");
+    expect(d.negative).toBe(SDXL_ANIME_NEG);
+    expect(d.size).toBe("1024x1024");
+  });
+
+  it("takes a size only when both edges are named", () => {
+    expect(settingsFor("z-image-turbo", { width: 1024, height: 768 }).size).toBe("1024x768");
+    expect(settingsFor("illustrious-xl", { width: 1024 }).size).toBe("1024x1024");
+  });
 });

--- a/ui-svelte/src/components/playground/imageGen.ts
+++ b/ui-svelte/src/components/playground/imageGen.ts
@@ -92,19 +92,42 @@ export const GENERIC_DEFAULTS = {
   denoise: 0.6,
 } satisfies (typeof IMAGE_DEFAULTS)[number];
 
-// The settings a model should load with: its preset, else the generic ones.
+// What the model itself says it wants, read off its launch line by the server
+// (apiModel.genDefaults). Absent fields = the flag was not emitted, i.e. no
+// opinion, so the preset/generic value stands.
+export interface ModelGenDefaults {
+  steps?: number;
+  cfg?: number;
+  sampler?: string;
+  width?: number;
+  height?: number;
+}
+
+// The settings a model should load with, in precedence order:
+//   1. what the model is actually LAUNCHED with (`gen`, from its own argv)
+//   2. its entry in IMAGE_DEFAULTS
+//   3. GENERIC_DEFAULTS
+// The model's own configuration has to win over the table below it, otherwise
+// setting defaultCfg on a model does nothing visible: the playground puts an
+// explicit cfg_scale on every /sdapi request, so the launch flag it overrides is
+// the very thing the user just configured. The table stays as the source for
+// what the command line cannot express (scheduler, negative prompt, denoise) and
+// for models that declare nothing.
 // `negative`/`denoise` are always present here so a switch clears a stale preset
 // value instead of inheriting it.
-export function settingsFor(id: string) {
+export function settingsFor(id: string, gen?: ModelGenDefaults) {
   const d = defaultsFor(id) ?? GENERIC_DEFAULTS;
+  const presetSize = "size" in d ? d.size : undefined;
   return {
-    steps: d.steps,
-    cfg: d.cfg,
-    sampler: d.sampler,
+    steps: gen?.steps || d.steps,
+    cfg: gen?.cfg || d.cfg,
+    sampler: gen?.sampler || d.sampler,
     scheduler: d.scheduler,
     negative: d.negative ?? GENERIC_DEFAULTS.negative,
     denoise: d.denoise ?? GENERIC_DEFAULTS.denoise,
-    size: "size" in d ? d.size : undefined,
+    // Only a launch line naming BOTH edges states a size; one alone is a
+    // half-specified canvas the aspect picker cannot honour.
+    size: gen?.width && gen?.height ? `${gen.width}x${gen.height}` : presetSize,
   };
 }
 

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -23,6 +23,14 @@ export interface ModelCapabilities {
   reasoning_effort?: string[];
 }
 
+export interface ModelGenDefaults {
+  steps?: number;
+  cfg?: number;
+  sampler?: string;
+  width?: number;
+  height?: number;
+}
+
 export interface Model {
   id: string;
   state: ModelStatus;
@@ -31,6 +39,10 @@ export interface Model {
   unlisted: boolean;
   peerID: string;
   capabilities?: ModelCapabilities;
+  // Image-generation defaults read off this model's own launch line
+  // (--steps/--cfg-scale/--sampling-method/--width/--height). Absent for
+  // non-image models, and per-field absent when the flag was not emitted.
+  genDefaults?: ModelGenDefaults;
   // Gguf path shared by a model's variants (ctx tiers, game, judge). Rows with
   // the same family are collapsed into one group. Empty => ungrouped.
   family?: string;


### PR DESCRIPTION
The Images tab put an explicit `cfg_scale`/`steps` on **every** `/sdapi` request, and a per-request field beats the launch flag, so the `--cfg-scale` / `--steps` autogen emits from `defaultCfg`/`defaultSteps` never applied. What actually decided the panel was `IMAGE_DEFAULTS`, a hardcoded substring table in the bundle, so any model without a row there generated at the generic cfg 7 / 20 steps no matter how it was configured. LongCat is the case that surfaced it.

`modelStatus` now reads the generation flags back off the model's own argv (the same way it already reads `-c`) and reports them as `genDefaults`; `settingsFor` prefers them over the table.

- new `apiGenDefaults` on `/api/models`: steps, cfg, sampler, width, height
- parsed from the command rather than carried as separate config fields, so a hand-edited `cmd` cannot drift from what the UI reports
- precedence: launch line > `IMAGE_DEFAULTS` > `GENERIC_DEFAULTS`. The table stays the source for what argv cannot express (scheduler, negative prompt, denoise, maxDim)
- a size is taken only when both edges are named: one alone is a half-specified canvas the aspect picker cannot honour
- the "Model default" hint line now shows the resolved values, so it matches what a model switch actually applies

Independent of #2 (no overlapping files), but it is what makes that PR's `defaultCfg` reach generation.