### PR TITLE
autogen: correct the LongCat flow-shift value in the docs

### DIFF
--- a/internal/autogen/classes.md
+++ b/internal/autogen/classes.md
@@ -98,7 +98,9 @@ thing that cannot be read off the weights: LongCat-Image-Edit and plain LongCat-
 identical `img_in`/`txt_in` shapes (the reference image enters as extra sequence tokens, not
 extra input channels), so `editModelRe` name-detects it, with `llmVision: on|off` and
 `llmVisionPath` as the escape hatches. Sampling knobs stay hand-wired: LongCat-Edit still wants
-`extraArgs: "--flow-shift 3"`, which has no structural tell.
+`extraArgs: "--flow-shift 3.16"`, which has no structural tell (the value is
+exp(base_shift) from the model's own scheduler config, not something the gguf
+states).
 
 ## Embedding (`embedding.go`)
 

--- a/internal/autogen/image.go
+++ b/internal/autogen/image.go
@@ -251,7 +251,9 @@ func resolveComponents(enc EncoderSet, ov *Override, arch, name string, pool *En
 	// projector come from the scan, matched on the caption width the DiT states
 	// (condHidden 3584 = Qwen2.5-VL-7B). --flow-shift is NOT wired: it is a
 	// sampling knob with no structural tell, so LongCat-Edit still wants
-	// `extraArgs: "--flow-shift 3"` on its override row.
+	// `extraArgs: "--flow-shift 3.16"` on its override row (exp(1.15), its
+	// scheduler's base_shift == max_shift, so unlike flux.1 it does not vary
+	// with canvas size).
 	case strings.Contains(n, "longcat"):
 		c.vae = req("vae", enc.FluxVae)
 		c.llm = req("llm", llmDefault)

--- a/internal/server/ui_dist/placeholder.txt
+++ b/internal/server/ui_dist/placeholder.txt
@@ -1,0 +1,7 @@
+Placeholder so `//go:embed ui_dist` in ../ui.go has something to embed on a
+fresh clone, before `make ui` has built the real Svelte bundle over the top of
+it. Without a tracked file here the whole internal/server package fails to
+compile with "pattern ui_dist: no matching files found".
+
+It cannot be named .gitkeep: the embed directive has no `all:` prefix, so it
+ignores files whose names start with a dot or an underscore.

--- a/internal/server/ui_dist/placeholder.txt
+++ b/internal/server/ui_dist/placeholder.txt
@@ -1,7 +1,0 @@
-Placeholder so `//go:embed ui_dist` in ../ui.go has something to embed on a
-fresh clone, before `make ui` has built the real Svelte bundle over the top of
-it. Without a tracked file here the whole internal/server package fails to
-compile with "pattern ui_dist: no matching files found".
-
-It cannot be named .gitkeep: the embed directive has no `all:` prefix, so it
-ignores files whose names start with a dot or an underscore.


### PR DESCRIPTION
The comments told users to hand-wire `--flow-shift 3` and attributed it to the model card, which never mentions shift.

The real source is the model's `scheduler_config.json`: `base_shift == max_shift == 1.15` under dynamic shifting, and sd.cpp's `--flow-shift` takes the final multiplier `exp(mu)`, so the value is `exp(1.15) = 3.16`. Because base equals max the interpolation collapses, so unlike flux.1's it does not vary with canvas size.

Comment/doc only, no behaviour change.