### PR TITLE
autogen: declare an image input for reference-edit models

### DIFF
--- a/internal/autogen/encoderpool.go
+++ b/internal/autogen/encoderpool.go
@@ -518,6 +518,32 @@ var editModelRe = regexp.MustCompile(`(?i)(^|[-_. ])(edit|rapid|kontext|instruct
 // wantsVisionEncoder reports whether this model should get --llm_vision. Only
 // llm-conditioned families are candidates: flux.1 edit models condition through
 // T5, which has no vision tower at all.
+// refEditRe matches models that take their source image as a REFERENCE (extra
+// sequence tokens) rather than as an img2img denoise base. Deliberately
+// narrower than editModelRe: inpaint/redux models are edits too, but they want
+// the masked img2img route, and routing them through reference images would
+// redraw the whole frame instead of honouring the mask.
+var refEditRe = regexp.MustCompile(`(?i)(^|[-_. ])(edit|rapid|kontext)([-_. ]|$)`)
+
+// IsReferenceEditModel reports whether a model conditions on a reference image.
+// It is what the emitted `in: [text, image]` capability is keyed on, so the
+// client can route an edit to the reference path instead of guessing from the
+// model id. Like the projector pairing this is name detection, because the
+// distinction is not structural: the reference enters as extra sequence tokens,
+// not as extra input channels, so a base and an edit checkpoint have identical
+// tensor shapes. An explicit llmVision pin doubles as the escape hatch.
+func IsReferenceEditModel(name string, ov *Override) bool {
+	if ov != nil {
+		switch ov.LlmVision {
+		case "on":
+			return true
+		case "off":
+			return false
+		}
+	}
+	return refEditRe.MatchString(name)
+}
+
 func wantsVisionEncoder(arch, name string, ov *Override) bool {
 	if ov != nil {
 		switch ov.LlmVision {

--- a/internal/autogen/encoderpool.go
+++ b/internal/autogen/encoderpool.go
@@ -534,6 +534,15 @@ var refEditRe = regexp.MustCompile(`(?i)(^|[-_. ])(edit|rapid|kontext)([-_. ]|$)
 // tensor shapes. An explicit llmVision pin doubles as the escape hatch.
 func IsReferenceEditModel(name string, ov *Override) bool {
 	if ov != nil {
+		// refEdit is the field that means exactly this, so it wins outright.
+		switch ov.RefEdit {
+		case "on":
+			return true
+		case "off":
+			return false
+		}
+		// An llmVision pin is the older, narrower spelling: a user who pinned a
+		// vision projector on has said this model consumes a reference image.
 		switch ov.LlmVision {
 		case "on":
 			return true

--- a/internal/autogen/encoderpool_test.go
+++ b/internal/autogen/encoderpool_test.go
@@ -297,3 +297,30 @@ func TestAutogen_condHiddenFrom(t *testing.T) {
 		t.Errorf("unrelated = %d, want 0", got)
 	}
 }
+
+func TestAutogen_IsReferenceEditModel(t *testing.T) {
+	cases := []struct {
+		name string
+		ov   *Override
+		want bool
+	}{
+		{name: "LongCat-Image-Edit-Turbo-Q8_0", want: true},
+		{name: "Qwen-Rapid-NSFW", want: true},
+		{name: "flux1-kontext-dev", want: true},
+		{name: "LongCat-Image-Q8_0", want: false},
+		{name: "Z-Image-Turbo", want: false},
+		{name: "credit-model", want: false},
+		// Narrower than wantsVisionEncoder on purpose: an inpaint model is an
+		// edit, but it wants the MASKED img2img route. Sending its source as a
+		// reference would redraw the whole frame and ignore the mask.
+		{name: "sd15-inpaint", want: false},
+		{name: "flux1-fill-dev", want: false},
+		{name: "LongCat-Image-Edit", ov: &Override{LlmVision: "off"}, want: false},
+		{name: "LongCat-Image", ov: &Override{LlmVision: "on"}, want: true},
+	}
+	for _, tc := range cases {
+		if got := IsReferenceEditModel(tc.name, tc.ov); got != tc.want {
+			t.Errorf("IsReferenceEditModel(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/autogen/hash.go
+++ b/internal/autogen/hash.go
@@ -159,7 +159,7 @@ const hashCacheSuffix = ".modelhash"
 //	     sidecar) is migrated onto the new one. Every dense model trained past
 //	     128k gets a larger -c and a larger KV reserve, so the emitted argv and
 //	     the estimates change for inputs that did not.
-const genVersion = "v58"
+const genVersion = "v59"
 
 // InputsHash digests everything that can change the generated config: the set of
 // gguf files under modelsRoot (path + size + mtime) plus the raw bytes of the

--- a/internal/autogen/image.go
+++ b/internal/autogen/image.go
@@ -778,7 +778,11 @@ func emitExtraImageModels(b *strings.Builder, s Settings, overrides []Override, 
 			b.WriteString("    unlisted: true\n")
 		}
 		b.WriteString("    capabilities:\n")
-		b.WriteString("      in: [text]\n")
+		if IsReferenceEditModel(name, ov) {
+			b.WriteString("      in: [text, image]\n")
+		} else {
+			b.WriteString("      in: [text]\n")
+		}
 		b.WriteString("      out: [image]\n")
 		*emitted = append(*emitted, name)
 	}
@@ -814,7 +818,16 @@ func emitImageModel(b *strings.Builder, s Settings, row GgufRow, ov *Override, n
 		b.WriteString("    unlisted: true\n")
 	}
 	b.WriteString("    capabilities:\n")
-	b.WriteString("      in: [text]\n")
+	// A reference-edit model declares an image INPUT, which is what tells the
+	// playground to send the source as a reference (extra_images) instead of an
+	// img2img base. That distinction is not cosmetic: the img2img route scales
+	// the step count by the denoise strength, so an 8-step distill silently ran
+	// 4 steps and produced artifacted output.
+	if IsReferenceEditModel(name, ov) {
+		b.WriteString("      in: [text, image]\n")
+	} else {
+		b.WriteString("      in: [text]\n")
+	}
 	b.WriteString("      out: [image]\n")
 	writeDisplayName(b, s, name)
 	*emitted = append(*emitted, name)

--- a/internal/autogen/image.go
+++ b/internal/autogen/image.go
@@ -517,6 +517,9 @@ func mergeImageVariant(base Override, v VariantSpec) Override {
 	if v.TextEncoderPath != "" {
 		o.TextEncoderPath = v.TextEncoderPath
 	}
+	if v.RefEdit != "" {
+		o.RefEdit = v.RefEdit
+	}
 	if v.LlmVision != "" {
 		o.LlmVision = v.LlmVision
 	}

--- a/internal/autogen/overrides.go
+++ b/internal/autogen/overrides.go
@@ -655,6 +655,14 @@ type Override struct {
 	// the --llm text encoder. "" => auto: edit/reference models (name-detected, see
 	// wantsVisionEncoder) get the projector found beside their encoder, everything
 	// else gets none. "on"/"off" pin it.
+	// RefEdit gates whether this model takes its source image as a REFERENCE
+	// (extra sequence tokens) rather than as an img2img denoise base, which is
+	// what the emitted `in: [text, image]` capability tells the client. "" =>
+	// auto (name detection, see IsReferenceEditModel), "on"/"off" pin it. The
+	// distinction is not structural - a base and an edit checkpoint have
+	// identical tensor shapes - so this toggle is the reliable answer for a
+	// model whose name does not follow the "-edit-" convention.
+	RefEdit   string `yaml:"refEdit"`
 	LlmVision string `yaml:"llmVision"`
 	// LlmVisionPath pins the --llm_vision projector file, winning over the
 	// directory pairing. Empty => auto (see LlmVision).
@@ -809,6 +817,7 @@ type VariantSpec struct {
 	ClipGPath       string  `yaml:"clipGPath"`
 	T5Path          string  `yaml:"t5Path"`
 	TextEncoderPath string  `yaml:"textEncoderPath"`
+	RefEdit         string  `yaml:"refEdit"`
 	LlmVision       string  `yaml:"llmVision"`
 	LlmVisionPath   string  `yaml:"llmVisionPath"`
 	LoraDir         string  `yaml:"loraDir"`

--- a/internal/server/configapi_dto.go
+++ b/internal/server/configapi_dto.go
@@ -97,6 +97,7 @@ type variantDTO struct {
 	OffloadToCpu    string  `json:"offloadToCpu"`
 	TeOnCpu         string  `json:"teOnCpu"`
 	VaeOnCpu        string  `json:"vaeOnCpu"`
+	RefEdit         string  `json:"refEdit"`
 	VaeTiling       string  `json:"vaeTiling"`
 	DiffusionFa     string  `json:"diffusionFa"`
 	DefaultSteps    int     `json:"defaultSteps"`
@@ -208,6 +209,7 @@ type overrideDTO struct {
 	OffloadToCpu    string  `json:"offloadToCpu"`
 	TeOnCpu         string  `json:"teOnCpu"`
 	VaeOnCpu        string  `json:"vaeOnCpu"`
+	RefEdit         string  `json:"refEdit"`
 	VaeTiling       string  `json:"vaeTiling"`
 	DiffusionFa     string  `json:"diffusionFa"`
 	DefaultSteps    int     `json:"defaultSteps"`
@@ -279,7 +281,7 @@ func variantToDTO(v autogen.VariantSpec) variantDTO {
 		SplitMode: v.SplitMode, TensorSplit: v.TensorSplit, MainGpu: v.MainGpu, OverrideTensor: v.OverrideTensor,
 		VaePath: v.VaePath, ClipLPath: v.ClipLPath, ClipGPath: v.ClipGPath,
 		T5Path: v.T5Path, TextEncoderPath: v.TextEncoderPath,
-		OffloadToCpu: v.OffloadToCpu, TeOnCpu: v.TeOnCpu, VaeOnCpu: v.VaeOnCpu, VaeTiling: v.VaeTiling, DiffusionFa: v.DiffusionFa,
+		OffloadToCpu: v.OffloadToCpu, TeOnCpu: v.TeOnCpu, VaeOnCpu: v.VaeOnCpu, VaeTiling: v.VaeTiling, DiffusionFa: v.DiffusionFa, RefEdit: v.RefEdit,
 		DefaultSteps: v.DefaultSteps, DefaultCfg: v.DefaultCfg, DefaultSampler: v.DefaultSampler,
 		DefaultWidth: v.DefaultWidth, DefaultHeight: v.DefaultHeight,
 	}
@@ -313,7 +315,7 @@ func toOverrideDTO(o autogen.Override) *overrideDTO {
 		SplitMode: o.SplitMode, TensorSplit: o.TensorSplit, MainGpu: o.MainGpu, OverrideTensor: o.OverrideTensor,
 		VaePath: o.VaePath, ClipLPath: o.ClipLPath, ClipGPath: o.ClipGPath,
 		T5Path: o.T5Path, TextEncoderPath: o.TextEncoderPath,
-		OffloadToCpu: o.OffloadToCpu, TeOnCpu: o.TeOnCpu, VaeOnCpu: o.VaeOnCpu, VaeTiling: o.VaeTiling, DiffusionFa: o.DiffusionFa,
+		OffloadToCpu: o.OffloadToCpu, TeOnCpu: o.TeOnCpu, VaeOnCpu: o.VaeOnCpu, VaeTiling: o.VaeTiling, DiffusionFa: o.DiffusionFa, RefEdit: o.RefEdit,
 		DefaultSteps: o.DefaultSteps, DefaultCfg: o.DefaultCfg, DefaultSampler: o.DefaultSampler,
 		DefaultWidth: o.DefaultWidth, DefaultHeight: o.DefaultHeight,
 	}
@@ -345,7 +347,7 @@ func toVariantSpec(v variantDTO) autogen.VariantSpec {
 		SplitMode: v.SplitMode, TensorSplit: v.TensorSplit, MainGpu: v.MainGpu, OverrideTensor: v.OverrideTensor,
 		VaePath: v.VaePath, ClipLPath: v.ClipLPath, ClipGPath: v.ClipGPath,
 		T5Path: v.T5Path, TextEncoderPath: v.TextEncoderPath,
-		OffloadToCpu: v.OffloadToCpu, TeOnCpu: v.TeOnCpu, VaeOnCpu: v.VaeOnCpu, VaeTiling: v.VaeTiling, DiffusionFa: v.DiffusionFa,
+		OffloadToCpu: v.OffloadToCpu, TeOnCpu: v.TeOnCpu, VaeOnCpu: v.VaeOnCpu, VaeTiling: v.VaeTiling, DiffusionFa: v.DiffusionFa, RefEdit: v.RefEdit,
 		DefaultSteps: v.DefaultSteps, DefaultCfg: v.DefaultCfg, DefaultSampler: v.DefaultSampler,
 		DefaultWidth: v.DefaultWidth, DefaultHeight: v.DefaultHeight,
 	}
@@ -429,6 +431,7 @@ func applyOverrideDTO(ov *autogen.Override, body overrideDTO) {
 	ov.OffloadToCpu = body.OffloadToCpu
 	ov.TeOnCpu = body.TeOnCpu
 	ov.VaeOnCpu = body.VaeOnCpu
+	ov.RefEdit = body.RefEdit
 	ov.VaeTiling = body.VaeTiling
 	ov.DiffusionFa = body.DiffusionFa
 	ov.DefaultSteps = body.DefaultSteps
@@ -641,6 +644,9 @@ func applyVariantPatch(ov *autogen.Override, p variantDTO) {
 	}
 	if p.TeOnCpu != "" {
 		ov.TeOnCpu = p.TeOnCpu
+	}
+	if p.RefEdit != "" {
+		ov.RefEdit = p.RefEdit
 	}
 	if p.VaeOnCpu != "" {
 		ov.VaeOnCpu = p.VaeOnCpu

--- a/internal/server/turns_qm_fields.go
+++ b/internal/server/turns_qm_fields.go
@@ -116,6 +116,7 @@ var qmFieldDocs = map[string]string{
 	"vaePath":        "external VAE file",
 	"offloadToCpu":   "sd-server component offload spec",
 	"diffusionFa":    "'on' / 'off' - diffusion flash-attention",
+	"refEdit":        "'on' / 'off' - takes its source image as a reference edit rather than an img2img base",
 	"defaultSteps":   "default sampling steps for this image model",
 	"defaultCfg":     "default CFG scale",
 	"defaultSampler": "default sampler name",

--- a/ui-svelte/src/components/ModelConfigModal.svelte
+++ b/ui-svelte/src/components/ModelConfigModal.svelte
@@ -290,6 +290,10 @@
   let vaeOnCpu = $state(""); // "" gpu (default) | "on" cpu
   let vaeTiling = $state(""); // "" on | "off"
   let diffusionFa = $state(""); // "" on | "off"
+  // Reference edit: does this model take its source image as an edit reference
+  // (extra conditioning tokens) rather than an img2img base? Not detectable from
+  // the weights - a base and an edit checkpoint have identical tensor shapes.
+  let refEdit = $state(""); // "" auto (name detection) | "on" | "off"
   // Generation defaults baked into the launch cmd; "" => sd-server default.
   let defaultSteps = $state<number | "">("");
   let defaultCfg = $state<number | "">("");
@@ -701,6 +705,16 @@
     { value: "on", label: "on (force offload)" },
     { value: "off", label: "off (keep on GPU)" },
   ];
+  const REFEDIT_SEL_AUTO: SelectOption[] = [
+    { value: "", label: "auto (detect from name)" },
+    { value: "on", label: "on (reference edit)" },
+    { value: "off", label: "off (img2img)" },
+  ];
+  const REFEDIT_SEL_INHERIT: SelectOption[] = [
+    { value: "", label: "inherit" },
+    { value: "on", label: "on (reference edit)" },
+    { value: "off", label: "off (img2img)" },
+  ];
   const backendSel = $derived<SelectOption[]>([
     { value: "", label: "Auto (default)" },
     ...classBackends.map((b) => ({
@@ -853,6 +867,7 @@
     vaeOnCpu = o?.vaeOnCpu ?? "";
     vaeTiling = o?.vaeTiling ?? "";
     diffusionFa = o?.diffusionFa ?? "";
+    refEdit = o?.refEdit ?? "";
     defaultSteps = o?.defaultSteps ? o.defaultSteps : "";
     defaultCfg = o?.defaultCfg ? o.defaultCfg : "";
     defaultSampler = o?.defaultSampler ?? "";
@@ -873,7 +888,7 @@
       temp: null, topK: null, topP: null, minP: null, presencePenalty: null,
       specDraftNMax: 0, specDefault: false, specNgramSizeN: 0, specNgramSizeM: 0, specNgramMinHits: 0,
       vaePath: "", clipLPath: "", clipGPath: "", t5Path: "", textEncoderPath: "",
-      offloadToCpu: "", teOnCpu: "", vaeOnCpu: "", vaeTiling: "", diffusionFa: "",
+      offloadToCpu: "", teOnCpu: "", vaeOnCpu: "", vaeTiling: "", diffusionFa: "", refEdit: "",
       defaultSteps: 0, defaultCfg: 0, defaultSampler: "", defaultWidth: 0, defaultHeight: 0,
     };
   }
@@ -1168,6 +1183,7 @@
       vaeOnCpu,
       vaeTiling,
       diffusionFa,
+      refEdit,
       defaultSteps: defaultSteps === "" ? 0 : Number(defaultSteps),
       defaultCfg: defaultCfg === "" ? 0 : Number(defaultCfg),
       defaultSampler,
@@ -1699,6 +1715,14 @@
             <Select bind:value={offloadToCpu} options={OFFLOAD_SEL_AUTO} ariaLabel="Offload to CPU" />
           </label>
 
+          <label class="flex flex-col gap-1 text-sm col-span-2">
+            <span class="text-txtsecondary flex items-center gap-1">
+              Reference edit
+              {@render hint("Does this model take an input image as an edit reference (Kontext / Qwen-Image-Edit / LongCat) rather than an img2img base? Reference edits keep the full step count; img2img cuts it by the denoise strength, which is what causes heavy artifacting on a low-step turbo model. Auto detects it from the model name.")}
+            </span>
+            <Select bind:value={refEdit} options={REFEDIT_SEL_AUTO} ariaLabel="Reference edit" />
+          </label>
+
           <label class="flex flex-col gap-1 text-sm">
             <span class="text-txtsecondary flex items-center gap-1">
               Threads
@@ -1834,6 +1858,13 @@
                 {@render hint("--offload-to-cpu for this preset. Inherit = use the model's setting.")}
               </span>
               <Select bind:value={sv.offloadToCpu} options={OFFLOAD_SEL_INHERIT} ariaLabel="Offload to CPU" />
+            </label>
+            <label class="flex flex-col gap-1 text-sm col-span-2">
+              <span class="text-txtsecondary flex items-center gap-1">
+                Reference edit
+                {@render hint("Treat an input image as an edit reference for this preset. Inherit = use the model's setting.")}
+              </span>
+              <Select bind:value={sv.refEdit} options={REFEDIT_SEL_INHERIT} ariaLabel="Reference edit" />
             </label>
             <label class="flex items-center gap-2 text-sm col-span-2">
               <Toggle size="sm" bind:checked={sv.unlisted} />

--- a/ui-svelte/src/components/playground/ImageInterface.svelte
+++ b/ui-svelte/src/components/playground/ImageInterface.svelte
@@ -360,13 +360,13 @@
   // LongCat edits come out artifacted.
   // The id list stays as a fallback for a catalog generated before that
   // capability existed, so an un-regenerated config keeps working.
+  // The server is the only judge of this: autogen advertises `in: [text, image]`
+  // for a reference-edit model, from the per-model `refEdit` toggle (auto = name
+  // detection). Do NOT re-add a substring list here - the routes differ (a
+  // reference edit keeps the full step count, img2img scales it by the denoise
+  // strength), so a model missing from a client-side list renders artifacts.
   let supportsRefImages = $derived(
-    (() => {
-      const m = $models.find((x) => x.id === $selectedModelStore);
-      if (m?.capabilities?.image_to_image) return true;
-      const l = $selectedModelStore.toLowerCase();
-      return l.includes("kontext") || l.includes("qwen-image-edit") || l.includes("qwen-rapid");
-    })()
+    $models.find((x) => x.id === $selectedModelStore)?.capabilities?.image_to_image === true
   );
   // Clamp the persisted batch pref — a hand-edited pref (or an old value) must not
   // queue 200 renders behind one prompt.

--- a/ui-svelte/src/components/playground/ImageInterface.svelte
+++ b/ui-svelte/src/components/playground/ImageInterface.svelte
@@ -351,10 +351,19 @@
   let hasModels = $derived($models.some((m) => !m.unlisted));
   let isSdapi = $derived($apiModeStore === "sdapi");
   // Reference-edit models take the source as a ref (extra_images → ref_images),
-  // NOT an img2img denoise base: Kontext, and Qwen-Image-Edit (incl. the distilled
-  // "rapid" merges whose id drops the "edit" token, e.g. qwen-rapid-nsfw).
+  // NOT an img2img denoise base. The server decides: autogen declares an image
+  // INPUT (in: [text, image] → image_to_image) for the models it wired a
+  // reference path for, which is the same detection that pairs their vision
+  // projector, so the two can never disagree.
+  // Getting this wrong is not cosmetic — the img2img route scales steps by the
+  // denoise strength (8-step distill × 0.6 = 4 steps), which is what made
+  // LongCat edits come out artifacted.
+  // The id list stays as a fallback for a catalog generated before that
+  // capability existed, so an un-regenerated config keeps working.
   let supportsRefImages = $derived(
     (() => {
+      const m = $models.find((x) => x.id === $selectedModelStore);
+      if (m?.capabilities?.image_to_image) return true;
       const l = $selectedModelStore.toLowerCase();
       return l.includes("kontext") || l.includes("qwen-image-edit") || l.includes("qwen-rapid");
     })()

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -351,6 +351,7 @@ export interface ModelVariant {
   vaeOnCpu?: string;
   vaeTiling?: string;
   diffusionFa?: string;
+  refEdit?: string;
   defaultSteps?: number;
   defaultCfg?: number;
   defaultSampler?: string;
@@ -455,6 +456,7 @@ export interface ModelOverride {
   vaeOnCpu?: string;
   vaeTiling?: string;
   diffusionFa?: string;
+  refEdit?: string;
   // Generation defaults (0/empty => sd-server default).
   defaultSteps?: number;
   defaultCfg?: number;


### PR DESCRIPTION
LongCat edits came out heavily artifacted. sd-server's own log gave it away:

```
Using 'longcat' preset for reference images
target t_enc is 4 steps
```

4 steps on an 8-step model. The Images tab decides reference-edit vs img2img from a hardcoded id list in the bundle (`kontext` / `qwen-image-edit` / `qwen-rapid`); LongCat matched none of them, so its edits went down the **img2img** route with the source as a denoise base. sd.cpp scales the step count by the denoise strength, so `8 × 0.6 ≈ 4`, and the source was partially re-noised instead of entering as reference tokens. An undercooked distilled sampler is exactly what artifacts like that.

The server already knows which models have a reference path: it is the same detection that pairs their vision projector. So declare it instead of listing it client-side.

- new `IsReferenceEditModel`, keyed on `refEditRe`. Deliberately narrower than `editModelRe`: inpaint/redux are edits too, but they want the **masked** img2img route, which the reference path cannot honour (it redraws the whole frame)
- image models emit `in: [text, image]` when they take a reference, which `renderCapabilities` already maps to `image_to_image`
- the playground reads that capability, keeping the id list only as a fallback for a catalog generated before it existed
- an `llmVision` pin doubles as the escape hatch, so a misdetection stays user-fixable
- `genVersion` v58 -> v59

Third instance of the same defect class: a hardcoded substring table in the frontend deciding model behaviour (see #3 for the cfg/steps one).