### PR TITLE
packaging: allow a prerelease tag so a build can go to one tester

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -84,6 +84,18 @@ runner (CGO is off project-wide), so the Windows wizard, `linux/amd64`,
 The tag is created on the dispatched ref's HEAD, and the script refuses to
 continue if the tag is not HEAD or origin already has it elsewhere.
 
+**A tag with a suffix (`v1.0.4-rc1`) makes the release a prerelease**, which is
+how a build gets handed to one tester without offering it to everyone. Two
+independent mechanisms keep it away from the rest: the updater polls
+`/releases/latest`, which GitHub answers without prereleases, and
+`internal/update`'s `semverRe` cannot parse a suffixed version, so `newer()`
+returns false even if the release is published by mistake. A plain `vX.Y.Z`
+ticked prerelease by hand has only the first of those, and burns a real version
+number on a test build. `docker.yml`'s tag-vs-published comparison already skips
+it, so no image is retagged either. Dispatch it from the feature branch: the tag
+then pins a commit that a squash-merge orphans, so delete the tag and the
+prerelease once testing is done.
+
 ## The Docker image
 
 Built by `docker.yml` from `docker/app/Dockerfile`. User-facing docs live in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (vMAJOR.MINOR.PATCH)'
+        description: 'Release tag (vMAJOR.MINOR.PATCH, or -SUFFIX for a prerelease)'
         required: true
         type: string
       draft:

--- a/Makefile
+++ b/Makefile
@@ -316,8 +316,11 @@ release-binaries:
 _build-release:
 	@if [ -z "$(VERSION)" ]; then \
 		echo "Error: VERSION=vMAJOR.MINOR.PATCH is required (e.g. make release VERSION=v0.5.1)" >&2; exit 1; fi
-	@echo "$(VERSION)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$' || { \
-		echo "Error: VERSION must be vMAJOR.MINOR.PATCH (e.g. v0.5.1)" >&2; exit 1; }
+	# Kept in step with build-release.ps1's own check: a -SUFFIX is allowed and
+	# makes the GitHub release a prerelease. Diverging here would reject locally
+	# what the CI path accepts.
+	@echo "$(VERSION)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$$' || { \
+		echo "Error: VERSION must be vMAJOR.MINOR.PATCH, optionally -SUFFIX (e.g. v0.5.1, v0.5.1-rc1)" >&2; exit 1; }
 	# Created on HEAD when it does not exist yet. build-release.ps1 then verifies
 	# the tag IS HEAD, so a tag that already lives on another commit stops the
 	# release instead of quietly shipping that commit under this version.

--- a/packaging/windows/build-release.ps1
+++ b/packaging/windows/build-release.ps1
@@ -30,8 +30,10 @@
   toolchain beyond Go itself.
 
 .PARAMETER Tag
-  Release tag (vX.Y.Z). Required, and it must already point at HEAD (or not
-  exist yet, in which case it is created on HEAD). Never inferred: see below.
+  Release tag (vX.Y.Z, or vX.Y.Z-<suffix> for a prerelease). Required, and it
+  must already point at HEAD (or not exist yet, in which case it is created on
+  HEAD). Never inferred: see below. A tag carrying a suffix marks the GitHub
+  release as a prerelease: see the regex below for why that is worth having.
 
 .PARAMETER Draft
   Create/keep the GitHub release as a draft (default). Pass -Draft false to publish.
@@ -106,7 +108,16 @@ function Die($m) { Write-Error $m; exit 1 }
 # whatever HEAD happened to be and published it under a version that tag may
 # not point at; a release has to name the version it is releasing.
 if (-not $Tag) { Die "-Tag vX.Y.Z is required (make release VERSION=vX.Y.Z)" }
-if ($Tag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+$') { Die "Tag must be vMAJOR.MINOR.PATCH (e.g. v0.5.1)" }
+# The suffix is what makes a test build safe to hand to one person. Two
+# independent mechanisms then keep it away from everyone else: the updater polls
+# /releases/latest, which GitHub answers without prereleases, AND
+# internal/update's semverRe refuses to parse a suffixed version, so newer()
+# returns false even if the release is later published by mistake. A plain
+# vX.Y.Z marked prerelease by hand has only the first of those.
+if ($Tag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$') {
+    Die "Tag must be vMAJOR.MINOR.PATCH, optionally -SUFFIX for a prerelease (e.g. v0.5.1, v0.5.1-rc1)"
+}
+$isPrerelease = $Tag.Contains('-')
 
 # $Tag is stamped into every binary (-X main.version) and the updater hands that
 # string to users as the version they are running, so the build has to come from
@@ -469,12 +480,13 @@ if (-not $exists) {
     # string is still passed as an argument, and `gh release create ""` fails.
     $createArgs = @('release', 'create', $Tag, '-R', $Repo, '--title', $Tag, '--notes', $body)
     if ($isDraft) { $createArgs += '--draft' }
+    if ($isPrerelease) { $createArgs += '--prerelease' }
     gh @createArgs
     if ($LASTEXITCODE -ne 0) { Die "gh release create failed" }
 } else {
     # A re-run is usually a fixed build of the same tag, so the body is rewritten
     # rather than left at whatever the first attempt wrote.
-    gh release edit $Tag -R $Repo --notes $body
+    gh release edit $Tag -R $Repo --notes $body --prerelease=$($isPrerelease.ToString().ToLower())
     if ($LASTEXITCODE -ne 0) { Die "gh release edit (notes) failed" }
 }
 gh release upload $Tag @uploads -R $Repo --clobber
@@ -488,4 +500,4 @@ if (-not $isDraft) {
     if ($LASTEXITCODE -ne 0) { Die "gh release edit failed" }
 }
 
-Write-Host "Done. $Tag (draft=$isDraft) -> https://github.com/$Repo/releases" -ForegroundColor Green
+Write-Host "Done. $Tag (draft=$isDraft, prerelease=$isPrerelease) -> https://github.com/$Repo/releases" -ForegroundColor Green


### PR DESCRIPTION
`build-release.ps1` enforced `^v[0-9]+\.[0-9]+\.[0-9]+$`, so handing a test build to a single person meant burning a real version number and ticking "pre-release" by hand. `internal/update`'s `newer()` already documents "a prerelease tag (v1.0.0-rc1)" as a case it refuses to parse, so the gap was on the builder side only.

A tag may now carry a semver suffix, and one that does creates the release with `--prerelease`. Two independent mechanisms then keep it away from everyone else: the updater polls `/releases/latest`, which GitHub answers without prereleases, and `semverRe` cannot parse the suffixed version, so `newer()` returns false even if the release is published by mistake.

- build-release.ps1: widened tag regex, `$isPrerelease`, `--prerelease` on create and on the re-run edit path
- Makefile: the same regex in `_build-release`, so a local `make release` does not reject what CI accepts
- release.yml: dispatch input description mentions the suffix
- .github/CLAUDE.md: when to use it, and that the tag wants deleting once the branch it was cut from is squash-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)