### PR TITLE
site: never advertise a prerelease on the download button

### DIFF
--- a/ui-svelte/site/build.mjs
+++ b/ui-svelte/site/build.mjs
@@ -218,7 +218,13 @@ function latestRelease() {
         stdio: ["ignore", "pipe", "ignore"],
       }),
     );
-    const rel = list.find((r) => !r.isDraft && /^v\d+\.\d+/.test(r.tagName));
+    // Prereleases are skipped, not just drafts. A prerelease exists to go to one
+    // tester by hand; the updater already ignores it (/releases/latest omits it,
+    // and internal/update's semverRe will not parse a suffixed tag), and the
+    // download button is the last path by which a test build could still reach
+    // an ordinary visitor. The isPrerelease field below stays wired so the label
+    // still works if that policy is ever relaxed.
+    const rel = list.find((r) => !r.isDraft && !r.isPrerelease && /^v\d+\.\d+/.test(r.tagName));
     if (!rel) return null;
     const view = JSON.parse(
       execFileSync("gh", ["release", "view", rel.tagName, "--json", "tagName,publishedAt,assets"], {


### PR DESCRIPTION
`latestRelease()` in `ui-svelte/site/build.mjs` filtered drafts but not prereleases, so the newest prerelease would become the hero download for every visitor to the site.

That is the last path by which a test build could reach ordinary users. The other two are already closed: the updater polls `/releases/latest`, which GitHub answers without prereleases, and `internal/update`'s `semverRe` will not parse a suffixed tag so `newer()` returns false; `docker.yml` skips when the newest `v*` tag is not the newest published release.

The chain that makes it fire is not obvious: Release completes, `pages.yml`'s `workflow_run` trigger rebuilds the site at the default branch ref, and `gh release list` returns the prerelease first.

- `build.mjs`: skip `isPrerelease` alongside `isDraft`; the field stays wired to the "(pre-release)" label so the policy can be relaxed without re-plumbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)