### PR TITLE
playground: keep composer dropdowns inside the viewport

### DIFF
--- a/ui-svelte/src/components/playground/Composer.svelte
+++ b/ui-svelte/src/components/playground/Composer.svelte
@@ -74,7 +74,15 @@
 </script>
 
 {#if showSettings}
-  <div use:closeOnOutside class="absolute bottom-full right-0 mb-2 w-80 z-20 flex flex-col gap-3 p-4 rounded-lg border border-card-border bg-surface shadow-lg text-[0.8125rem]">
+  <!-- max-h/overflow: the image panel is tall enough to run past the top of a
+       short window. It has to scroll itself, because the shell clips rather than
+       letting the document grow a pair of scrollbars. 100vh needs the `zoom`
+       division (see index.css); 9rem leaves room for the composer below it. -->
+  <div
+    use:closeOnOutside
+    class="absolute bottom-full right-0 mb-2 w-80 z-20 flex flex-col gap-3 p-4 rounded-lg border border-card-border bg-surface shadow-lg text-[0.8125rem] overflow-y-auto overscroll-contain pretty-scroll"
+    style="max-height: calc(100vh / var(--qm-scale) - 9rem)"
+  >
     <div class="flex items-center justify-between">
       <span class="font-medium text-txtmain">{settingsTitle}</span>
       <button

--- a/ui-svelte/src/components/playground/Select.svelte
+++ b/ui-svelte/src/components/playground/Select.svelte
@@ -13,6 +13,52 @@
   let open = $state(false);
   let selectedLabel = $derived(options.find((o) => o.value === value)?.label ?? value);
 
+  // Drop direction + height, measured against the viewport on every open. The
+  // list lives inside popovers (the composer's settings panel) that are NOT
+  // scroll containers, so an unclamped 16rem list hanging off the bottom row
+  // escapes the h-screen root and gives the whole document scrollbars.
+  let btnEl = $state<HTMLButtonElement>();
+  let up = $state(false);
+  let maxH = $state(256);
+
+  const GAP = 8; // mt-1/mb-1 plus a little breathing room
+  const MIN_H = 96;
+
+  // The viewport, narrowed to the nearest clipping ancestor: dropping out of a
+  // scrollable settings panel is just as invisible as dropping off the page.
+  function bounds(): { top: number; bottom: number } {
+    // `zoom` scales layout but not viewport units, so measure the box the page
+    // actually paints into rather than window.innerHeight.
+    let top = 0;
+    let bottom = document.documentElement.clientHeight;
+    let el = btnEl?.parentElement ?? null;
+    while (el && el !== document.body) {
+      const o = getComputedStyle(el).overflowY;
+      if (o !== "visible") {
+        const r = el.getBoundingClientRect();
+        top = Math.max(top, r.top);
+        bottom = Math.min(bottom, r.bottom);
+      }
+      el = el.parentElement;
+    }
+    return { top, bottom };
+  }
+
+  function place() {
+    if (!btnEl) return;
+    const r = btnEl.getBoundingClientRect();
+    const b = bounds();
+    const below = b.bottom - r.bottom - GAP;
+    const above = r.top - b.top - GAP;
+    up = below < Math.min(256, above) && above > below;
+    maxH = Math.max(MIN_H, Math.min(256, Math.floor(up ? above : below)));
+  }
+
+  function toggle() {
+    if (!open) place();
+    open = !open;
+  }
+
   function select(v: string) {
     value = v;
     open = false;
@@ -29,12 +75,13 @@
 
 <div class="relative w-full" use:clickOutside>
   <button
+    bind:this={btnEl}
     type="button"
     {disabled}
     class="w-full flex items-center justify-between gap-2 rounded border border-card-border bg-surface text-left focus:outline-none focus:border-primary disabled:opacity-50 {compact
       ? 'px-2.5 py-1.5 text-[0.8125rem]'
       : 'px-3 py-2'}"
-    onclick={() => (open = !open)}
+    onclick={toggle}
     onkeydown={(e) => e.key === "Escape" && (open = false)}
   >
     <span class="truncate">{selectedLabel}</span>
@@ -43,7 +90,10 @@
 
   {#if open}
     <div
-      class="absolute left-0 top-full mt-1 z-30 min-w-full w-max max-w-[16rem] max-h-64 overflow-y-auto pretty-scroll rounded-md border border-card-border bg-surface shadow-lg py-1 text-[0.8125rem]"
+      style="max-height: {maxH}px"
+      class="absolute left-0 z-30 min-w-full w-max max-w-[16rem] overflow-y-auto overscroll-contain pretty-scroll rounded-md border border-card-border bg-surface shadow-lg py-1 text-[0.8125rem] {up
+        ? 'bottom-full mb-1'
+        : 'top-full mt-1'}"
     >
       {#each options as o (o.value)}
         <button

--- a/ui-svelte/src/routes/PlaygroundShell.svelte
+++ b/ui-svelte/src/routes/PlaygroundShell.svelte
@@ -583,7 +583,11 @@
   }
 </script>
 
-<div class="relative h-screen flex bg-chrome">
+<!-- overflow-hidden: the shell is exactly one viewport tall and every pane owns
+     its own scroller, so anything that escapes (a popover, a dropdown) is a bug
+     that would otherwise show up as document scrollbars on both axes. Tooltips
+     and modals are `fixed` off <body>, so clipping here does not reach them. -->
+<div class="relative h-screen flex bg-chrome overflow-hidden">
   <!-- Side rail: icons only at rest; expands on hover. Same width hover or with the chat list open.
        The slot reserves only the RESTING width - the rail itself is absolute inside it, so a
        hover expansion draws over the tab like a curtain instead of reflowing it. Pinning the


### PR DESCRIPTION
Fixes the scrollbars that appeared on both axes when opening a config dropdown from the image chat composer.

The settings panel is not a scroll container and the shell is exactly one viewport tall, so a `Select` list opening downward at a fixed 16rem from the bottom rows escaped to the document.

- `Select` measures on open: flips up when below is tighter than above, and clamps its height to the space its clipping ancestors actually leave
- the composer settings popover scrolls itself instead of running past the top of a short window
- `overflow-hidden` on the playground shell root as a backstop

🤖 Generated with [Claude Code](https://claude.com/claude-code)