### PR TITLE
autogen: trim ctx before the spawn guard spills a GPU layer

### DIFF
--- a/internal/autogen/liveoffload.go
+++ b/internal/autogen/liveoffload.go
@@ -179,6 +179,26 @@ func LiveOffloadArgs(s Settings, args []string, freeGB float64, freeOK bool, log
 			filepath.Base(model), res.EstVramGB, freeGB)
 	}
 
+	// Context is the cheaper currency. When the live reading falls a little short
+	// of what the baked plan assumed, the planner pays for the difference in
+	// PLACEMENT: a dense model drops a layer - its weights AND its KV to RAM,
+	// crossed on every token - to reclaim what a few thousand tokens of window
+	// would have covered. Shrink the window first and keep the baked placement if
+	// that fits. Only the argv is rewritten, so the config keeps its full window
+	// for the next spawn, when the desktop may have handed the VRAM back.
+	if res.Ngl < bakedNgl || res.NCpuMoe > bakedNcpu {
+		if _, ctxIdx := argVal(args, "-c", "--ctx-size"); ctxIdx >= 0 {
+			if ctx, trimmed, ok := trimCtxForPlacement(s, meta, in, argSlots(args), bakedNgl, bakedNcpu); ok {
+				if logf != nil {
+					logf(fmt.Sprintf("dynoffload: free=%.1fGB -> -c %d->%d instead of -ngl %d->%d (est %.1fGB)",
+						freeGB, in.Ctx, ctx, bakedNgl, res.Ngl, trimmed.EstVramGB))
+				}
+				args = rewriteCtx(args, ctxIdx, ctx)
+				in.Ctx, res = ctx, trimmed
+			}
+		}
+	}
+
 	// Admission floor. Without one, multi-resident loading always "succeeds":
 	// the sizer just pushes the new model's layers/experts to CPU until it fits
 	// whatever VRAM the already-resident models left over, and the box ends up
@@ -302,6 +322,61 @@ func rewriteOffload(args []string, nglIdx, ncIdx, newNgl, newNcpu int) []string 
 		out = append(out, "--n-cpu-moe", strconv.Itoa(newNcpu))
 	}
 	return out
+}
+
+// ctxTrimFloorFrac bounds how far the guard may shrink the launch window to buy
+// back a layer. Below ~60% of the configured window the window itself is the
+// thing the user notices (a conversation that used to fit now doesn't), and
+// spilling a layer becomes the better trade.
+const ctxTrimFloorFrac = 0.6
+
+// trimCtxForPlacement looks for the largest context <= the baked one that keeps
+// the BAKED placement under the live budget, stepping down one 4096-token block
+// per slot at a time. Returns the trimmed TOTAL -c value and its estimate.
+//
+// -c is total context (per-slot x --parallel, because --kv-unified shares one KV
+// pool), so the step is scaled by the slot count: anything else would leave slots
+// holding a non-multiple of the 4096 block the sizer rounds to, and the next
+// probe would re-round to the same place and loop without progress.
+func trimCtxForPlacement(s Settings, meta Metadata, in EstimateInput, slots, bakedNgl, bakedNcpu int) (int, EstimateResult, bool) {
+	if in.Ctx <= 0 {
+		return 0, EstimateResult{}, false
+	}
+	if slots < 1 {
+		slots = 1
+	}
+	step := 4096 * slots
+	floor := int(float64(in.Ctx) * ctxTrimFloorFrac)
+	probe := in
+	for ctx := in.Ctx - step; ctx >= step && ctx >= floor; ctx -= step {
+		probe.Ctx = ctx
+		res, err := EstimatePlan(s, meta, probe)
+		if err != nil {
+			return 0, EstimateResult{}, false
+		}
+		if res.Ngl >= bakedNgl && res.NCpuMoe <= bakedNcpu {
+			return ctx, res, true
+		}
+	}
+	return 0, EstimateResult{}, false
+}
+
+// rewriteCtx is rewriteOffload's twin for -c: copy, assign by index. The flag is
+// always present when this is called (the caller got the index from argVal), so
+// there is no append path.
+func rewriteCtx(args []string, ctxIdx, ctx int) []string {
+	out := append([]string(nil), args...)
+	out[ctxIdx] = strconv.Itoa(ctx)
+	return out
+}
+
+// argSlots is the launched --parallel value (1 when unset), i.e. how many slots
+// the total -c is divided across.
+func argSlots(args []string) int {
+	if n := atoiFlag(args, "-np", "--parallel"); n > 0 {
+		return n
+	}
+	return 1
 }
 
 // argVal returns the value following the first matching flag and the index of

--- a/internal/autogen/liveoffload.md
+++ b/internal/autogen/liveoffload.md
@@ -1,7 +1,7 @@
 # autogen — spawn-time placement guard (`liveoffload.go`)
 
-Re-derives `-ngl` / `--n-cpu-moe` from free VRAM *right now*, so a stale baked plan
-can't OOM. Generate-time math lives in [`sizing.md`](sizing.md).
+Re-derives `-ngl` / `--n-cpu-moe` (and, when that would cost a layer, `-c`) from free VRAM
+*right now*, so a stale baked plan can't OOM. Generate-time math lives in [`sizing.md`](sizing.md).
 
 ## It is a spawn-time guard, NOT a regen
 
@@ -12,6 +12,7 @@ emitted argv (`-m`/`-c`/`-ctk`/`-ctv`/`--spec-type`/`--ctx-checkpoints`/`-cms`/`
 
 - **It only ever offloads MORE** than the baked plan (raises `--n-cpu-moe` / lowers `-ngl`).
   Ample VRAM or a hand-pinned `cpuOffload` is left untouched.
+- Before it spills anything, it tries to pay in **context** instead - see below.
 - If `EstVramGB > freeGB` even at the planner's max offload it returns an error and the
   spawn is **refused** — a clean load failure, not an OOM crash.
 - **Fails open**: non-`.gguf` cmd, no `-ngl`, unreadable gguf, or no GPU telemetry all pass
@@ -31,6 +32,30 @@ after the load, with Discord/Steam/explorer/a VR runtime adding ~1.2 GB more. A 
 same config "fit reliably" one day and stuttered the next. Capping at the target makes that
 setting bind on the load path too (it used to apply only at generate time), which is what
 makes the split deterministic day to day.
+
+## Context is trimmed before a layer is spilled
+
+When the live budget lands a little under what the baked plan assumed, the sizer's own answer
+is a *placement* change: a dense model drops one layer, which sends that layer's weights **and
+its KV** to RAM to be crossed on every token, just to reclaim a few tenths of a GB. That is a
+bad trade against giving up a few thousand tokens of window: it is the `64/65 layers` case.
+
+So when the live plan is worse than the baked one, `trimCtxForPlacement` first walks `-c` down
+in whole 4096-token blocks per slot, looking for the largest window that keeps the **baked**
+placement under the live budget. If it finds one, only `-c` is rewritten (`rewriteCtx`) and the
+placement rewrite never happens; if it doesn't, the guard falls through to the old behaviour
+and spills as before.
+
+- The step is `4096 x --parallel` because `-c` is TOTAL context (`--kv-unified` shares one KV
+  pool across slots): a step that isn't a whole slot-block leaves each slot on a non-multiple of
+  the block the sizer rounds to.
+- `ctxTrimFloorFrac` (0.6) bounds the trim. Below ~60% of the configured window the *window* is
+  the thing the user notices, and spilling a layer becomes the better trade again.
+- The trim runs **before** the `minGpuFraction` refusal, so trimming can also rescue a load that
+  would otherwise be refused outright.
+- Only the argv is rewritten. The config keeps its full window, so the next spawn gets it back
+  when the desktop hands the VRAM back: the launched context now varies per spawn the same way
+  `-ngl` already did.
 
 ## Drafters and vision twins are charged
 

--- a/internal/autogen/liveoffload_test.go
+++ b/internal/autogen/liveoffload_test.go
@@ -143,3 +143,84 @@ func TestLiveOffload_BudgetCap(t *testing.T) {
 		t.Fatalf("unset target: got %v want 12.0", got)
 	}
 }
+
+// The whole point of the ctx trim: when the live budget lands a hair under what
+// the baked plan assumed, the sizer's answer is to spill a layer (a dense
+// model's weights AND its KV to RAM, crossed every token) to buy back a few
+// tenths of a GB. Giving up a block of context buys the same VRAM and costs
+// only window, so trimCtxForPlacement has to find a smaller ctx that keeps the
+// baked placement rather than letting the placement rewrite happen.
+func TestLiveOffload_TrimCtxKeepsBakedPlacement(t *testing.T) {
+	meta := Metadata{
+		Architecture: "llama", BlockCount: 32,
+		HeadCountKv: 8, KeyLength: 128, ValueLength: 128,
+		ContextLength: 131072, EmbeddingLength: 4096,
+		FileSizeGB: 12,
+	}
+	s := Settings{
+		TargetVramGB: 24, VramOverheadGB: 0.5, MaxRamGB: 64,
+		DenseCtxLadder: []int{131072, 65536, 32768}, DenseMinCtx: 4096,
+	}
+	in := EstimateInput{Ctx: 32768, KvK: "q8_0", KvV: "q8_0", TargetVramGB: 24}
+
+	baked, err := EstimatePlan(s, meta, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baked.Ngl < int(meta.BlockCount) {
+		t.Fatalf("setup: expected a whole-model fit at 24GB, got ngl=%d", baked.Ngl)
+	}
+
+	// Walk the budget down until the sizer first gives up a layer. That is the
+	// "64/65" the user reported, reproduced without guessing a magic number.
+	var short EstimateResult
+	tight := in
+	for b := 23.9; b > 12; b -= 0.1 {
+		tight.TargetVramGB = b
+		short, err = EstimatePlan(s, meta, tight)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if short.Ngl < baked.Ngl {
+			break
+		}
+	}
+	if short.Ngl >= baked.Ngl {
+		t.Fatalf("setup: never lost a layer down to 12GB (ngl=%d)", short.Ngl)
+	}
+
+	ctx, trimmed, ok := trimCtxForPlacement(s, meta, tight, 1, baked.Ngl, baked.NCpuMoe)
+	if !ok {
+		t.Fatalf("no trim found at %.1fGB (ngl would drop %d->%d)", tight.TargetVramGB, baked.Ngl, short.Ngl)
+	}
+	if ctx >= in.Ctx || ctx%4096 != 0 {
+		t.Fatalf("trimmed ctx = %d, want a smaller multiple of 4096", ctx)
+	}
+	if ctx < int(float64(in.Ctx)*ctxTrimFloorFrac) {
+		t.Fatalf("trimmed ctx %d is below the %.0f%% floor", ctx, ctxTrimFloorFrac*100)
+	}
+	if trimmed.Ngl < baked.Ngl || trimmed.NCpuMoe > baked.NCpuMoe {
+		t.Fatalf("trim did not restore the baked placement: ngl=%d ncpumoe=%d", trimmed.Ngl, trimmed.NCpuMoe)
+	}
+}
+
+// The step is per-slot: with --parallel 4 the total -c has to move in 4x4096
+// blocks, or each slot ends up holding a non-multiple of the sizer's block.
+func TestLiveOffload_TrimStepsWholeSlots(t *testing.T) {
+	if got := argSlots([]string{"-m", "x.gguf", "-np", "4"}); got != 4 {
+		t.Fatalf("slots = %d want 4", got)
+	}
+	if got := argSlots([]string{"-m", "x.gguf"}); got != 1 {
+		t.Fatalf("slots default = %d want 1", got)
+	}
+
+	args := []string{"-m", "x.gguf", "-c", "32768", "-ngl", "99"}
+	_, idx := argVal(args, "-c", "--ctx-size")
+	out := rewriteCtx(args, idx, 24576)
+	if !reflect.DeepEqual(out, []string{"-m", "x.gguf", "-c", "24576", "-ngl", "99"}) {
+		t.Fatalf("rewriteCtx: %v", out)
+	}
+	if args[3] != "32768" {
+		t.Fatalf("rewriteCtx mutated its input: %v", args)
+	}
+}


### PR DESCRIPTION
When the live free-VRAM reading lands a little under what the baked plan assumed, the spawn-time guard paid for the shortfall in placement: a dense model dropped one layer, sending that layer's weights and its KV to RAM to be crossed on every token, to reclaim a few tenths of a GB. That is the "64/65 gpu layers" case, and a bad trade against a few thousand tokens of window.

LiveOffloadArgs now tries the cheaper currency first: when the live plan is worse than the baked one, trimCtxForPlacement walks -c down in whole 4096-token blocks per slot and takes the largest window that keeps the baked placement under the live budget, falling through to the old placement rewrite only if none fits.

- trimCtxForPlacement + rewriteCtx + argSlots in liveoffload.go
- step is 4096 x --parallel, since -c is total context under --kv-unified
- ctxTrimFloorFrac (0.6) stops the trim before the window is what hurts
- runs before the minGpuFraction refusal, so a trim can rescue that load
- only the argv is rewritten: the config keeps its full window