### PR TITLE
config editor: variant "none" inheritance, explicit mmproj path, launch-box round-trip fixes

### DIFF
--- a/internal/autogen/CLAUDE.md
+++ b/internal/autogen/CLAUDE.md
@@ -87,7 +87,8 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
   flag, so all three price the same launch. `Override.Mmproj` pins the decision per model —
   `gpu` / `ram` skip the dual sizing, `none` emits no twin at all (unlike an unlisted twin,
   which still builds). Surfaced as the "Image projector" dropdown on the model config modal's
-  Default tab, shown only when the model has a projector. `VariantSpec.Mmproj` repeats the knob
+  Default tab, shown only when the model resolves to a projector at all (discovered, or named
+  by `mmprojFile` below). `VariantSpec.Mmproj` repeats the knob
   on the reserved `vision` variant and OUTRANKS the model-wide pin there (blank = inherit); it
   is deliberately absent from every other variant tab, because no other variant's profile loads
   a projector at all. Careful: an image-class model routes through `emitImageModel` before the
@@ -180,6 +181,20 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
   a donation** — the donor's model and the recipient must also agree on arch, embedding length,
   block count and vocab size (`sidecarCompatible`). That gate is not cosmetic: a drafter whose
   vocab differs doesn't degrade, it aborts the launch (`tensor 'output.weight' has wrong shape`).
+- **`Override.MmprojFile` names a projector outright, and CREATES the twin.** Discovery only
+  ever sees a projector in the model's own folder or in a family sibling's, so one shared
+  mmproj kept in a folder of its own is invisible: no twin, no explanation, and hand-typing
+  `--mmproj` into the launch box is swallowed by `IGNORE_VALUE` (`modelCmdForm.ts`) on purpose.
+  `mmprojFile` (model-wide, or on the reserved `vision` variant with the usual sentinel) is
+  resolved by `mmprojFor` (`family.go`) and beats discovery entirely; `mmproj: none` still
+  wins over it, since placement is checked past the twin gate. The path is `os.Stat`'d there
+  rather than read off `GgufRow.MmprojSizeGB` — that size describes DISCOVERY's file, and
+  pricing an override's projector at another file's size is how a twin ends up sized against
+  VRAM it will not have. **Automatic pairing is deliberately NOT widened to match**: a
+  projector is bound to one vision tower, so an auto-paired unrelated one would load clean and
+  then hallucinate on every image. `mmprojFileErr` (`configapi.go`) is the safety net that
+  replaces it — save rejects a path that is missing, a directory, or whose gguf header is not
+  `architecture == "clip"`, the same rule `MmprojSidecarForDir` pairs by.
   Consequences to keep in mind: a model that never had a `-vision` twin can grow one, `-md`
   appears where no drafter is visible in the folder, and anything summing `DraftSizeGB` across
   rows must dedupe on `DraftPath` (one file, many rows — `internal/setup/probe.go`). Per-model

--- a/internal/autogen/CLAUDE.md
+++ b/internal/autogen/CLAUDE.md
@@ -270,6 +270,25 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
   download and wire up; shipping a curated replacement for one vendor's family played
   favourites and silently dropped whatever the baked template supported that the replacement
   did not (Qwen 3.8's reasoning-effort ladder, for one).
+- **A variant can drop an inherited template with `chatTemplateFile: none`.** Empty means
+  "inherit the model-wide value" on every free-form string a variant carries, which left no
+  way to say "this profile runs on the gguf's baked-in template". `inherit.go` gives the off
+  state a name (`NoneSentinel`, matching the `mmproj: none` vocabulary) and owns the whole
+  rule: `inheritStr` at merge, `NormalizeNone` on every door an `Override` comes in
+  through so a sentinel written at MODEL level can never reach the emitter as a literal
+  path. **Both doors, not just the config file:** `LoadGenerateFile` covers the file, and
+  `applyOverrideDTO` covers the editor — `handleAPIModelCmdPreview` renders the
+  launch-command box straight from that DTO without ever reading the config, so a sentinel
+  left unresolved there shows `--chat-template-file "none"` and the preview silently
+  disagrees with what saving produces. Never normalize a `VariantSpec`; there the sentinel
+  is the point. It covers the free-form/path knobs
+  only — `chatTemplateFile`, `extraArgs`, `tensorSplit`, `overrideTensor`, `kvKDraft`/
+  `kvVDraft`, and the sd-server component paths. The enums are deliberately excluded: they
+  already spell out their own off state (`flashAttn: off`, `mmproj: none`, `ropeScaling:
+  none`), and a second spelling would be ambiguous. `ModelConfigModal.svelte` keeps hand-kept
+  twins (`inheritStr`/`deltaStr`) so the previewed command matches what the generator emits,
+  and so deleting a flag from a variant's launch box saves as `none` rather than silently
+  inheriting it straight back.
 - **`scanChatTemplate` still reads the baked template**, but only for the effort ladder.
   `ReadGgufMetadata` decodes `tokenizer.chat_template` and derives `ChatTemplateEffortLevels`
   (plus `ChatTemplatePreservesThinking`, which nothing consumes today) — the flag and the level

--- a/internal/autogen/cmshoist_test.go
+++ b/internal/autogen/cmshoist_test.go
@@ -1,0 +1,32 @@
+package autogen
+
+import "testing"
+
+// -cms is emitted on every text model, and extraArgs is appended verbatim after
+// it, so a copy that slipped into extraArgs (the launch-box editor used to not
+// parse the flag) came out on the line twice, gaining one more per round trip.
+// The emitter hoists it back out and honours it as the pin it was meant to be.
+func TestAutogen_hoistCmsFromExtra(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		wantExtra string
+		wantStep  int
+	}{
+		{"nothing to hoist", "--foo bar", "--foo bar", 0},
+		{"empty", "", "", 0},
+		{"alone", "-cms 256", "", 256},
+		{"between other args", "--foo bar -cms 256 --baz", "--foo bar --baz", 256},
+		{"long alias", "--checkpoint-min-step 512 --foo", "--foo", 512},
+		{"several copies keep the first", "-cms 256 --foo -cms 512", "--foo", 256},
+		{"dangling flag is dropped", "--foo -cms", "--foo", 0},
+		{"non-numeric value is dropped, not pinned", "-cms abc --foo", "--foo", 0},
+		{"a longer flag ending in cms is left alone", "--not-cms 256", "--not-cms 256", 0},
+	}
+	for _, tc := range tests {
+		extra, step := hoistCmsFromExtra(tc.in)
+		if extra != tc.wantExtra || step != tc.wantStep {
+			t.Errorf("%s: got %q/%d, want %q/%d", tc.name, extra, step, tc.wantExtra, tc.wantStep)
+		}
+	}
+}

--- a/internal/autogen/family.go
+++ b/internal/autogen/family.go
@@ -364,6 +364,27 @@ func MmprojSidecarForDir(dir string) (path string, sizeGB float64) {
 	return "", 0
 }
 
+// mmprojFor resolves which projector a model's "-vision" twin loads and how big
+// it is: the explicit mmprojFile override when it names one, else whatever
+// discovery paired (dir-local, or inherited from a family sibling).
+//
+// The size cannot come from the row: GgufRow.MmprojSizeGB describes discovery's
+// file, and pricing an override's projector at another file's size is how a twin
+// ends up sized against 0.5 GB of VRAM it will not have. So an explicit path is
+// stat'd. A path that does not exist yields 0 and is left to save-time
+// validation (configapi) rather than dropped here, which would silently emit no
+// twin for a path the user can see in the editor.
+func mmprojFor(row GgufRow, mmprojFile string) (path string, sizeGB float64) {
+	p := strings.TrimSpace(mmprojFile)
+	if p == "" {
+		return row.MmprojPath, row.MmprojSizeGB
+	}
+	if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+		return p, round(float64(fi.Size())/gib, 2)
+	}
+	return p, 0
+}
+
 // MmprojSidecarFor is DraftSidecarFor for the vision projector: the one in the
 // model's own dir, else the one inherited from a family sibling. It answers what
 // the "-vision" twin actually loads, which is not something the model's folder

--- a/internal/autogen/generate.go
+++ b/internal/autogen/generate.go
@@ -573,12 +573,10 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 			if v.Parallel > 0 {
 				effOv.Parallel = v.Parallel
 			}
-			if strings.TrimSpace(v.ExtraArgs) != "" {
-				effOv.ExtraArgs = v.ExtraArgs
-			}
-			if strings.TrimSpace(v.ChatTemplateFile) != "" {
-				effOv.ChatTemplateFile = v.ChatTemplateFile
-			}
+			// Free-form string knobs (chat template, extra args, tensor
+			// placement, draft KV) resolve through the shared sentinel rule:
+			// empty inherits, "none" forces the knob off. See inherit.go.
+			mergeInheritStrings(&effOv, v)
 			// Sampler / speculative sub-knobs: non-zero/non-nil variant value wins.
 			if v.Dry != nil {
 				effOv.Dry = v.Dry
@@ -640,12 +638,6 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 			if v.NoRepack {
 				effOv.NoRepack = true
 			}
-			if v.KvKDraft != "" {
-				effOv.KvKDraft = v.KvKDraft
-			}
-			if v.KvVDraft != "" {
-				effOv.KvVDraft = v.KvVDraft
-			}
 			if v.CacheReuse != 0 {
 				effOv.CacheReuse = v.CacheReuse
 			}
@@ -685,14 +677,8 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 			if v.SplitMode != "" {
 				effOv.SplitMode = v.SplitMode
 			}
-			if v.TensorSplit != "" {
-				effOv.TensorSplit = v.TensorSplit
-			}
 			if v.MainGpu != 0 {
 				effOv.MainGpu = v.MainGpu
-			}
-			if v.OverrideTensor != "" {
-				effOv.OverrideTensor = v.OverrideTensor
 			}
 		}
 		emitProfile(b, s, meta, row, prof, ctx, ngl, ncpuMoe, plan, ekvK, ekvV, pkvInRam, &effOv)

--- a/internal/autogen/generate.go
+++ b/internal/autogen/generate.go
@@ -375,8 +375,18 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 	// "none" drops the twin outright: a projector the user does not want wired
 	// (a family-inherited one they judge wrong for this finetune, or vision they
 	// simply never use) should cost no served id at all.
-	if row.MmprojPath != "" && !strings.EqualFold(override.Mmproj, "none") {
-		mmprojOh := MmprojVramGB(row.MmprojPath, row.MmprojSizeGB, s)
+	// The projector is whatever the override names, falling back to discovery.
+	// An explicit path is also what CREATES the twin: a model that paired with
+	// nothing has no twin at all today, and that is the whole point of the field
+	// (one shared mmproj in its own folder, pointed at by several models).
+	// The reserved "vision" variant may name its own, with the usual sentinel.
+	mmprojFile := override.MmprojFile
+	if v := visionSpec; v != nil {
+		mmprojFile = inheritStr(v.MmprojFile, mmprojFile)
+	}
+	mmprojPath, mmprojSizeGB := mmprojFor(row, mmprojFile)
+	if mmprojPath != "" && !strings.EqualFold(override.Mmproj, "none") {
+		mmprojOh := MmprojVramGB(mmprojPath, mmprojSizeGB, s)
 		vp := profile{
 			Name:              fmt.Sprintf("%s-vision", name),
 			Target:            soloTarget,

--- a/internal/autogen/generate_cmd.go
+++ b/internal/autogen/generate_cmd.go
@@ -342,8 +342,16 @@ func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ng
 	// Vision twin loads the projector for image input. --no-mmproj-offload keeps
 	// the CLIP tower on the CPU: no VRAM for the projector (the sizer already
 	// priced the twin that way), slower image encode, same token throughput.
-	if prof.Vision && row.MmprojPath != "" {
-		lines = append(lines, fmt.Sprintf("--mmproj %s", strings.ReplaceAll(row.MmprojPath, "\\", "/")))
+	// ov is the EFFECTIVE override here (model-wide with the vision variant's
+	// knobs merged in), so an explicit mmprojFile - from either level - is
+	// already resolved by the time the argv is rendered.
+	mmprojFileOv := ""
+	if ov != nil {
+		mmprojFileOv = ov.MmprojFile
+	}
+	mmprojPath, _ := mmprojFor(row, mmprojFileOv)
+	if prof.Vision && mmprojPath != "" {
+		lines = append(lines, fmt.Sprintf("--mmproj %s", strings.ReplaceAll(mmprojPath, "\\", "/")))
 		if prof.CpuMmproj {
 			lines = append(lines, "--no-mmproj-offload")
 		}

--- a/internal/autogen/generate_cmd.go
+++ b/internal/autogen/generate_cmd.go
@@ -7,6 +7,7 @@ package autogen
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -244,6 +245,17 @@ func effectiveUb(meta Metadata, prof profile, ov *Override, ctx int, budgetGB fl
 // block) and RenderSoloCmd (which joins them for the editor preview). Any
 // Override.ExtraArgs are appended verbatim as a final line.
 func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ngl, ncpuMoe int, kvK, kvV string, kvInRam bool, ov *Override) []string {
+	// extraArgs is appended verbatim at the end, so anything in it that we also
+	// emit ourselves lands on the line TWICE. -cms is the one that actually
+	// happened: the launch-box editor did not parse it, so it survived a round
+	// trip into extraArgs, and every later trip appended one more copy. Hoist it
+	// back out here and treat it as the pin it was meant to be, so a config
+	// written by an older UI self-heals on the next generate.
+	extraArgs, extraCms := "", 0
+	if ov != nil {
+		extraArgs, extraCms = hoistCmsFromExtra(ov.ExtraArgs)
+	}
+
 	cpuMoeFlag := ""
 	if ncpuMoe > 0 {
 		cpuMoeFlag = fmt.Sprintf(" --n-cpu-moe %d", ncpuMoe)
@@ -452,6 +464,9 @@ func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ng
 		if stepProf.CheckpointMinStep == 0 && ov != nil {
 			stepProf.CheckpointMinStep = ov.CheckpointMinStep
 		}
+		if stepProf.CheckpointMinStep == 0 {
+			stepProf.CheckpointMinStep = extraCms
+		}
 		lines = append(lines, fmt.Sprintf("-cms %d", effectiveCheckpointMinStep(stepProf, ckptConstGB, ckptRecurrent)))
 	}
 	// DRY sampler: defaults to settings.DryDefault (nil => off) and a per-model
@@ -571,12 +586,38 @@ func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ng
 			lines = append(lines, fmt.Sprintf("-ot %s", ov.OverrideTensor))
 		}
 	}
-	if ov != nil {
-		if extra := strings.TrimSpace(ov.ExtraArgs); extra != "" {
-			lines = append(lines, extra)
-		}
+	if extra := strings.TrimSpace(extraArgs); extra != "" {
+		lines = append(lines, extra)
 	}
 	return lines
+}
+
+// hoistCmsFromExtra splits a `-cms <n>` (or its `--checkpoint-min-step` alias)
+// out of a free-form extraArgs string, returning the rest and the value (0 when
+// absent). Only the FIRST is hoisted as a value; any further copies are dropped,
+// since a stale config can hold several and llama-server would just take the
+// last. Matched on whitespace boundaries so `--not-cms 256` is left alone.
+func hoistCmsFromExtra(extra string) (string, int) {
+	if !strings.Contains(extra, "cms") && !strings.Contains(extra, "checkpoint-min-step") {
+		return extra, 0
+	}
+	f := strings.Fields(extra)
+	out := make([]string, 0, len(f))
+	step := 0
+	for i := 0; i < len(f); i++ {
+		if f[i] != "-cms" && f[i] != "--checkpoint-min-step" {
+			out = append(out, f[i])
+			continue
+		}
+		if i+1 >= len(f) {
+			continue // dangling flag: drop it, we emit our own
+		}
+		if n, err := strconv.Atoi(f[i+1]); err == nil && step == 0 {
+			step = n
+		}
+		i++
+	}
+	return strings.Join(out, " "), step
 }
 
 // RenderSoloCmd previews the full launch command for a candidate override,

--- a/internal/autogen/hash.go
+++ b/internal/autogen/hash.go
@@ -165,7 +165,12 @@ const hashCacheSuffix = ".modelhash"
 //	     deliberately not widened (a projector belongs to one vision tower), but
 //	     a shared projector kept in a folder of its own is now reachable, so a
 //	     config can gain a twin and an --mmproj it did not have.
-const genVersion = "v60"
+//	v61: -cms is hoisted back out of extraArgs. The launch-box editor did not
+//	     parse the flag, so an edit round trip pushed it into extraArgs, where it
+//	     was appended AFTER the computed copy (and grew by one per trip). Any
+//	     config carrying one now emits a single -cms, and the hoisted value acts
+//	     as the pin it was meant to be.
+const genVersion = "v61"
 
 // InputsHash digests everything that can change the generated config: the set of
 // gguf files under modelsRoot (path + size + mtime) plus the raw bytes of the

--- a/internal/autogen/hash.go
+++ b/internal/autogen/hash.go
@@ -159,7 +159,13 @@ const hashCacheSuffix = ".modelhash"
 //	     sidecar) is migrated onto the new one. Every dense model trained past
 //	     128k gets a larger -c and a larger KV reserve, so the emitted argv and
 //	     the estimates change for inputs that did not.
-const genVersion = "v59"
+//	v60: a model can name its vision projector explicitly (mmprojFile), which
+//	     overrides discovery AND creates a "-vision" twin for a model whose
+//	     own folder (and whose family) ships no mmproj at all. Auto-pairing is
+//	     deliberately not widened (a projector belongs to one vision tower), but
+//	     a shared projector kept in a folder of its own is now reachable, so a
+//	     config can gain a twin and an --mmproj it did not have.
+const genVersion = "v60"
 
 // InputsHash digests everything that can change the generated config: the set of
 // gguf files under modelsRoot (path + size + mtime) plus the raw bytes of the

--- a/internal/autogen/image.go
+++ b/internal/autogen/image.go
@@ -504,32 +504,14 @@ func mergeImageVariant(base Override, v VariantSpec) Override {
 	o := base
 	o.Variants = nil
 	o.Unlisted = v.Unlisted
-	if v.VaePath != "" {
-		o.VaePath = v.VaePath
-	}
-	if v.ClipLPath != "" {
-		o.ClipLPath = v.ClipLPath
-	}
-	if v.ClipGPath != "" {
-		o.ClipGPath = v.ClipGPath
-	}
-	if v.T5Path != "" {
-		o.T5Path = v.T5Path
-	}
-	if v.TextEncoderPath != "" {
-		o.TextEncoderPath = v.TextEncoderPath
-	}
+	// Component paths resolve through the shared sentinel rule: empty inherits
+	// the model-wide path, "none" drops the encoder for this preset only.
+	mergeInheritImageStrings(&o, &v)
 	if v.RefEdit != "" {
 		o.RefEdit = v.RefEdit
 	}
 	if v.LlmVision != "" {
 		o.LlmVision = v.LlmVision
-	}
-	if v.LlmVisionPath != "" {
-		o.LlmVisionPath = v.LlmVisionPath
-	}
-	if v.LoraDir != "" {
-		o.LoraDir = v.LoraDir
 	}
 	if v.OffloadToCpu != "" {
 		o.OffloadToCpu = v.OffloadToCpu

--- a/internal/autogen/inherit.go
+++ b/internal/autogen/inherit.go
@@ -1,0 +1,108 @@
+package autogen
+
+import "strings"
+
+// NoneSentinel is the value a variant writes on an inheriting free-form string
+// knob to mean "explicitly nothing" rather than "inherit the model-wide value".
+//
+// Every free-form string on VariantSpec uses empty => inherit, which leaves a
+// variant no way to express "the model pins a chat template, this profile wants
+// the gguf's baked-in one". The field carries three states through two, and the
+// third one was simply unreachable. Rather than widen each field to *string
+// (the PreserveThinking treatment - correct, but it moves the yaml round-trip,
+// both DTO directions and every `||` coalesce in the editor), the off state gets
+// a name, matching the vocabulary Mmproj already uses ("gpu"/"ram"/"none").
+//
+// Only free-form and path knobs take the sentinel. The enum knobs already spell
+// out their own off state (flashAttn "off", mmap "off", mmproj "none",
+// ropeScaling "none", contextShift "off"), and giving those a second spelling
+// would be ambiguous, not consistent.
+//
+// A literal file named "none" is thus unreachable as a bare value; write it as
+// "./none" or an absolute path.
+const NoneSentinel = "none"
+
+// isNone reports whether s is the "explicitly nothing" sentinel. Case- and
+// space-insensitive: it is typed by hand into a text box.
+func isNone(s string) bool {
+	return strings.EqualFold(strings.TrimSpace(s), NoneSentinel)
+}
+
+// inheritStr resolves one inheriting free-form string: empty inherits the
+// model-wide value, the sentinel forces the knob off, anything else pins.
+func inheritStr(variant, model string) string {
+	switch v := strings.TrimSpace(variant); {
+	case v == "":
+		return model
+	case isNone(v):
+		return ""
+	default:
+		return variant
+	}
+}
+
+// clearNone maps a model-wide sentinel to empty. At model level empty ALREADY
+// means "no flag", so "none" there is redundant - but a user who learned the
+// word on a variant will write it on the model too, and left alone it would be
+// emitted as a literal path.
+func clearNone(s string) string {
+	if isNone(s) {
+		return ""
+	}
+	return s
+}
+
+// mergeInheritStrings layers a variant's free-form string knobs over the
+// effective override, honouring the sentinel. It is the single place that
+// decides which knobs are sentinel-aware; the enum knobs stay in the plain
+// non-empty-wins chain in buildProfiles.
+func mergeInheritStrings(eff *Override, v *VariantSpec) {
+	eff.ChatTemplateFile = inheritStr(v.ChatTemplateFile, eff.ChatTemplateFile)
+	eff.ExtraArgs = inheritStr(v.ExtraArgs, eff.ExtraArgs)
+	eff.TensorSplit = inheritStr(v.TensorSplit, eff.TensorSplit)
+	eff.OverrideTensor = inheritStr(v.OverrideTensor, eff.OverrideTensor)
+	eff.KvKDraft = inheritStr(v.KvKDraft, eff.KvKDraft)
+	eff.KvVDraft = inheritStr(v.KvVDraft, eff.KvVDraft)
+}
+
+// mergeInheritImageStrings is mergeInheritStrings for the sd-server component
+// paths, which merge in mergeImageVariant rather than the llama chain. Dropping
+// an inherited encoder ("this preset runs without the external T5") was
+// unreachable for the same reason.
+func mergeInheritImageStrings(o *Override, v *VariantSpec) {
+	o.VaePath = inheritStr(v.VaePath, o.VaePath)
+	o.ClipLPath = inheritStr(v.ClipLPath, o.ClipLPath)
+	o.ClipGPath = inheritStr(v.ClipGPath, o.ClipGPath)
+	o.T5Path = inheritStr(v.T5Path, o.T5Path)
+	o.TextEncoderPath = inheritStr(v.TextEncoderPath, o.TextEncoderPath)
+	o.LlmVisionPath = inheritStr(v.LlmVisionPath, o.LlmVisionPath)
+	o.LoraDir = inheritStr(v.LoraDir, o.LoraDir)
+}
+
+// NormalizeNone clears a sentinel written at MODEL level on every knob
+// mergeInheritStrings / mergeInheritImageStrings cover. At model level empty
+// already means "no flag", so the two are equivalent and resolving early keeps
+// every consumer honest.
+//
+// It must run on every door an Override comes in through, not just the config
+// file: the launch-command preview builds one straight from the editor's DTO
+// and renders it without ever touching LoadGenerateFile, so a sentinel left
+// unresolved there renders as --chat-template-file "none" and the box silently
+// disagrees with what a save would produce.
+//
+// Never call it on a VariantSpec. There the sentinel is the whole point.
+func NormalizeNone(o *Override) {
+	o.ChatTemplateFile = clearNone(o.ChatTemplateFile)
+	o.ExtraArgs = clearNone(o.ExtraArgs)
+	o.TensorSplit = clearNone(o.TensorSplit)
+	o.OverrideTensor = clearNone(o.OverrideTensor)
+	o.KvKDraft = clearNone(o.KvKDraft)
+	o.KvVDraft = clearNone(o.KvVDraft)
+	o.VaePath = clearNone(o.VaePath)
+	o.ClipLPath = clearNone(o.ClipLPath)
+	o.ClipGPath = clearNone(o.ClipGPath)
+	o.T5Path = clearNone(o.T5Path)
+	o.TextEncoderPath = clearNone(o.TextEncoderPath)
+	o.LlmVisionPath = clearNone(o.LlmVisionPath)
+	o.LoraDir = clearNone(o.LoraDir)
+}

--- a/internal/autogen/inherit.go
+++ b/internal/autogen/inherit.go
@@ -58,6 +58,7 @@ func clearNone(s string) string {
 // non-empty-wins chain in buildProfiles.
 func mergeInheritStrings(eff *Override, v *VariantSpec) {
 	eff.ChatTemplateFile = inheritStr(v.ChatTemplateFile, eff.ChatTemplateFile)
+	eff.MmprojFile = inheritStr(v.MmprojFile, eff.MmprojFile)
 	eff.ExtraArgs = inheritStr(v.ExtraArgs, eff.ExtraArgs)
 	eff.TensorSplit = inheritStr(v.TensorSplit, eff.TensorSplit)
 	eff.OverrideTensor = inheritStr(v.OverrideTensor, eff.OverrideTensor)
@@ -93,6 +94,7 @@ func mergeInheritImageStrings(o *Override, v *VariantSpec) {
 // Never call it on a VariantSpec. There the sentinel is the whole point.
 func NormalizeNone(o *Override) {
 	o.ChatTemplateFile = clearNone(o.ChatTemplateFile)
+	o.MmprojFile = clearNone(o.MmprojFile)
 	o.ExtraArgs = clearNone(o.ExtraArgs)
 	o.TensorSplit = clearNone(o.TensorSplit)
 	o.OverrideTensor = clearNone(o.OverrideTensor)

--- a/internal/autogen/inherit_test.go
+++ b/internal/autogen/inherit_test.go
@@ -1,0 +1,93 @@
+package autogen
+
+import (
+	"strings"
+	"testing"
+)
+
+// The sentinel exists because "" already means inherit, so a variant had no way
+// to say "drop the knob the model-wide override sets". Each case is one of the
+// three states the field now carries.
+func TestInheritStr(t *testing.T) {
+	for _, c := range []struct {
+		name    string
+		variant string
+		model   string
+		want    string
+	}{
+		{"blank inherits", "", "C:/t/model.jinja", "C:/t/model.jinja"},
+		{"blank inherits nothing", "", "", ""},
+		{"value pins", "C:/t/var.jinja", "C:/t/model.jinja", "C:/t/var.jinja"},
+		{"none drops the inherited value", "none", "C:/t/model.jinja", ""},
+		{"none is case-insensitive", "None", "C:/t/model.jinja", ""},
+		{"none tolerates padding", "  none  ", "C:/t/model.jinja", ""},
+		{"none with nothing to drop", "none", "", ""},
+		{"a path merely containing none still pins", "C:/none/x.jinja", "C:/t/m.jinja", "C:/none/x.jinja"},
+	} {
+		if got := inheritStr(c.variant, c.model); got != c.want {
+			t.Errorf("%s: inheritStr(%q, %q) = %q, want %q", c.name, c.variant, c.model, got, c.want)
+		}
+	}
+}
+
+// A sentinel written at model level would otherwise reach the emitter as a
+// literal path, so it is cleared once at load.
+func TestNormalizeNone(t *testing.T) {
+	o := Override{
+		ChatTemplateFile: "none", ExtraArgs: "NONE", TensorSplit: "none",
+		OverrideTensor: "3,1", VaePath: "none", T5Path: "D:/t5.gguf",
+	}
+	NormalizeNone(&o)
+	for name, got := range map[string]string{
+		"ChatTemplateFile": o.ChatTemplateFile, "ExtraArgs": o.ExtraArgs,
+		"TensorSplit": o.TensorSplit, "VaePath": o.VaePath,
+	} {
+		if got != "" {
+			t.Errorf("%s = %q, want cleared", name, got)
+		}
+	}
+	if o.OverrideTensor != "3,1" || o.T5Path != "D:/t5.gguf" {
+		t.Errorf("real values must survive: %q / %q", o.OverrideTensor, o.T5Path)
+	}
+}
+
+// The whole point, end to end: a variant of a model that pins a chat template
+// can run on the gguf's baked-in one.
+func TestBuildCmdLines_VariantDropsInheritedChatTemplate(t *testing.T) {
+	model := Override{ChatTemplateFile: "C:/my/tmpl.jinja", ExtraArgs: "--verbose"}
+
+	for _, c := range []struct {
+		name         string
+		variant      VariantSpec
+		wantTemplate string // "" => the flag must be absent
+		wantArgs     string
+	}{
+		{"untouched variant inherits", VariantSpec{Name: "v"}, "C:/my/tmpl.jinja", "--verbose"},
+		{"variant pins its own", VariantSpec{Name: "v", ChatTemplateFile: "C:/other.jinja"}, "C:/other.jinja", "--verbose"},
+		{"none drops it", VariantSpec{Name: "v", ChatTemplateFile: "none"}, "", "--verbose"},
+		{"none drops extra args independently", VariantSpec{Name: "v", ExtraArgs: "none"}, "C:/my/tmpl.jinja", ""},
+	} {
+		eff := model
+		v := c.variant
+		mergeInheritStrings(&eff, &v)
+
+		if eff.ChatTemplateFile != c.wantTemplate {
+			t.Errorf("%s: template = %q, want %q", c.name, eff.ChatTemplateFile, c.wantTemplate)
+		}
+		if eff.ExtraArgs != c.wantArgs {
+			t.Errorf("%s: extraArgs = %q, want %q", c.name, eff.ExtraArgs, c.wantArgs)
+		}
+
+		s := Settings{}
+		s.applyDefaults()
+		prof := profile{Name: "t", Ctx: 8192}
+		got := strings.Join(buildCmdLines(s, Metadata{Architecture: "qwen35moe"}, GgufRow{FullPath: "/m.gguf"}, prof, 8192, 99, 0, "q8_0", "q8_0", false, &eff), " ")
+		if c.wantTemplate == "" {
+			if strings.Contains(got, "--chat-template-file") {
+				t.Errorf("%s: flag must be absent, got:\n%s", c.name, got)
+			}
+		} else if !strings.Contains(got, `--chat-template-file "`+c.wantTemplate+`"`) {
+			t.Errorf("%s: want %s in:\n%s", c.name, c.wantTemplate, got)
+		}
+	}
+}

--- a/internal/autogen/mmprojfile_test.go
+++ b/internal/autogen/mmprojfile_test.go
@@ -1,0 +1,207 @@
+package autogen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mmprojFor is the one place that decides WHICH projector the vision twin
+// loads, and at what size it gets priced. The size is the subtle half: it can
+// never come from the row (that describes discovery's file), or an override
+// pointing at a 2 GB projector gets budgeted against a 0.5 GB sibling.
+func TestAutogen_mmprojFor(t *testing.T) {
+	dir := t.TempDir()
+	explicit := filepath.Join(dir, "shared-mmproj-f16.gguf")
+	// Sizes round to 2 decimals of a GB (same as discovery's), so the fixture has
+	// to be big enough to survive that: 64 MiB = 0.06 GB.
+	f, err := os.Create(explicit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(64 << 20); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	row := GgufRow{MmprojPath: "C:/models/dir-local-mmproj.gguf", MmprojSizeGB: 7}
+
+	if p, sz := mmprojFor(row, ""); p != row.MmprojPath || sz != row.MmprojSizeGB {
+		t.Errorf("empty override: got %q/%.2f, want discovery's %q/%.2f", p, sz, row.MmprojPath, row.MmprojSizeGB)
+	}
+	if p, sz := mmprojFor(row, "  "); p != row.MmprojPath || sz != row.MmprojSizeGB {
+		t.Errorf("blank override: got %q/%.2f, want discovery's values", p, sz)
+	}
+	p, sz := mmprojFor(row, explicit)
+	if p != explicit {
+		t.Errorf("explicit path: got %q, want %q", p, explicit)
+	}
+	if sz != 0.06 {
+		t.Errorf("explicit path size: got %.2f GB, want the stat'd 0.06 (never the row's %.2f)", sz, row.MmprojSizeGB)
+	}
+	// A path that does not exist is passed through with size 0 rather than
+	// dropped: save-time validation owns that message, and silently emitting no
+	// twin for a path the user can see in the editor is the worse failure.
+	if p, sz := mmprojFor(row, filepath.Join(dir, "gone.gguf")); p == row.MmprojPath || sz != 0 {
+		t.Errorf("missing path: got %q/%.2f, want the override path at size 0", p, sz)
+	}
+	// A directory is not a file: same treatment as missing.
+	if _, sz := mmprojFor(row, dir); sz != 0 {
+		t.Errorf("directory: got size %.2f, want 0", sz)
+	}
+}
+
+// The variant-level field is sentinel-aware exactly like ChatTemplateFile:
+// empty inherits the model-wide path, "none" forces the twin back onto
+// discovery, anything else pins.
+func TestAutogen_MmprojFileVariantInherit(t *testing.T) {
+	const modelWide = "C:/models/shared/mmproj-f16.gguf"
+	tests := []struct {
+		name    string
+		variant string
+		want    string
+	}{
+		{"empty inherits", "", modelWide},
+		{"none clears", NoneSentinel, ""},
+		{"explicit pins", "C:/models/other/mmproj-q8.gguf", "C:/models/other/mmproj-q8.gguf"},
+	}
+	for _, tc := range tests {
+		eff := Override{MmprojFile: modelWide}
+		v := VariantSpec{Name: "vision", MmprojFile: tc.variant}
+		mergeInheritStrings(&eff, &v)
+		if eff.MmprojFile != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, eff.MmprojFile, tc.want)
+		}
+	}
+}
+
+// End to end against the real tree: an explicit path must CREATE a vision twin
+// for a model that paired with nothing, and "none" must still win over it.
+// This is the crux of the feature - the twin used to exist only when discovery
+// had already found a projector.
+func TestAutogen_Generate_MmprojFileCreatesTwin(t *testing.T) {
+	if _, err := os.Stat(realModelsRoot); err != nil {
+		t.Skipf("models root %s absent", realModelsRoot)
+	}
+	rows, err := DiscoverGgufModelsMulti([]string{realModelsRoot})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	// A projector to borrow, and a TEXT model that discovery gave none. The
+	// target has to be an ordinary llama model: a diffusion or SAM row never
+	// grows a vision twin, whatever the field says.
+	var projector string
+	var target GgufRow
+	for _, r := range rows {
+		if projector == "" && r.MmprojPath != "" {
+			projector = r.MmprojPath
+		}
+		if target.FullPath != "" || r.MmprojPath != "" || r.IsSam {
+			continue
+		}
+		meta, err := ReadGgufMetadataCached(r.FullPath)
+		if err != nil || meta.BlockCount == 0 || meta.Architecture == "clip" || isImageArch(meta.Architecture) {
+			continue
+		}
+		target = r
+	}
+	if projector == "" || target.FullPath == "" {
+		t.Skip("need one model with a projector and one without in the tree")
+	}
+
+	gen := func(ov Override) string {
+		t.Helper()
+		ov.Match = "*" + filepath.Base(target.FullPath)
+		gf := GenerateFile{
+			Settings:  Settings{ModelsRoot: realModelsRoot},
+			Overrides: []Override{ov},
+		}
+		gf.Settings.applyDefaults()
+		out, err := Generate(gf, "T")
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		return out
+	}
+	// Count twins rather than guess the model's served id: every other model in
+	// the tree is untouched by the override, so the delta is this model's.
+	twins := func(out string) int { return strings.Count(out, "-vision\":") }
+	flag := "--mmproj " + strings.ReplaceAll(projector, "\\", "/")
+
+	// The projector's own model emits the flag too, so count uses rather than
+	// asking whether it appears at all.
+	base := gen(Override{})
+
+	set := gen(Override{MmprojFile: projector})
+	if got, want := twins(set), twins(base)+1; got != want {
+		t.Errorf("explicit mmprojFile: %d vision twins, want %d (the override must create one)", got, want)
+	}
+	if got, want := strings.Count(set, flag), strings.Count(base, flag)+1; got != want {
+		t.Errorf("explicit mmprojFile: %d uses of %q, want %d", got, flag, want)
+	}
+
+	// Placement "none" is checked past the twin gate, so it drops a twin the
+	// path would otherwise have created.
+	none := gen(Override{MmprojFile: projector, Mmproj: "none"})
+	if got, want := twins(none), twins(base); got != want {
+		t.Errorf(`mmproj "none" over an explicit path: %d vision twins, want %d`, got, want)
+	}
+	if got, want := strings.Count(none, flag), strings.Count(base, flag); got != want {
+		t.Errorf(`mmproj "none" over an explicit path: %d uses of %q, want %d`, got, flag, want)
+	}
+}
+
+// An explicit path beats a projector sitting right next to the model.
+func TestAutogen_Generate_MmprojFileBeatsDirLocal(t *testing.T) {
+	if _, err := os.Stat(realModelsRoot); err != nil {
+		t.Skipf("models root %s absent", realModelsRoot)
+	}
+	rows, err := DiscoverGgufModelsMulti([]string{realModelsRoot})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	// Two DIFFERENT projectors: one paired with a model, one to point it at.
+	var withProj GgufRow
+	var other string
+	for _, r := range rows {
+		if r.MmprojPath == "" {
+			continue
+		}
+		if withProj.FullPath == "" {
+			withProj = r
+			continue
+		}
+		if r.MmprojPath != withProj.MmprojPath {
+			other = r.MmprojPath
+			break
+		}
+	}
+	if withProj.FullPath == "" || other == "" {
+		t.Skip("need two models with different projectors in the tree")
+	}
+
+	gen := func(ovs ...Override) string {
+		t.Helper()
+		gf := GenerateFile{Settings: Settings{ModelsRoot: realModelsRoot}, Overrides: ovs}
+		gf.Settings.applyDefaults()
+		out, err := Generate(gf, "T")
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		return out
+	}
+	// `other` is some other model's own projector, so it appears in the baseline
+	// too. Count, don't Contains: what proves the override won is one MORE use of
+	// it and one FEWER of the dir-local file.
+	otherFlag := "--mmproj " + strings.ReplaceAll(other, "\\", "/")
+	localFlag := "--mmproj " + strings.ReplaceAll(withProj.MmprojPath, "\\", "/")
+	base := gen()
+	out := gen(Override{Match: "*" + filepath.Base(withProj.FullPath), MmprojFile: other})
+
+	if got, want := strings.Count(out, otherFlag), strings.Count(base, otherFlag)+1; got != want {
+		t.Errorf("explicit %q: %d uses, want %d", other, got, want)
+	}
+	if got, want := strings.Count(out, localFlag), strings.Count(base, localFlag)-1; got != want {
+		t.Errorf("dir-local %q: %d uses, want %d (the override must replace it)", withProj.MmprojPath, got, want)
+	}
+}

--- a/internal/autogen/overrides.go
+++ b/internal/autogen/overrides.go
@@ -644,6 +644,22 @@ type Override struct {
 	// On a VARIANT this field is sentinel-aware: empty inherits the model-wide
 	// value and NoneSentinel drops it. See inherit.go.
 	ChatTemplateFile string `yaml:"chatTemplateFile"`
+	// MmprojFile names the vision projector explicitly (--mmproj), for the case
+	// discovery cannot serve: one shared mmproj kept in a folder of its own and
+	// pointed at by several models. Discovery only pairs a projector sitting in
+	// the gguf's own directory, or in a family sibling's (inheritSidecars), and
+	// that rule is deliberately NOT widened - a projector is bound to a specific
+	// vision tower, so an auto-paired stranger yields a twin that loads clean and
+	// hallucinates on every image. Naming the file is the user stating intent.
+	//
+	// Set => used instead of anything discovery found, AND it creates the
+	// "-vision" twin for a model that paired with nothing. Mmproj "none" still
+	// wins (no twin at all). Distinct from Mmproj, which is the projector's
+	// PLACEMENT ("" auto / gpu / ram / none), not its path.
+	//
+	// On a VARIANT this field is sentinel-aware: empty inherits the model-wide
+	// value and NoneSentinel drops it. See inherit.go.
+	MmprojFile string `yaml:"mmprojFile"`
 	// --- Image (diffusion / sd-server) knobs ---
 	// Only consumed for image-arch models (emitImageModel / imageCmdLines); ignored
 	// by the llama-server path. The component paths are the external VAE + text
@@ -766,6 +782,9 @@ type VariantSpec struct {
 	ExtraArgs  string `yaml:"extraArgs"`
 	// ChatTemplateFile mirrors Override; empty => inherit the model-wide value.
 	ChatTemplateFile string `yaml:"chatTemplateFile"`
+	// MmprojFile mirrors Override; empty => inherit the model-wide value, "none"
+	// => no explicit projector (fall back to whatever discovery paired).
+	MmprojFile string `yaml:"mmprojFile"`
 	// Mmproj pins the image projector's placement, but ONLY on the reserved
 	// "vision" variant - it is the one variant that tunes a profile carrying an
 	// mmproj at all. Same vocabulary as Override.Mmproj ("gpu"/"ram"/"none");

--- a/internal/autogen/overrides.go
+++ b/internal/autogen/overrides.go
@@ -637,9 +637,12 @@ type Override struct {
 	// editable launch-parameters box into here.
 	ExtraArgs string `yaml:"extraArgs"`
 	// ChatTemplateFile is a path to a .jinja chat template that replaces the
-	// gguf's baked-in one (--chat-template-file). Empty => the baked-in template,
-	// except for archs autogen ships a known-good fix for (Qwen 3.5/3.6); a
-	// non-empty value always wins over that built-in fix.
+	// gguf's baked-in one (--chat-template-file). Empty => the baked-in template.
+	// No arch gets a substitute picked for it (see buildCmdLines); the built-in
+	// Qwen 3.5/3.6 fix this comment used to describe is gone.
+	//
+	// On a VARIANT this field is sentinel-aware: empty inherits the model-wide
+	// value and NoneSentinel drops it. See inherit.go.
 	ChatTemplateFile string `yaml:"chatTemplateFile"`
 	// --- Image (diffusion / sd-server) knobs ---
 	// Only consumed for image-arch models (emitImageModel / imageCmdLines); ignored
@@ -744,9 +747,15 @@ type VariantSpec struct {
 	// settings.slotCache.enable like the model-wide flag.
 	SlotCache *bool `yaml:"slotCache"`
 	// Engine knobs mirroring Override, so a variant can carry the full launch
-	// shape (the UI's "full settings page" for a variant). Named variants are
-	// STANDALONE: zero/empty => the generator default, NOT the model-wide Override
-	// (the Default tab and a variant are independent profiles).
+	// shape (the UI's "full settings page" for a variant). Zero/empty => INHERIT
+	// the model-wide Override; the variant's own non-zero value wins at merge
+	// (see the effOv chain in buildProfiles). This comment used to claim variants
+	// were standalone, which the merge code has never done.
+	//
+	// Because empty means inherit, the free-form string knobs below take
+	// NoneSentinel ("none") to mean "explicitly nothing" - otherwise a variant of
+	// a model that pins a chat template / extra args / tensor placement has no
+	// way to run without it. See inherit.go.
 	KvInRam    bool   `yaml:"kvInRam"`
 	CpuOffload int    `yaml:"cpuOffload"`
 	FlashAttn  string `yaml:"flashAttn"`
@@ -1112,6 +1121,10 @@ func LoadGenerateFile(path, modelsDirOverride string) (GenerateFile, error) {
 		if strings.TrimSpace(o.Match) == "" {
 			return GenerateFile{}, fmt.Errorf("overrides[%d]: match is required", i)
 		}
+		// A model-level "none" is redundant (empty already means no flag) but a
+		// user who learned the sentinel on a variant will write it here too;
+		// clear it once, centrally, so it can never reach the emitter as a path.
+		NormalizeNone(&gf.Overrides[i])
 	}
 	return gf, nil
 }

--- a/internal/server/configapi.go
+++ b/internal/server/configapi.go
@@ -23,7 +23,9 @@ import (
 // Relative paths resolve against the server's cwd, like the built-in template.
 func chatTemplateErr(p string) string {
 	p = strings.TrimSpace(p)
-	if p == "" {
+	// "" inherits / omits the flag; autogen.NoneSentinel is the variant's way to
+	// say "explicitly no template". Neither names a file to stat.
+	if p == "" || strings.EqualFold(p, autogen.NoneSentinel) {
 		return ""
 	}
 	st, err := os.Stat(p)

--- a/internal/server/configapi.go
+++ b/internal/server/configapi.go
@@ -38,6 +38,40 @@ func chatTemplateErr(p string) string {
 	return ""
 }
 
+// mmprojFileErr validates an explicit --mmproj path at SAVE time. Same two
+// checks as chatTemplateErr (missing, directory) plus one that has no
+// chat-template equivalent: the file must be a CLIP projector.
+//
+// That last check is the safety net standing in for the auto-pairing this field
+// deliberately does not widen. A wrong projector is not a load failure the user
+// gets to see: llama-server starts clean, the twin serves, and every image
+// answer is confabulated. Pointing the field at a normal model gguf is the easy
+// way to land there, and the gguf header says plainly which is which - the same
+// rule MmprojSidecarForDir pairs by, never a filename guess.
+func mmprojFileErr(p string) string {
+	p = strings.TrimSpace(p)
+	// "" falls back to discovery; autogen.NoneSentinel is a variant saying
+	// "explicitly not the model-wide path". Neither names a file to stat.
+	if p == "" || strings.EqualFold(p, autogen.NoneSentinel) {
+		return ""
+	}
+	st, err := os.Stat(p)
+	if err != nil {
+		return "mmproj projector file not found: " + p
+	}
+	if st.IsDir() {
+		return "mmproj path is a directory, not a file: " + p
+	}
+	meta, err := autogen.ReadGgufMetadataCached(p)
+	if err != nil {
+		return "mmproj file is not a readable gguf: " + p
+	}
+	if meta.Architecture != "clip" {
+		return "not a vision projector: " + p + " has gguf architecture " + meta.Architecture + ", want clip"
+	}
+	return ""
+}
+
 // AutogenAdmin carries everything the per-model config endpoints need to edit
 // the UI-owned override sidecar, regenerate the config, and hot-reload. It is
 // set by main only when the server was started with -generate; otherwise the
@@ -286,6 +320,10 @@ func (s *Server) handleAPIModelOverridePut(w http.ResponseWriter, r *http.Reques
 		shared.SendResponse(w, r, http.StatusBadRequest, msg)
 		return
 	}
+	if msg := mmprojFileErr(body.MmprojFile); msg != "" {
+		shared.SendResponse(w, r, http.StatusBadRequest, msg)
+		return
+	}
 	// Base the sidecar row on the hand-authored FILE override so its file-only
 	// fields (ctxVariants, quant) survive — the sidecar row shadows the file row
 	// wholesale, so anything the editor doesn't carry would otherwise be lost. The
@@ -453,6 +491,10 @@ func (s *Server) handleAPIModelVariantPost(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if msg := chatTemplateErr(v.ChatTemplateFile); msg != "" {
+		shared.SendResponse(w, r, http.StatusBadRequest, msg)
+		return
+	}
+	if msg := mmprojFileErr(v.MmprojFile); msg != "" {
 		shared.SendResponse(w, r, http.StatusBadRequest, msg)
 		return
 	}

--- a/internal/server/configapi_dto.go
+++ b/internal/server/configapi_dto.go
@@ -443,6 +443,11 @@ func applyOverrideDTO(ov *autogen.Override, body overrideDTO) {
 	for _, v := range body.Variants {
 		ov.Variants = append(ov.Variants, toVariantSpec(v))
 	}
+	// Resolve a model-level "none" here rather than only at config load: this DTO
+	// also feeds the launch-command preview, which renders without ever reading
+	// the config file. The variants above are deliberately left alone - on a
+	// variant the sentinel is meaningful, not redundant.
+	autogen.NormalizeNone(ov)
 }
 
 // applyVariantPatch layers only the NON-ZERO fields of a variantDTO patch onto

--- a/internal/server/configapi_dto.go
+++ b/internal/server/configapi_dto.go
@@ -45,6 +45,9 @@ type variantDTO struct {
 	Parallel         int    `json:"parallel"`
 	ExtraArgs        string `json:"extraArgs"`
 	ChatTemplateFile string `json:"chatTemplateFile"`
+	// MmprojFile pins the projector path; empty inherits the model-wide value,
+	// autogen.NoneSentinel falls back to discovery. See autogen.Override.
+	MmprojFile string `json:"mmprojFile"`
 	// Mmproj is meaningful only on the reserved "vision" variant; see
 	// autogen.VariantSpec.Mmproj.
 	Mmproj string `json:"mmproj"`
@@ -139,6 +142,7 @@ type overrideDTO struct {
 	Ub               int    `json:"ub"`
 	ExtraArgs        string `json:"extraArgs"`
 	ChatTemplateFile string `json:"chatTemplateFile"`
+	MmprojFile       string `json:"mmprojFile"`
 	Unlisted         bool   `json:"unlisted"`
 	Skip             bool   `json:"skip"`
 	SlotCache        *bool  `json:"slotCache"` // opt this model into on-disk slot KV persistence; nil/absent => OFF (opt-in)
@@ -268,7 +272,7 @@ func variantToDTO(v autogen.VariantSpec) variantDTO {
 		KvInRam: v.KvInRam, CpuOffload: v.CpuOffload,
 		FlashAttn: v.FlashAttn, Mmap: v.Mmap, Mlock: v.Mlock,
 		Threads: v.Threads, Parallel: v.Parallel, ExtraArgs: v.ExtraArgs,
-		ChatTemplateFile: v.ChatTemplateFile, Mmproj: v.Mmproj,
+		ChatTemplateFile: v.ChatTemplateFile, MmprojFile: v.MmprojFile, Mmproj: v.Mmproj,
 		DryMultiplier: v.DryMultiplier, DryBase: v.DryBase, DryAllowedLength: v.DryAllowedLength,
 		Temp: v.Temp, TopK: v.TopK, TopP: v.TopP, MinP: v.MinP, PresencePenalty: v.PresencePenalty,
 		SpecDraftNMax: v.SpecDraftNMax, SpecDefault: v.SpecDefault,
@@ -298,6 +302,7 @@ func toOverrideDTO(o autogen.Override) *overrideDTO {
 		Threads: o.Threads, Parallel: o.Parallel, Ub: o.Ub,
 		ExtraArgs:        o.ExtraArgs,
 		ChatTemplateFile: o.ChatTemplateFile,
+		MmprojFile:       o.MmprojFile,
 		Unlisted:         o.Unlisted, Skip: o.Skip, SlotCache: o.SlotCache,
 		SlotCachePreamble: o.SlotCachePreamble,
 		CtxVariants:       o.CtxVariants, CtxCheckpoints: o.CtxCheckpoints,
@@ -334,7 +339,7 @@ func toVariantSpec(v variantDTO) autogen.VariantSpec {
 		KvInRam: v.KvInRam, CpuOffload: v.CpuOffload,
 		FlashAttn: v.FlashAttn, Mmap: v.Mmap, Mlock: v.Mlock,
 		Threads: v.Threads, Parallel: v.Parallel, ExtraArgs: v.ExtraArgs,
-		ChatTemplateFile: v.ChatTemplateFile, Mmproj: v.Mmproj,
+		ChatTemplateFile: v.ChatTemplateFile, MmprojFile: v.MmprojFile, Mmproj: v.Mmproj,
 		DryMultiplier: v.DryMultiplier, DryBase: v.DryBase, DryAllowedLength: v.DryAllowedLength,
 		Temp: v.Temp, TopK: v.TopK, TopP: v.TopP, MinP: v.MinP, PresencePenalty: v.PresencePenalty,
 		SpecDraftNMax: v.SpecDraftNMax, SpecDefault: v.SpecDefault,
@@ -379,6 +384,7 @@ func applyOverrideDTO(ov *autogen.Override, body overrideDTO) {
 	ov.Ub = body.Ub
 	ov.ExtraArgs = strings.TrimSpace(body.ExtraArgs)
 	ov.ChatTemplateFile = strings.TrimSpace(body.ChatTemplateFile)
+	ov.MmprojFile = strings.TrimSpace(body.MmprojFile)
 	ov.Unlisted = body.Unlisted
 	ov.Skip = body.Skip
 	ov.SlotCache = body.SlotCache
@@ -518,6 +524,9 @@ func applyVariantPatch(ov *autogen.Override, p variantDTO) {
 	}
 	if strings.TrimSpace(p.ChatTemplateFile) != "" {
 		ov.ChatTemplateFile = strings.TrimSpace(p.ChatTemplateFile)
+	}
+	if strings.TrimSpace(p.MmprojFile) != "" {
+		ov.MmprojFile = strings.TrimSpace(p.MmprojFile)
 	}
 	if p.DryMultiplier != 0 {
 		ov.DryMultiplier = p.DryMultiplier

--- a/internal/server/mmprojfile_test.go
+++ b/internal/server/mmprojfile_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/quartermaster-labs/quartermaster/internal/autogen"
+)
+
+// writeMinimalGguf emits the smallest well-formed GGUF that carries a
+// general.architecture string: magic, version, zero tensors, one KV pair. The
+// validator only reads the header, so this is enough to stand in for a real
+// projector (arch "clip") or a real model (anything else) without dragging a
+// multi-gigabyte file into the test.
+func writeMinimalGguf(t *testing.T, path, arch string) string {
+	t.Helper()
+	var b []byte
+	u64 := func(v uint64) { b = binary.LittleEndian.AppendUint64(b, v) }
+	u32 := func(v uint32) { b = binary.LittleEndian.AppendUint32(b, v) }
+	str := func(s string) { u64(uint64(len(s))); b = append(b, s...) }
+
+	b = append(b, "GGUF"...)
+	u32(3) // version
+	u64(0) // tensor count
+	u64(1) // kv count
+	str("general.architecture")
+	u32(8) // GGUF_TYPE_STRING
+	str(arch)
+
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// A projector pointed at the wrong file is the one mistake this field can make
+// that the user never sees at runtime: llama-server starts, the vision twin
+// serves, and every image answer is confabulated. So save-time validation has
+// to reject more than "missing" - it checks the gguf header says clip, the same
+// rule discovery pairs projectors by.
+func TestServer_mmprojFileErr(t *testing.T) {
+	dir := t.TempDir()
+	clip := writeMinimalGguf(t, filepath.Join(dir, "mmproj-f16.gguf"), "clip")
+	model := writeMinimalGguf(t, filepath.Join(dir, "qwen3-8b-q4.gguf"), "qwen3")
+	notGguf := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(notGguf, []byte("not a gguf"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantSub string // "" => must be accepted
+	}{
+		{"empty falls back to discovery", "", ""},
+		{"none sentinel", autogen.NoneSentinel, ""},
+		{"a real projector", clip, ""},
+		{"whitespace is trimmed", "  " + clip + "  ", ""},
+		{"missing file", filepath.Join(dir, "gone.gguf"), "not found"},
+		{"a directory", dir, "directory"},
+		{"not a gguf at all", notGguf, "not a readable gguf"},
+		{"a normal model gguf", model, "not a vision projector"},
+	}
+	for _, tc := range tests {
+		got := mmprojFileErr(tc.path)
+		switch {
+		case tc.wantSub == "" && got != "":
+			t.Errorf("%s: rejected with %q, want accepted", tc.name, got)
+		case tc.wantSub != "" && !strings.Contains(got, tc.wantSub):
+			t.Errorf("%s: got %q, want a message containing %q", tc.name, got, tc.wantSub)
+		}
+	}
+}

--- a/internal/server/pickfile_spec.go
+++ b/internal/server/pickfile_spec.go
@@ -25,4 +25,9 @@ var pickSpecs = map[string]filePickSpec{
 		WinFilter:      "Chat templates (*.jinja;*.j2;*.jinja2)|*.jinja;*.j2;*.jinja2|All files (*.*)|*.*",
 		ZenityPatterns: []string{"Chat templates | *.jinja *.j2 *.jinja2", "All files | *"},
 	},
+	"mmproj": {
+		Title:          "Select vision projector (mmproj gguf)",
+		WinFilter:      "GGUF models (*.gguf)|*.gguf|All files (*.*)|*.*",
+		ZenityPatterns: []string{"GGUF models | *.gguf", "All files | *"},
+	},
 }

--- a/internal/server/turns_qm_fields.go
+++ b/internal/server/turns_qm_fields.go
@@ -82,6 +82,7 @@ var qmFieldDocs = map[string]string{
 	"preserveThinking": "keep prior-turn <think> blocks in the chat history",
 	"spec":             "speculative decoding spec (e.g. draft-mtp, draft-dflash, ngram-mod)",
 	"chatTemplateFile": "path to a .jinja chat template replacing the gguf's baked-in one (--chat-template-file). Use THIS field, never extraArgs",
+	"mmprojFile":       "path to the vision projector gguf (--mmproj) when it does not sit beside the model; also creates the -vision twin. Use THIS field, never extraArgs",
 	"extraArgs":        "extra backend flags appended verbatim. Only for flags with no field of their own",
 	"backend":          "backend registry id to launch with; '' = the class default",
 	"slotCache":        "opt into on-disk slot-KV persistence; null = default (on)",

--- a/ui-svelte/src/components/ModelConfigModal.svelte
+++ b/ui-svelte/src/components/ModelConfigModal.svelte
@@ -30,6 +30,7 @@
     fmtCtx,
     genDefaultKv,
     genDefaultNum,
+    cmdNum,
     genDefaultSpec,
     hoistChatTemplate,
     nglDisplay,
@@ -55,6 +56,8 @@
   let { modelId, open, onclose, openForId = "" }: Props = $props();
 
   let dialogEl: HTMLDialogElement | undefined = $state();
+  // The scrolling body, so a post-save re-seed can restore the reading position.
+  let bodyEl: HTMLDivElement | undefined = $state();
 
   let loading = $state(false);
   let saving = $state(false);
@@ -266,6 +269,12 @@
   // flags back into the form (parseCmd, on blur) and stashes anything autogen
   // doesn't model into extraArgs (passthrough, appended to the emitted command).
   let cmdDraft = $state("");
+  // The command the render effect last produced, i.e. what the box held before
+  // the user touched it. A blur compares against this, not against the model's
+  // autogen baseline: for a flag the generator ALWAYS emits, the text alone
+  // cannot say whether a value is a pin or the computed default, so "the user
+  // did not touch it" is the only safe read of an unchanged value.
+  let cmdRendered = $state("");
   let extraArgs = $state("");
 
   // --- Backend selection (per-model) ---
@@ -351,6 +360,7 @@
     specNgramSizeM = p.specNgramSizeM;
     specNgramMinHits = p.specNgramMinHits;
     extraArgs = p.extraArgs;
+    ctxCheckpoints = ckptEdit(p.ctxCheckpoints, ctxCheckpoints);
     adv.chatTemplateFile = p.chatTemplateFile;
     adv.temp = samplerDelta(p.temp, "--temp");
     adv.topK = samplerDelta(p.topK, "--top-k");
@@ -364,6 +374,19 @@
   // Without it, blurring the box for any unrelated reason would convert autogen's
   // arch-derived --top-k 20 / --min-p 0 baseline into an explicit per-model pin
   // that then never tracks a future change to that baseline.
+  // --ctx-checkpoints out of the box. autogen ALWAYS emits this flag (llama-server
+  // otherwise keeps 32 snapshots and silently overflows VRAM), so "absent from the
+  // box" cannot round-trip as "absent from the command" - it means the user wants
+  // checkpointing off, which is the pinned 0. A value left exactly as rendered is
+  // treated as untouched and keeps whatever the field held (auto, or a pin), so a
+  // blur for some unrelated edit never freezes the computed default into a pin.
+  function ckptEdit(parsed: number | null, current: number | null): number | null {
+    const shown = cmdNum(cmdRendered, "--ctx-checkpoints");
+    if (parsed === null) return shown === "" ? current : 0;
+    if (parsed === shown) return current;
+    return parsed;
+  }
+
   function samplerDelta(parsed: number | "", flag: string): number | "" {
     return parsed === genDefaultNum(config, flag) ? "" : parsed;
   }
@@ -433,10 +456,13 @@
     v.topP = sv(p.topP, "--top-p");
     v.minP = sv(p.minP, "--min-p");
     v.presencePenalty = sv(p.presencePenalty, "--presence-penalty");
-    v.extraArgs = p.extraArgs.trim();
-    // The variant box renders the inherited model-wide template too — capture it
-    // as a delta so an untouched value stays "inherit" ("") instead of pinning.
-    v.chatTemplateFile = p.chatTemplateFile === adv.chatTemplateFile.trim() ? "" : p.chatTemplateFile;
+    // The variant box renders the INHERITED model-wide values too, so these are
+    // captured as a delta against the Default tab: unchanged stays "inherit"
+    // ("") instead of pinning, and deleting a flag the model-wide sets becomes
+    // an explicit "none" rather than silently inheriting it straight back.
+    v.ctxCheckpoints = ckptEdit(p.ctxCheckpoints, v.ctxCheckpoints ?? null);
+    v.extraArgs = deltaStr(p.extraArgs.trim(), extraArgs);
+    v.chatTemplateFile = deltaStr(p.chatTemplateFile, adv.chatTemplateFile);
   }
 
   function onCmdInput(e: Event) {
@@ -484,11 +510,35 @@
     cmdTimer = setTimeout(async () => {
       try {
         cmdDraft = await previewCmd(modelId!, ov);
+        cmdRendered = cmdDraft;
       } catch {
         /* leave the last good command in the box */
       }
     }, 150);
   });
+
+  // Resolve one inheriting free-form string knob the same way autogen does
+  // (internal/autogen/inherit.go): blank inherits the model-wide value, the
+  // literal "none" forces the knob off, anything else pins. Kept in sync by
+  // hand — the preview must render the command the generator will emit, and a
+  // plain `||` chain would show `--chat-template-file none`.
+  const NONE_SENTINEL = "none";
+  const isNone = (v: string | undefined): boolean => (v ?? "").trim().toLowerCase() === NONE_SENTINEL;
+  function inheritStr(variant: string | undefined, model: string | undefined): string {
+    const v = (variant ?? "").trim();
+    if (v === "") return model ?? "";
+    if (v.toLowerCase() === NONE_SENTINEL) return "";
+    return variant ?? "";
+  }
+
+  // Inverse of inheritStr: turn a variant's fully-rendered value back into the
+  // delta the config file stores.
+  function deltaStr(parsed: string, model: string): string {
+    const m = (model ?? "").trim();
+    if (parsed === m) return "";
+    if (parsed === "" && m !== "") return NONE_SENTINEL;
+    return parsed;
+  }
 
   // A named variant INHERITS the model-wide override (the Default tab) and layers
   // its own non-blank fields on top — same as the generate path. So the preview
@@ -501,11 +551,11 @@
       const base = buildOverride();
       return {
         ...base,
-        vaePath: v.vaePath || base.vaePath,
-        clipLPath: v.clipLPath || base.clipLPath,
-        clipGPath: v.clipGPath || base.clipGPath,
-        t5Path: v.t5Path || base.t5Path,
-        textEncoderPath: v.textEncoderPath || base.textEncoderPath,
+        vaePath: inheritStr(v.vaePath, base.vaePath),
+        clipLPath: inheritStr(v.clipLPath, base.clipLPath),
+        clipGPath: inheritStr(v.clipGPath, base.clipGPath),
+        t5Path: inheritStr(v.t5Path, base.t5Path),
+        textEncoderPath: inheritStr(v.textEncoderPath, base.textEncoderPath),
         offloadToCpu: v.offloadToCpu || base.offloadToCpu,
         teOnCpu: v.teOnCpu || base.teOnCpu,
         vaeOnCpu: v.vaeOnCpu || base.vaeOnCpu,
@@ -518,7 +568,7 @@
         defaultSampler: v.defaultSampler || base.defaultSampler,
         defaultWidth: v.defaultWidth || base.defaultWidth,
         defaultHeight: v.defaultHeight || base.defaultHeight,
-        extraArgs: v.extraArgs || base.extraArgs,
+        extraArgs: inheritStr(v.extraArgs, base.extraArgs),
         unlisted: v.unlisted ?? false,
         variants: [],
       };
@@ -543,7 +593,7 @@
       threads: v.threads || base.threads || 0,
       parallel: v.parallel || base.parallel || 0,
       ub: v.ub || base.ub || 0,
-      extraArgs: v.extraArgs || base.extraArgs || "",
+      extraArgs: inheritStr(v.extraArgs, base.extraArgs),
       dry: v.dry ?? base.dry ?? null,
       dryMultiplier: v.dryMultiplier || base.dryMultiplier || 0,
       dryBase: v.dryBase || base.dryBase || 0,
@@ -565,8 +615,8 @@
       directIo: v.directIo ?? base.directIo ?? false,
       noOpOffload: v.noOpOffload ?? base.noOpOffload ?? false,
       noRepack: v.noRepack ?? base.noRepack ?? false,
-      kvKDraft: v.kvKDraft || base.kvKDraft || "",
-      kvVDraft: v.kvVDraft || base.kvVDraft || "",
+      kvKDraft: inheritStr(v.kvKDraft, base.kvKDraft),
+      kvVDraft: inheritStr(v.kvVDraft, base.kvVDraft),
       cacheReuse: v.cacheReuse || base.cacheReuse || 0,
       cacheRamMB: v.cacheRamMB || base.cacheRamMB || 0,
       cacheIdleSlots: v.cacheIdleSlots || base.cacheIdleSlots || "",
@@ -580,10 +630,10 @@
       ropeFreqBase: v.ropeFreqBase || base.ropeFreqBase || 0,
       yarnOrigCtx: v.yarnOrigCtx || base.yarnOrigCtx || 0,
       splitMode: v.splitMode || base.splitMode || "",
-      tensorSplit: v.tensorSplit || base.tensorSplit || "",
+      tensorSplit: inheritStr(v.tensorSplit, base.tensorSplit),
       mainGpu: v.mainGpu || base.mainGpu || 0,
-      overrideTensor: v.overrideTensor || base.overrideTensor || "",
-      chatTemplateFile: v.chatTemplateFile || base.chatTemplateFile || "",
+      overrideTensor: inheritStr(v.overrideTensor, base.overrideTensor),
+      chatTemplateFile: inheritStr(v.chatTemplateFile, base.chatTemplateFile),
       ctxCheckpoints: v.ctxCheckpoints ?? null,
       // variant-local: never inherited from the base.
       unlisted: v.unlisted ?? false,
@@ -920,8 +970,14 @@
     );
   }
 
-  async function load() {
+  // keepView: re-seed in place after a save instead of landing on the tab the
+  // modal was originally opened for. Saving from a variant used to drop you back
+  // on Default at the top of the page - the config had not changed tab, only the
+  // re-seed had forgotten which one you were on.
+  async function load(keepView = false) {
     if (!modelId) return;
+    const keepName = keepView ? (selectedV?.name ?? "") : "";
+    const keepScroll = keepView ? (bodyEl?.scrollTop ?? 0) : 0;
     loading = true;
     error = null;
     try {
@@ -936,6 +992,7 @@
       const o = cfg.override;
       autoCtx = parseCtx(cfg.cmd);
       cmdDraft = cfg.cmd; // render effect refreshes this to the canonical (${PORT}) form
+      cmdRendered = cfg.cmd;
       seedFromOverride(o);
       defaultVariants = (cfg.defaultVariants ?? []).map((v) => ({ ...v }));
       origDefaultVariants = JSON.stringify(defaultVariants);
@@ -950,8 +1007,8 @@
       // Land on the clicked row's variant: the model id ends with "-<name>" for
       // a variant/tier, or is the bare base for Default. Match the longest name so a
       // name that's a suffix of another doesn't win.
-      let chosen = "";
-      if (openForId) {
+      let chosen = keepName;
+      if (!chosen && openForId) {
         for (const v of [...variants, ...ctxTiers, ...defaultVariants]) {
           if (openForId.endsWith("-" + v.name) && v.name.length > chosen.length) chosen = v.name;
         }
@@ -959,6 +1016,9 @@
       selectedV = chosen
         ? ([...variants, ...ctxTiers, ...defaultVariants].find((v) => v.name === chosen) ?? null)
         : null;
+      // The re-seed re-renders the body, which resets its scroll. Put it back on
+      // the next frame, once the new content has laid out.
+      if (keepScroll > 0) requestAnimationFrame(() => bodyEl?.scrollTo({ top: keepScroll }));
       // Fetch each variant's own launch cmd so blank mmap checkboxes reflect that
       // variant's placement (not the base's). Best-effort, parallel, non-blocking.
       const idSet = new Set(get(models).map((m) => m.id));
@@ -1363,8 +1423,9 @@
         await putDefaultVariants(defaultVariants);
       }
       // Stay open — the live reload applies in the background. Re-seed from the
-      // regenerated config so the modal reflects what actually got saved.
-      await load();
+      // regenerated config so the modal reflects what actually got saved, without
+      // moving the user off the tab they saved from.
+      await load(true);
       saved = true;
       clearTimeout(savedTimer);
       savedTimer = setTimeout(() => (saved = false), 2000);
@@ -1486,7 +1547,7 @@
       </div>
     {/if}
 
-    <div class="overflow-y-auto flex-1 p-4 space-y-4 pretty-scroll">
+    <div bind:this={bodyEl} class="overflow-y-auto flex-1 p-4 space-y-4 pretty-scroll">
       {#if loading}
         <p class="text-txtsecondary">Loading…</p>
       {:else if error}
@@ -2499,7 +2560,9 @@
           ></textarea>
           <p class="text-xs text-txtsecondary mt-1">
             Edits sync with the fields above on blur. Flags autogen doesn't model are kept verbatim;
-            <code>-c</code>/<code>-ngl</code>/<code>--n-cpu-moe</code> stay sizer-controlled.
+            <code>-c</code>/<code>-ngl</code>/<code>--n-cpu-moe</code>/<code>-b</code> stay
+            sizer-controlled and come back on the next render. <code>--ctx-checkpoints</code> is
+            always emitted: deleting it sets checkpoints to 0 rather than dropping the flag.
           </p>
           <p class="text-xs text-txtsecondary mt-1 font-mono break-all">{config.gguf}</p>
         </details>
@@ -2838,21 +2901,28 @@
                 <input type="number" min="0" step="1024" value={vnum(sv.yarnOrigCtx)} oninput={(e) => (sv.yarnOrigCtx = Number((e.currentTarget as HTMLInputElement).value))} use:wheelAdjust class="cfg-input w-24 ml-auto" placeholder="inherit" />
               </label>
               <label class="flex items-center gap-2">
-                <span class="text-txtsecondary flex items-center gap-1">Tensor split {@render hint("-ts. Per-GPU proportion, e.g. 3,1.")}</span>
-                <input type="text" value={sv.tensorSplit ?? ""} oninput={(e) => (sv.tensorSplit = (e.currentTarget as HTMLInputElement).value)} class="cfg-input w-24 ml-auto" placeholder="inherit" />
+                <span class="text-txtsecondary flex items-center gap-1">Tensor split {@render hint("-ts. Per-GPU proportion, e.g. 3,1. Empty inherits the model-wide value; none forces it off.")}</span>
+                <input type="text" value={sv.tensorSplit ?? ""} oninput={(e) => (sv.tensorSplit = (e.currentTarget as HTMLInputElement).value)} class="cfg-input w-24 ml-auto" placeholder="inherit / none" />
               </label>
               <label class="flex items-center gap-2 col-span-2">
-                <span class="text-txtsecondary flex items-center gap-1 shrink-0">Override tensor {@render hint("-ot. Manual tensor→buffer placement, e.g. exps=CPU.")}</span>
-                <input type="text" value={sv.overrideTensor ?? ""} oninput={(e) => (sv.overrideTensor = (e.currentTarget as HTMLInputElement).value)} class="cfg-input flex-1 ml-auto font-mono" placeholder="inherit" />
+                <span class="text-txtsecondary flex items-center gap-1 shrink-0">Override tensor {@render hint("-ot. Manual tensor→buffer placement, e.g. exps=CPU. Empty inherits the model-wide value; none forces it off.")}</span>
+                <input type="text" value={sv.overrideTensor ?? ""} oninput={(e) => (sv.overrideTensor = (e.currentTarget as HTMLInputElement).value)} class="cfg-input flex-1 ml-auto font-mono" placeholder="inherit / none" />
               </label>
               <label class="flex items-center gap-2 col-span-2">
-                <span class="text-txtsecondary flex items-center gap-1 shrink-0">Chat template file {@render hint("--chat-template-file. Path to a .jinja chat template replacing the gguf's baked-in one. Empty = inherit the model-wide value.")}</span>
-                <input type="text" value={sv.chatTemplateFile ?? ""} oninput={(e) => (sv.chatTemplateFile = (e.currentTarget as HTMLInputElement).value)} class="cfg-input flex-1 ml-auto font-mono" placeholder="inherit" spellcheck="false" />
+                <span class="text-txtsecondary flex items-center gap-1 shrink-0">Chat template file {@render hint("--chat-template-file. Path to a .jinja chat template replacing the gguf's baked-in one. Empty inherits the model-wide value; none forces it off (the gguf's baked-in template).")}</span>
+                <input type="text" value={sv.chatTemplateFile ?? ""} oninput={(e) => (sv.chatTemplateFile = (e.currentTarget as HTMLInputElement).value)} class="cfg-input flex-1 ml-auto font-mono" placeholder="inherit / none" spellcheck="false" />
                 <button
                   type="button" use:tip={"Browse for a .jinja template"} aria-label="Browse for a chat template file"
                   class="shrink-0 p-1.5 rounded border border-transparent text-txtsecondary hover:text-primary hover:border-primary transition-colors"
                   onclick={() => browseChatTemplate((p) => (sv.chatTemplateFile = p))}
                 ><FolderOpen size={14} /></button>
+                <button
+                  type="button"
+                  use:tip={"No template: run this variant on the gguf's baked-in one, ignoring the model-wide pin"}
+                  aria-pressed={isNone(sv.chatTemplateFile)}
+                  class="shrink-0 px-1.5 py-1 rounded border text-xs transition-colors {isNone(sv.chatTemplateFile) ? 'border-primary text-primary' : 'border-transparent text-txtsecondary hover:text-primary hover:border-primary'}"
+                  onclick={() => (sv.chatTemplateFile = isNone(sv.chatTemplateFile) ? "" : NONE_SENTINEL)}
+                >None</button>
               </label>
               <label class="flex items-center gap-2">
                 <Toggle size="sm" checked={!!sv.directIo} onchange={(on) => (sv.directIo = on)} />
@@ -2888,7 +2958,9 @@
             ></textarea>
             <p class="text-xs text-txtsecondary mt-1">
               Edits sync with the fields above on blur. Flags autogen doesn't model are kept verbatim;
-              <code>-c</code>/<code>-ngl</code>/<code>--n-cpu-moe</code> stay sizer-controlled.
+              <code>-c</code>/<code>-ngl</code>/<code>--n-cpu-moe</code>/<code>-b</code> stay
+              sizer-controlled and come back on the next render. <code>--ctx-checkpoints</code> is
+              always emitted: deleting it sets checkpoints to 0 rather than dropping the flag.
             </p>
           </details>
         {/if}

--- a/ui-svelte/src/components/ModelConfigModal.svelte
+++ b/ui-svelte/src/components/ModelConfigModal.svelte
@@ -34,6 +34,7 @@
     cmdNum,
     genDefaultSpec,
     hoistChatTemplate,
+    hoistCms,
     nglDisplay,
     noNoMmap,
     parseCmdFields,
@@ -365,6 +366,7 @@
     extraArgs = p.extraArgs;
     ctxCheckpoints = ckptEdit(p.ctxCheckpoints, ctxCheckpoints);
     adv.chatTemplateFile = p.chatTemplateFile;
+    adv.checkpointMinStep = cmsEdit(p.checkpointMinStep, adv.checkpointMinStep);
     adv.temp = samplerDelta(p.temp, "--temp");
     adv.topK = samplerDelta(p.topK, "--top-k");
     adv.topP = samplerDelta(p.topP, "--top-p");
@@ -386,6 +388,20 @@
   function ckptEdit(parsed: number | null, current: number | null): number | null {
     const shown = cmdNum(cmdRendered, "--ctx-checkpoints");
     if (parsed === null) return shown === "" ? current : 0;
+    if (parsed === shown) return current;
+    return parsed;
+  }
+
+  // -cms out of the box. Same shape as ckptEdit, and for the same reason:
+  // autogen ALWAYS emits this flag, so a value identical to the rendered one
+  // means "untouched" and must keep whatever the field held - otherwise a blur
+  // for some unrelated edit freezes the sizer's computed spacing into a pin that
+  // then never tracks a future change to it. There is no "no -cms" state to
+  // round-trip to, so deleting the flag reads as 0 (let the sizer pick) and the
+  // flag reappears on the next render.
+  function cmsEdit(parsed: number | "", current: number | ""): number | "" {
+    const shown = cmdNum(cmdRendered, "-cms");
+    if (parsed === "") return shown === "" ? current : 0;
     if (parsed === shown) return current;
     return parsed;
   }
@@ -464,6 +480,7 @@
     // ("") instead of pinning, and deleting a flag the model-wide sets becomes
     // an explicit "none" rather than silently inheriting it straight back.
     v.ctxCheckpoints = ckptEdit(p.ctxCheckpoints, v.ctxCheckpoints ?? null);
+    v.checkpointMinStep = Number(cmsEdit(p.checkpointMinStep, v.checkpointMinStep ?? "")) || 0;
     v.extraArgs = deltaStr(p.extraArgs.trim(), extraArgs);
     v.chatTemplateFile = deltaStr(p.chatTemplateFile, adv.chatTemplateFile);
   }
@@ -902,6 +919,14 @@
         extraArgs = h.extra;
         if (!adv.chatTemplateFile) adv.chatTemplateFile = h.path;
       }
+      // Same for a -cms captured into extraArgs before the box parsed it: left
+      // there it is emitted a second time after the sizer's own copy, and grows
+      // by one more on every round trip through the launch box.
+      const c = hoistCms(extraArgs);
+      if (c.step !== "") {
+        extraArgs = c.extra;
+        if (!adv.checkpointMinStep) adv.checkpointMinStep = c.step;
+      }
     }
     unlisted = o?.unlisted ?? false;
     skip = o?.skip ?? false;
@@ -914,6 +939,11 @@
       if (h.path) {
         c.extraArgs = h.extra;
         if (!c.chatTemplateFile) c.chatTemplateFile = h.path;
+      }
+      const m = hoistCms(c.extraArgs ?? "");
+      if (m.step !== "") {
+        c.extraArgs = m.extra;
+        if (!c.checkpointMinStep) c.checkpointMinStep = m.step;
       }
       return c;
     });

--- a/ui-svelte/src/components/ModelConfigModal.svelte
+++ b/ui-svelte/src/components/ModelConfigModal.svelte
@@ -166,7 +166,7 @@
     swaFull: boolean; checkpointMinStep: number | ""; contextShift: string; specDraftNMin: number | "";
     slotPromptSimilarity: number | ""; ropeScaling: string; ropeScale: number | ""; ropeFreqBase: number | "";
     yarnOrigCtx: number | ""; splitMode: string; tensorSplit: string; mainGpu: number | ""; overrideTensor: string;
-    chatTemplateFile: string;
+    chatTemplateFile: string; mmprojFile: string;
     // Sampler defaults. "" => omit the flag (llama's default, or the arch
     // baseline for top-k/min-p); a number pins it, INCLUDING 0 — which is why
     // these round-trip through null rather than the 0-means-inherit convention
@@ -180,7 +180,7 @@
       swaFull: false, checkpointMinStep: "", contextShift: "", specDraftNMin: "",
       slotPromptSimilarity: "", ropeScaling: "", ropeScale: "", ropeFreqBase: "",
       yarnOrigCtx: "", splitMode: "", tensorSplit: "", mainGpu: "", overrideTensor: "",
-      chatTemplateFile: "",
+      chatTemplateFile: "", mmprojFile: "",
       temp: "", topK: "", topP: "", minP: "", presencePenalty: "",
     };
   }
@@ -197,7 +197,7 @@
       ropeScaling: o?.ropeScaling ?? "", ropeScale: o?.ropeScale || "", ropeFreqBase: o?.ropeFreqBase || "",
       yarnOrigCtx: o?.yarnOrigCtx || "", splitMode: o?.splitMode ?? "", tensorSplit: o?.tensorSplit ?? "",
       mainGpu: o?.mainGpu || "", overrideTensor: o?.overrideTensor ?? "",
-      chatTemplateFile: o?.chatTemplateFile ?? "",
+      chatTemplateFile: o?.chatTemplateFile ?? "", mmprojFile: o?.mmprojFile ?? "",
       // `?? ""`, never `|| ""`: a saved 0 (greedy temp, min-p off) is a pin, and
       // `||` would silently read it back as "inherit".
       temp: o?.temp ?? "", topK: o?.topK ?? "", topP: o?.topP ?? "",
@@ -221,17 +221,19 @@
       ropeScaling: adv.ropeScaling, ropeScale: n(adv.ropeScale), ropeFreqBase: n(adv.ropeFreqBase),
       yarnOrigCtx: n(adv.yarnOrigCtx), splitMode: adv.splitMode, tensorSplit: adv.tensorSplit,
       mainGpu: n(adv.mainGpu), overrideTensor: adv.overrideTensor,
-      chatTemplateFile: adv.chatTemplateFile.trim(),
+      chatTemplateFile: adv.chatTemplateFile.trim(), mmprojFile: adv.mmprojFile.trim(),
       temp: nn(adv.temp), topK: nn(adv.topK), topP: nn(adv.topP),
       minP: nn(adv.minP), presencePenalty: nn(adv.presencePenalty),
     };
   }
-  // Native open-file dialog for the chat-template path (the dialog opens on the
-  // server host — the operator's own machine for a local install). Returns null
-  // on cancel or on a platform with no picker, leaving the text field alone.
-  async function browseChatTemplate(apply: (path: string) => void): Promise<void> {
+  // Native open-file dialog for a path field (the dialog opens on the server
+  // host — the operator's own machine for a local install). The kind is a
+  // server-side whitelist key (pickfile_spec.go), never a filter built here.
+  // Returns null on cancel or on a platform with no picker, leaving the field
+  // alone.
+  async function browseFile(kind: string, apply: (path: string) => void): Promise<void> {
     try {
-      const picked = await pickFileOfKind("template");
+      const picked = await pickFileOfKind(kind);
       if (picked) apply(picked);
     } catch {
       // picker failed — the field stays typable, no need to nag
@@ -635,6 +637,7 @@
       mainGpu: v.mainGpu || base.mainGpu || 0,
       overrideTensor: inheritStr(v.overrideTensor, base.overrideTensor),
       chatTemplateFile: inheritStr(v.chatTemplateFile, base.chatTemplateFile),
+      mmprojFile: inheritStr(v.mmprojFile, base.mmprojFile),
       ctxCheckpoints: v.ctxCheckpoints ?? null,
       // variant-local: never inherited from the base.
       unlisted: v.unlisted ?? false,
@@ -697,11 +700,19 @@
   // Tooltip on the reserved "vision" variant's name field. When the projector
   // was borrowed from a family member it names the file, so nobody hunts this
   // model's own folder for an mmproj that isn't there.
+  // The projector this model's twin actually loads, in three distinguishable
+  // states: pinned by hand (mmprojFile beats everything), borrowed from a family
+  // sibling, or simply sitting in the model's own folder. Only the first two are
+  // worth saying out loud - a dir-local projector is what everyone expects.
+  const mmprojPinned = $derived(adv.mmprojFile.trim());
+  const mmprojResolved = $derived(mmprojPinned || config?.mmprojPath || "");
   const visionNameTip = $derived(
     "Reserved: the auto-generated vision twin that loads the mmproj image projector. Tune its ctx/VRAM/visibility here; uncheck Unlisted to surface it in the model picker." +
-      (config?.mmprojInherited && config.mmprojPath
-        ? ` Projector: ${config.mmprojPath} (borrowed from a family member).`
-        : ""),
+      (mmprojPinned
+        ? ` Projector: ${mmprojPinned} (pinned by hand, discovery ignored).`
+        : config?.mmprojInherited && config.mmprojPath
+          ? ` Projector: ${config.mmprojPath} (borrowed from a family member).`
+          : ""),
   );
 
   // llama.cpp's kv_cache_types, minus iq4_nl (no flash-attention KV kernel).
@@ -934,7 +945,7 @@
       reasoningFmt: "", unlisted: false, ctxCheckpoints: null, dry: null, preserveThinking: null,
       slotCache: null,
       kvInRam: false, cpuOffload: 0, flashAttn: "", mmap: "", mlock: false,
-      threads: 0, parallel: 0, extraArgs: "", chatTemplateFile: "",
+      threads: 0, parallel: 0, extraArgs: "", chatTemplateFile: "", mmprojFile: "",
       dryMultiplier: 0, dryBase: 0, dryAllowedLength: 0,
       temp: null, topK: null, topP: null, minP: null, presencePenalty: null,
       specDraftNMax: 0, specDefault: false, specNgramSizeN: 0, specNgramSizeM: 0, specNgramMinHits: 0,
@@ -965,7 +976,7 @@
       !v.vramTargetGB && !v.kvK && !v.kvV && !v.spec && !v.ub &&
       !v.reasoningFmt && !v.unlisted &&
       v.ctxCheckpoints == null && v.dry == null && v.preserveThinking == null && v.slotCache == null && !v.kvInRam && !v.cpuOffload &&
-      !v.flashAttn && !v.mmap && !v.mlock && !v.threads && !v.parallel && !v.extraArgs && !v.chatTemplateFile &&
+      !v.flashAttn && !v.mmap && !v.mlock && !v.threads && !v.parallel && !v.extraArgs && !v.chatTemplateFile && !v.mmprojFile &&
       !v.dryMultiplier && !v.dryBase && !v.dryAllowedLength &&
       v.temp == null && v.topK == null && v.topP == null && v.minP == null && v.presencePenalty == null &&
       !v.specDraftNMax && !v.specDefault && !v.specNgramSizeN && !v.specNgramSizeM && !v.specNgramMinHits
@@ -1587,22 +1598,29 @@
            Without it the draft-mtp / draft-dflash chips — and the vision twin —
            claim a capability the folder visibly has no file for, which reads as
            a bug. Same wording for both so the badge means one thing. -->
-      {#snippet borrowedBadge(text: string)}
+      {#snippet borrowedBadge(text: string, label: string)}
         <span
           class="rounded border border-card-border px-1.5 py-px text-[10px] uppercase tracking-wide text-txtsecondary cursor-help"
-          use:tip={text}>borrowed</span>
+          use:tip={text}>{label}</span>
       {/snippet}
       {#snippet borrowedDraft()}
         {#if config?.draftInherited}
           {@render borrowedBadge(
             `This model's folder ships no draft model. draft-* loads ${config.draftPath ?? "a sibling's drafter"}, borrowed from another quant or a finetune with the same architecture, layer count, embedding width and vocabulary. Put a drafter next to this model to use that one instead.`,
+            "borrowed",
           )}
         {/if}
       {/snippet}
       {#snippet borrowedMmproj()}
-        {#if config?.mmprojInherited}
+        {#if mmprojPinned}
+          {@render borrowedBadge(
+            `Projector file set by hand: the vision twin loads ${mmprojPinned}. Discovery and family inheritance are ignored while this is set - clear the Projector file field to go back to them.`,
+            "pinned",
+          )}
+        {:else if config?.mmprojInherited}
           {@render borrowedBadge(
             `This model's folder ships no image projector. The vision twin loads ${config.mmprojPath ?? "a sibling's projector"}, borrowed from another quant or a finetune with the same architecture, layer count, embedding width and vocabulary. Put an mmproj next to this model to use that one instead.`,
+            "borrowed",
           )}
         {/if}
       {/snippet}
@@ -2252,7 +2270,7 @@
             {@render specRow(spec, (v) => (spec = v))}
           </div>
 
-          {#if config?.mmprojPath}
+          {#if mmprojResolved}
             <label class="flex flex-col gap-1 text-sm">
               <span class="text-txtsecondary flex items-center gap-1">
                 Image projector
@@ -2262,6 +2280,22 @@
               <Select bind:value={mmprojMode} options={MMPROJ_SEL} ariaLabel="Image projector placement" />
             </label>
           {/if}
+
+          <label class="flex flex-col gap-1 text-sm col-span-2">
+            <span class="text-txtsecondary flex items-center gap-1">
+              Projector file
+              {@render hint("--mmproj. The vision projector gguf this model's twin loads. Empty = whatever sits in the model's own folder, or is borrowed from a family member. Set it when one shared projector lives in a folder of its own, pointed at by several models: an explicit path also CREATES the vision twin for a model that pairs with nothing. Discovery is deliberately not widened - a projector belongs to one vision tower, and an unrelated one loads clean and then hallucinates on every image - so the path is checked to be a clip gguf when you save.")}
+              {@render borrowedMmproj()}
+            </span>
+            <div class="flex items-center gap-2">
+              <input type="text" bind:value={adv.mmprojFile} class="cfg-input flex-1 font-mono" placeholder={config?.mmprojPath || "D:/LLM/Models/mmproj/qwen3vl-mmproj-f16.gguf"} spellcheck="false" />
+              <button
+                type="button" use:tip={"Browse for a projector .gguf"} aria-label="Browse for a vision projector file"
+                class="shrink-0 p-1.5 rounded border border-transparent text-txtsecondary hover:text-primary hover:border-primary transition-colors"
+                onclick={() => browseFile("mmproj", (p) => (adv.mmprojFile = p))}
+              ><FolderOpen size={14} /></button>
+            </div>
+          </label>
 
           {#if effSpecs.includes("draft-mtp") || effSpecs.includes("draft-dflash")}
             <label class="flex flex-col gap-1 text-sm">
@@ -2541,7 +2575,7 @@
               <button
                 type="button" use:tip={"Browse for a .jinja template"} aria-label="Browse for a chat template file"
                 class="shrink-0 p-1.5 rounded border border-transparent text-txtsecondary hover:text-primary hover:border-primary transition-colors"
-                onclick={() => browseChatTemplate((p) => (adv.chatTemplateFile = p))}
+                onclick={() => browseFile("template", (p) => (adv.chatTemplateFile = p))}
               ><FolderOpen size={14} /></button>
             </label>
             <label class="flex items-center gap-2">
@@ -2662,6 +2696,27 @@
                   {@render hint("Where this twin's CLIP projector lives. Inherit uses the Default tab's pick (auto = on the GPU while it costs neither GPU layers nor a quarter of the context window). On GPU pins it there - fastest image encode, paid for in context/offload on every request. In RAM (--no-mmproj-offload) frees that VRAM and encodes on the CPU: seconds per image, token speed untouched. None emits no vision twin at all.")}
                 </span>
                 <Select bind:value={sv.mmproj} options={MMPROJ_SEL_INHERIT} ariaLabel="Image projector placement" />
+              </label>
+              <label class="flex flex-col gap-1 text-sm col-span-2">
+                <span class="text-txtsecondary flex items-center gap-1">
+                  Projector file
+                  {@render hint("--mmproj. The projector gguf this twin loads. Empty inherits the Default tab's path; none forces it back to discovery (the projector next to the model, or a family member's).")}
+                </span>
+                <div class="flex items-center gap-2">
+                  <input type="text" value={sv.mmprojFile ?? ""} oninput={(e) => (sv.mmprojFile = (e.currentTarget as HTMLInputElement).value)} class="cfg-input flex-1 font-mono" placeholder="inherit / none" spellcheck="false" />
+                  <button
+                    type="button" use:tip={"Browse for a projector .gguf"} aria-label="Browse for a vision projector file"
+                    class="shrink-0 p-1.5 rounded border border-transparent text-txtsecondary hover:text-primary hover:border-primary transition-colors"
+                    onclick={() => browseFile("mmproj", (p) => (sv.mmprojFile = p))}
+                  ><FolderOpen size={14} /></button>
+                  <button
+                    type="button"
+                    use:tip={"No pinned projector: this twin goes back to discovery, ignoring the model-wide path"}
+                    aria-pressed={isNone(sv.mmprojFile)}
+                    class="shrink-0 px-1.5 py-1 rounded border text-xs transition-colors {isNone(sv.mmprojFile) ? 'border-primary text-primary' : 'border-transparent text-txtsecondary hover:text-primary hover:border-primary'}"
+                    onclick={() => (sv.mmprojFile = isNone(sv.mmprojFile) ? "" : NONE_SENTINEL)}
+                  >None</button>
+                </div>
               </label>
             {/if}
             <label class="flex flex-col gap-1 text-sm">
@@ -2934,7 +2989,7 @@
                 <button
                   type="button" use:tip={"Browse for a .jinja template"} aria-label="Browse for a chat template file"
                   class="shrink-0 p-1.5 rounded border border-transparent text-txtsecondary hover:text-primary hover:border-primary transition-colors"
-                  onclick={() => browseChatTemplate((p) => (sv.chatTemplateFile = p))}
+                  onclick={() => browseFile("template", (p) => (sv.chatTemplateFile = p))}
                 ><FolderOpen size={14} /></button>
                 <button
                   type="button"

--- a/ui-svelte/src/components/ModelConfigModal.svelte
+++ b/ui-svelte/src/components/ModelConfigModal.svelte
@@ -17,6 +17,7 @@
     models,
   } from "../stores/api";
   import { get } from "svelte/store";
+  import { tick } from "svelte";
   import { FolderOpen, HelpCircle, X } from "lucide-svelte";
   import { tip } from "../lib/tooltip";
   import { askConfirm } from "../lib/confirm";
@@ -954,6 +955,7 @@
     // Select the ARRAY's element, not the raw literal: $state wraps elements in a
     // proxy, so `selectedV = nv` never `===` the rendered tab and nothing lights up.
     selectedV = variants[variants.length - 1];
+    focusVariantName();
   }
 
   // True when a ctx tier carries nothing but its ctx value, so it round-trips as
@@ -1291,6 +1293,7 @@
     variants = [...variants, variantFromDefault(name)];
     // Select the proxied array element (see addImageVariantEntry).
     selectedV = variants[variants.length - 1];
+    focusVariantName();
   }
 
   // Add a fresh fleet-wide variant (shared by every model) and select it. Saved
@@ -1305,6 +1308,7 @@
     // variant: it inherits at creation, then drifts independently (standalone).
     defaultVariants = [...defaultVariants, variantFromDefault(name)];
     selectedV = defaultVariants[defaultVariants.length - 1];
+    focusVariantName();
   }
 
   // Remove a tab from whichever bucket holds it (per-model variant, ctx tier, or
@@ -1355,6 +1359,22 @@
   function setVSlotCache(val: string) {
     if (selectedV) selectedV.slotCache = val === "inherit" ? null : val === "on";
   }
+  // The selected variant's name field, so a freshly added variant can put the
+  // caret in it. Only one of the two name inputs (image preset / llm variant) is
+  // ever mounted, so a single ref is enough.
+  let nameInput = $state<HTMLInputElement | null>(null);
+
+  // A new variant is born holding a placeholder ("variant", "preset2") that is
+  // never what the user meant to keep, and the name drives the served id, so the
+  // first thing they always do is rename it. Focus the field and SELECT the
+  // placeholder, so the next keystroke replaces it instead of appending to it.
+  // tick() first: the field only enters the DOM once the new tab's panel renders.
+  async function focusVariantName() {
+    await tick();
+    nameInput?.focus();
+    nameInput?.select();
+  }
+
   // Renaming the selected variant must move the selection pointer with it so the
   // derived `selectedV` keeps resolving to the same array element.
   function renameSelectedVariant(e: Event) {
@@ -1874,7 +1894,7 @@
                 Name (suffix)
                 {@render hint("The preset's id suffix. Loads as <base-id>-<name>.")}
               </span>
-              <input type="text" value={sv.name} oninput={renameSelectedVariant} class="cfg-input" placeholder="e.g. fast, quality, hd" />
+              <input type="text" bind:this={nameInput} value={sv.name} oninput={renameSelectedVariant} class="cfg-input" placeholder="e.g. fast, quality, hd" />
             </label>
 
             <div class="col-span-2 font-mono text-[0.6rem] uppercase tracking-wider text-txtsecondary mt-1">Generation defaults</div>
@@ -2587,7 +2607,7 @@
               {#if sv.name === "vision"}
                 <input type="text" value="vision" readonly class="cfg-input opacity-70" use:tip={visionNameTip} />
               {:else}
-                <input type="text" value={sv.name} oninput={renameSelectedVariant} class="cfg-input" placeholder="e.g. game, long, judge" />
+                <input type="text" bind:this={nameInput} value={sv.name} oninput={renameSelectedVariant} class="cfg-input" placeholder="e.g. game, long, judge" />
               {/if}
             </label>
             <label class="flex flex-col gap-1 text-sm">

--- a/ui-svelte/src/components/modelCmdForm.test.ts
+++ b/ui-svelte/src/components/modelCmdForm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseCmdFields, genDefaultNum, cmdNum, specToggle } from "./modelCmdForm";
+import { parseCmdFields, genDefaultNum, cmdNum, specToggle, hoistCms } from "./modelCmdForm";
 import type { ModelConfig } from "../stores/api";
 
 // The sampler defaults are the one flag group where 0 is a real value, so the
@@ -85,6 +85,42 @@ describe("parseCmdFields --ctx-checkpoints", () => {
   });
   it("never bleeds into extraArgs", () => {
     expect(parseCmdFields("llama-server -m x.gguf --ctx-checkpoints 2").extraArgs).toBe("");
+  });
+});
+
+// -cms is the flag that proved this whole class of bug: autogen emits it on
+// every text model, the box did not parse it, so it landed in extraArgs and was
+// re-appended after the generated copy - once more per round trip through the
+// launch box.
+describe("parseCmdFields -cms", () => {
+  it("captures both spellings", () => {
+    expect(parseCmdFields("llama-server -m x.gguf -cms 256").checkpointMinStep).toBe(256);
+    expect(parseCmdFields("llama-server -m x.gguf --checkpoint-min-step 512").checkpointMinStep).toBe(512);
+  });
+  it("reports \"\" when the user deleted the flag", () => {
+    expect(parseCmdFields("llama-server -m x.gguf -c 4096").checkpointMinStep).toBe("");
+  });
+  it("never bleeds into extraArgs", () => {
+    expect(parseCmdFields("llama-server -m x.gguf -cms 256 --foo bar").extraArgs).toBe("--foo bar");
+    expect(parseCmdFields("llama-server -m x.gguf --checkpoint-min-step 256").extraArgs).toBe("");
+  });
+});
+
+// Installs saved before the parse existed carry the flag inside extraArgs.
+// Hoisting it back into the field on load is what actually stops the duplicate
+// the user already has on disk.
+describe("hoistCms", () => {
+  it("pulls the flag out and returns the rest", () => {
+    expect(hoistCms("-cms 256")).toEqual({ extra: "", step: 256 });
+    expect(hoistCms("--foo bar -cms 256 --baz")).toEqual({ extra: "--foo bar --baz", step: 256 });
+    expect(hoistCms("--checkpoint-min-step 512 --foo")).toEqual({ extra: "--foo", step: 512 });
+  });
+  it("leaves an extraArgs without it untouched", () => {
+    expect(hoistCms("--foo bar")).toEqual({ extra: "--foo bar", step: "" });
+    expect(hoistCms("")).toEqual({ extra: "", step: "" });
+  });
+  it("does not match a longer flag that merely ends in -cms", () => {
+    expect(hoistCms("--not-cms 256").step).toBe("");
   });
 });
 

--- a/ui-svelte/src/components/modelCmdForm.test.ts
+++ b/ui-svelte/src/components/modelCmdForm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseCmdFields, genDefaultNum, specToggle } from "./modelCmdForm";
+import { parseCmdFields, genDefaultNum, cmdNum, specToggle } from "./modelCmdForm";
 import type { ModelConfig } from "../stores/api";
 
 // The sampler defaults are the one flag group where 0 is a real value, so the
@@ -72,5 +72,25 @@ describe("parseCmdFields mmproj flags", () => {
       "llama-server -m x.gguf --mmproj C:/models/mmproj.gguf --no-mmproj-offload --foo bar",
     );
     expect(p.extraArgs).toBe("--foo bar");
+  });
+});
+
+describe("parseCmdFields --ctx-checkpoints", () => {
+  it("captures the value instead of swallowing it", () => {
+    expect(parseCmdFields("llama-server -m x.gguf --ctx-checkpoints 2").ctxCheckpoints).toBe(2);
+    expect(parseCmdFields("llama-server -m x.gguf --ctx-checkpoints 0").ctxCheckpoints).toBe(0);
+  });
+  it("reports null when the user deleted the flag", () => {
+    expect(parseCmdFields("llama-server -m x.gguf -c 4096").ctxCheckpoints).toBeNull();
+  });
+  it("never bleeds into extraArgs", () => {
+    expect(parseCmdFields("llama-server -m x.gguf --ctx-checkpoints 2").extraArgs).toBe("");
+  });
+});
+
+describe("cmdNum", () => {
+  it("reads a flag off any command text, not just the model baseline", () => {
+    expect(cmdNum("llama-server --ctx-checkpoints 3 -c 8192", "--ctx-checkpoints")).toBe(3);
+    expect(cmdNum("llama-server -c 8192", "--ctx-checkpoints")).toBe("");
   });
 });

--- a/ui-svelte/src/components/modelCmdForm.ts
+++ b/ui-svelte/src/components/modelCmdForm.ts
@@ -89,6 +89,10 @@ export interface ParsedCmd {
   // the user deleted the flag. Kept as null rather than "" because the caller
   // has to tell "not in the text" from the pinned 0 that disables checkpointing.
   ctxCheckpoints: number | null;
+  // -cms as it stands in the box, "" when the flag is absent. autogen always
+  // emits it, so an unparsed copy would land in extraArgs and be appended a
+  // SECOND time on the next render - one more per round trip.
+  checkpointMinStep: number | "";
   // Speculative sub-knobs (value "" / false => omit).
   specDraftNMax: number | "";
   specDefault: boolean;
@@ -106,6 +110,22 @@ export function hoistChatTemplate(extra: string): { extra: string; path: string 
   if (!m) return { extra, path: "" };
   const path = m[2].replace(/^"|"$/g, "");
   return { extra: (extra.slice(0, m.index) + " " + extra.slice(m.index! + m[0].length)).trim(), path };
+}
+
+// Pull a `-cms <n>` / `--checkpoint-min-step <n>` pair out of a free-form
+// extraArgs string, returning the remaining args plus the value ("" when
+// absent). Installs written before the box parsed -cms captured it into
+// extraArgs, where the emitter appends it after its own computed copy: harmless
+// to llama-server (last wins) but it grows by one on every box round trip, and
+// it silently overrides the sizer's spacing. Hoisted back into the field on
+// load, exactly like a template smuggled in through extraArgs.
+export function hoistCms(extra: string): { extra: string; step: number | "" } {
+  const m = extra.match(/(^|\s)(?:-cms|--checkpoint-min-step)\s+(\d+)/);
+  if (!m) return { extra, step: "" };
+  return {
+    extra: (extra.slice(0, m.index) + " " + extra.slice(m.index! + m[0].length)).replace(/\s+/g, " ").trim(),
+    step: Number(m[2]),
+  };
 }
 
 // A flag value that keeps 0 distinct from absent: null/"" (flag not in the box)
@@ -140,7 +160,8 @@ export function parseCmdFields(cmd: string): ParsedCmd {
     reason: string | null = null,
     rBudget: string | null = null,
     ctFile: string | null = null,
-    ckpt: string | null = null;
+    ckpt: string | null = null,
+    cms: string | null = null;
   let noMmap = false,
     mlockF = false,
     noKv = false,
@@ -200,6 +221,9 @@ export function parseCmdFields(cmd: string): ParsedCmd {
       case "--dry-base": dBase = val(); break;
       case "--dry-allowed-length": dAllow = val(); break;
       case "--ctx-checkpoints": ckpt = val(); break;
+      // Both spellings: the emitter writes the short one, a hand-edited box or a
+      // qm-tools write may carry llama's long alias.
+      case "-cms": case "--checkpoint-min-step": cms = val(); break;
       case "--spec-draft-n-max": sNMax = val(); break;
       case "--spec-default": specDef = true; break;
       case "--spec-ngram-map-k4v-size-n": sNgN = val(); break;
@@ -243,6 +267,7 @@ export function parseCmdFields(cmd: string): ParsedCmd {
     minP: numFlag(minP),
     presencePenalty: numFlag(presP),
     ctxCheckpoints: ckpt !== null && ckpt !== "" && !Number.isNaN(Number(ckpt)) ? Number(ckpt) : null,
+    checkpointMinStep: numFlag(cms),
     specDraftNMax: sNMax !== null && sNMax !== "" ? Number(sNMax) : "",
     specDefault: specDef,
     specNgramSizeN: sNgN !== null && sNgN !== "" ? Number(sNgN) : "",

--- a/ui-svelte/src/components/modelCmdForm.ts
+++ b/ui-svelte/src/components/modelCmdForm.ts
@@ -27,14 +27,17 @@ export const IMG_SAMPLERS = ["", "euler_a", "euler", "heun", "dpm2", "dpmpp2s_a"
 // the box so editing them never flips a form "auto" toggle or pins a value.
 // Value-flags owned by other controls (sliders / toggles / sizer), swallowed
 // when parsing so they never bleed into extraArgs and double-emit:
-//   -c/-ngl/--n-cpu-moe/-b  sizer; --ctx-checkpoints  its own field;
+//   -c/-ngl/--n-cpu-moe/-b  sizer;
 //   --chat-template-kwargs  legacy preserve-thinking form, still swallowed so an
 //   older saved command does not bleed into extraArgs; -md  draft path;
 //   --slot-save-path  the slotCacheOn toggle.
 // --chat-template-file is NOT here: it has its own case below that captures the
 // path into the advanced field. Swallowing it silently dropped a template set
 // any other way (qm-tools/hand-edited extraArgs) on the first box blur.
-export const IGNORE_VALUE = new Set(["-m", "--port", "--host", "--cors-origins", "-c", "-ngl", "--n-cpu-moe", "-b", "--ctx-checkpoints", "--chat-template-kwargs", "-md", "--slot-save-path", "--mmproj"]);
+// --ctx-checkpoints is not here either, for the same reason: swallowing it made
+// the box lie, since deleting it from the text left the field (and so the next
+// render) untouched. It parses into ParsedCmd.ctxCheckpoints instead.
+export const IGNORE_VALUE = new Set(["-m", "--port", "--host", "--cors-origins", "-c", "-ngl", "--n-cpu-moe", "-b", "--chat-template-kwargs", "-md", "--slot-save-path", "--mmproj"]);
 // Legacy: an older build shipped this template in the package and autogen
 // pointed --chat-template-file at it. Neither is true any more (the folder is
 // gone, and templates are user-managed), but a config written by that build can
@@ -82,6 +85,10 @@ export interface ParsedCmd {
   topP: number | "";
   minP: number | "";
   presencePenalty: number | "";
+  // --ctx-checkpoints as it stands in the box: a number when present, null when
+  // the user deleted the flag. Kept as null rather than "" because the caller
+  // has to tell "not in the text" from the pinned 0 that disables checkpointing.
+  ctxCheckpoints: number | null;
   // Speculative sub-knobs (value "" / false => omit).
   specDraftNMax: number | "";
   specDefault: boolean;
@@ -132,7 +139,8 @@ export function parseCmdFields(cmd: string): ParsedCmd {
     sp: string | null = null,
     reason: string | null = null,
     rBudget: string | null = null,
-    ctFile: string | null = null;
+    ctFile: string | null = null,
+    ckpt: string | null = null;
   let noMmap = false,
     mlockF = false,
     noKv = false,
@@ -191,6 +199,7 @@ export function parseCmdFields(cmd: string): ParsedCmd {
       case "--dry-multiplier": dMult = val(); break;
       case "--dry-base": dBase = val(); break;
       case "--dry-allowed-length": dAllow = val(); break;
+      case "--ctx-checkpoints": ckpt = val(); break;
       case "--spec-draft-n-max": sNMax = val(); break;
       case "--spec-default": specDef = true; break;
       case "--spec-ngram-map-k4v-size-n": sNgN = val(); break;
@@ -233,6 +242,7 @@ export function parseCmdFields(cmd: string): ParsedCmd {
     topP: numFlag(topP),
     minP: numFlag(minP),
     presencePenalty: numFlag(presP),
+    ctxCheckpoints: ckpt !== null && ckpt !== "" && !Number.isNaN(Number(ckpt)) ? Number(ckpt) : null,
     specDraftNMax: sNMax !== null && sNMax !== "" ? Number(sNMax) : "",
     specDefault: specDef,
     specNgramSizeN: sNgN !== null && sNgN !== "" ? Number(sNgN) : "",
@@ -343,7 +353,15 @@ export function genDefaultKv(c: ModelConfig | null): string {
 // echoed back", so an arch-derived baseline is not silently frozen into an
 // explicit per-model pin. "" when the flag is absent or non-numeric.
 export function genDefaultNum(c: ModelConfig | null, flag: string): number | "" {
-  const m = new RegExp(`(?:^|\\s)${flag}\\s+(\\S+)`).exec(c?.cmd ?? "");
+  return cmdNum(c?.cmd ?? "", flag);
+}
+
+// The numeric value ANY rendered command carries for `flag` ("" when the flag is
+// absent or valueless). Same read as genDefaultNum against arbitrary text: a box
+// edit is judged against the command the render effect last produced, which is
+// the only way to tell "the user changed this" from "the user left it alone".
+export function cmdNum(cmd: string, flag: string): number | "" {
+  const m = new RegExp(`(?:^|\\s)${flag}\\s+(\\S+)`).exec(cmd);
   return m && m[1] !== "" && !Number.isNaN(Number(m[1])) ? Number(m[1]) : "";
 }
 

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -298,6 +298,9 @@ export interface ModelVariant {
   parallel?: number;
   extraArgs?: string;
   chatTemplateFile?: string; // .jinja path; "" => inherit model-wide
+  // Only read on the reserved "vision" variant: the projector gguf this twin
+  // loads. "" => inherit the model-wide mmprojFile; "none" => back to discovery.
+  mmprojFile?: string;
   // Only read on the reserved "vision" variant: "" (inherit) | "gpu" | "ram" | "none".
   mmproj?: string;
   // Sampler / speculative sub-knobs (0/empty => inherit model-wide).
@@ -388,6 +391,10 @@ export interface ModelOverride {
   ub?: number; // 0 => auto (physical batch -ub/-b)
   extraArgs?: string; // extra llama-server flags appended verbatim (passthrough)
   chatTemplateFile?: string; // --chat-template-file path; "" => the gguf's baked-in template
+  // --mmproj path. "" => whatever discovery pairs (dir-local, or a family
+  // sibling's). Set => that file, and the "-vision" twin exists even when
+  // nothing was discovered.
+  mmprojFile?: string;
   unlisted?: boolean;
   skip?: boolean;
   slotCache?: boolean; // opt this model into on-disk slot KV persistence (opt-in; needs the global toggle on)


### PR DESCRIPTION
Four related fixes to the model config editor and what it emits.

- A variant can now say "explicitly none" for an inherited string field: empty inherits the model-wide value, `none` forces it off. The launch box also stops lying about `--ctx-checkpoints`, which it rendered but never parsed back.
- New caret placement: creating a variant focuses and selects its name field, so it can be renamed off "variant" immediately.
- `mmprojFile`: a per-model and per-variant explicit vision-projector path. Set it and discovery and family inheritance are both bypassed; set it where discovery found nothing and the model GROWS a `-vision` twin it never had. `mmproj: "none"` still wins, VRAM is priced by stat'ing the named file, and save-time validation rejects anything whose gguf architecture is not `clip`. Automatic discovery is deliberately not widened.
- `-cms` no longer duplicates itself: the box did not parse the flag, so a round trip pushed it into `extraArgs`, which is appended verbatim after the emitter's own copy (one more per trip). Parsed now, hoisted back out of a saved `extraArgs` on both sides, so existing configs self-heal on the next generate.

`genVersion` v59 -> v61.