### PR TITLE
autogen: charge a split gguf the whole set, not shard 1

### DIFF
--- a/internal/autogen/discover.go
+++ b/internal/autogen/discover.go
@@ -48,7 +48,7 @@ type GgufRow struct {
 }
 
 var (
-	shardRe      = regexp.MustCompile(`-(\d{5})-of-\d{5}\.gguf$`)
+	shardRe      = regexp.MustCompile(`-(\d{5})-of-(\d{5})\.gguf$`)
 	ggufSuffixRe = regexp.MustCompile(`(?i)-GGUF$`)
 	// Separate MTP/draft sidecar (e.g. Gemma-4 ships "mtp-gemma-4-12B-it.gguf"
 	// alongside the main model). Loaded via -md + --spec-type draft-mtp, not served alone.
@@ -286,12 +286,13 @@ func DiscoverGgufModels(modelsRoot string, skipPatterns ...string) ([]GgufRow, e
 		}
 
 		rows = append(rows, GgufRow{
-			ID:        idKey,
-			BaseID:    baseKey,
-			FullPath:  path,
-			FileName:  name,
-			Quant:     quant,
-			SizeGB:    round(float64(fi.Size())/gib, 2),
+			ID:       idKey,
+			BaseID:   baseKey,
+			FullPath: path,
+			FileName: name,
+			Quant:    quant,
+			// Split set: the whole set's bytes, not shard 1's. See ggufSetSizeBytes.
+			SizeGB:    round(float64(ggufSetSizeBytes(path, fi.Size()))/gib, 2),
 			Publisher: pubName,
 			Repo:      repoName,
 		})

--- a/internal/autogen/gguf.go
+++ b/internal/autogen/gguf.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -519,6 +520,41 @@ func (r *ggufReader) readIntArray() ([]int64, error) {
 	return out, nil
 }
 
+// ggufSetSizeBytes reports the bytes a gguf really charges: its own size, or the
+// summed size of every shard when path is one file of a split set
+// ("<model>-00001-of-00004.gguf"). llama-server is handed shard 1 and opens the
+// siblings itself, so discovery represents the whole set by that one file - but
+// the weights figure the VRAM sizer charges is the whole set, not the shard.
+// Stat'ing shard 1 alone reported an 80B MoE as a quarter of its real size,
+// which offloaded it whole (-ngl 99, no --n-cpu-moe) and spent the phantom slack
+// on context; on Windows the driver spills the overflow into system RAM rather
+// than failing, so the only symptom was a very slow run.
+//
+// A sibling that cannot be stat'd is skipped rather than fatal: a short total
+// still beats a quarter one, and a truncated set is llama.cpp's error to report.
+func ggufSetSizeBytes(path string, own int64) int64 {
+	loc := shardRe.FindStringSubmatchIndex(path)
+	if loc == nil {
+		return own
+	}
+	idx, errIdx := strconv.Atoi(path[loc[2]:loc[3]])
+	count, errCount := strconv.Atoi(path[loc[4]:loc[5]])
+	if errIdx != nil || errCount != nil || count <= 1 || idx < 1 || idx > count {
+		return own
+	}
+	prefix := path[:loc[0]]
+	total := own
+	for i := 1; i <= count; i++ {
+		if i == idx {
+			continue
+		}
+		if fi, err := os.Stat(fmt.Sprintf("%s-%05d-of-%05d.gguf", prefix, i, count)); err == nil {
+			total += fi.Size()
+		}
+	}
+	return total
+}
+
 // ReadGgufMetadata parses the metadata KV section of a GGUF file. Tensor
 // descriptors are not read, so the work is bounded to the header.
 func ReadGgufMetadata(path string) (Metadata, error) {
@@ -531,7 +567,7 @@ func ReadGgufMetadata(path string) (Metadata, error) {
 		return Metadata{}, err
 	}
 	defer f.Close()
-	return ReadGgufMetadataFrom(f, path, fi.Size())
+	return ReadGgufMetadataFrom(f, path, ggufSetSizeBytes(path, fi.Size()))
 }
 
 // ReadGgufMetadataFrom is ReadGgufMetadata over an already-open source. Callers

--- a/internal/autogen/hash.go
+++ b/internal/autogen/hash.go
@@ -170,7 +170,13 @@ const hashCacheSuffix = ".modelhash"
 //	     was appended AFTER the computed copy (and grew by one per trip). Any
 //	     config carrying one now emits a single -cms, and the hoisted value acts
 //	     as the pin it was meant to be.
-const genVersion = "v61"
+//	v62: a split gguf is charged the whole set's bytes, not shard 1's. Discovery
+//	     represents a set by its first shard (correct: llama-server opens the
+//	     siblings itself), but stat'ing that one file sized an 80B MoE at a
+//	     quarter of itself, so the plan offloaded it whole and spent the phantom
+//	     slack on context. Every split model's -ngl/--n-cpu-moe/-c changes for
+//	     inputs that did not.
+const genVersion = "v62"
 
 // InputsHash digests everything that can change the generated config: the set of
 // gguf files under modelsRoot (path + size + mtime) plus the raw bytes of the

--- a/internal/autogen/metacache.go
+++ b/internal/autogen/metacache.go
@@ -28,6 +28,11 @@ type cachedMeta struct {
 // stale fingerprint it falls back to a full header read via ReadGgufMetadata and
 // caches the result. Safe for concurrent use. When the path can't be stat'd it
 // degrades to an uncached read (ReadGgufMetadata reports the real error).
+//
+// For a split set the fingerprint is shard 1's alone, so replacing only a later
+// shard does not invalidate the entry even though FileSizeGB sums the whole set
+// (ggufSetSizeBytes). Re-quantizing a model rewrites shard 1 too, so the case
+// that matters in practice still invalidates.
 func ReadGgufMetadataCached(path string) (Metadata, error) {
 	key := filepath.ToSlash(path)
 	fi, statErr := os.Stat(path)

--- a/internal/autogen/shardsize_test.go
+++ b/internal/autogen/shardsize_test.go
@@ -1,0 +1,83 @@
+package autogen
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// A split set charges the sum of every shard. Stat'ing the first shard alone
+// told the sizer an 80B MoE was a quarter of its size, so it offloaded the whole
+// model to a 24 GB card and spent the phantom slack on context.
+func TestGgufSetSizeBytes_SumsSiblings(t *testing.T) {
+	dir := t.TempDir()
+	writeStub(t, dir, "Model-Q4_K_XL-00001-of-00004.gguf", 1000)
+	writeStub(t, dir, "Model-Q4_K_XL-00002-of-00004.gguf", 2000)
+	writeStub(t, dir, "Model-Q4_K_XL-00003-of-00004.gguf", 3000)
+	writeStub(t, dir, "Model-Q4_K_XL-00004-of-00004.gguf", 4000)
+
+	first := filepath.Join(dir, "Model-Q4_K_XL-00001-of-00004.gguf")
+	if got := ggufSetSizeBytes(first, 1000); got != 10000 {
+		t.Errorf("first shard: got %d bytes, want 10000 (the whole set)", got)
+	}
+	// Asked about a later shard, the answer is still the set: the caller's own
+	// size is trusted for that shard and the rest are stat'd.
+	third := filepath.Join(dir, "Model-Q4_K_XL-00003-of-00004.gguf")
+	if got := ggufSetSizeBytes(third, 3000); got != 10000 {
+		t.Errorf("third shard: got %d bytes, want 10000", got)
+	}
+}
+
+// A missing sibling is skipped, not fatal: a short total still beats a quarter
+// one, and a truncated set is llama.cpp's error to report.
+func TestGgufSetSizeBytes_MissingSiblingSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeStub(t, dir, "Model-00001-of-00003.gguf", 1000)
+	writeStub(t, dir, "Model-00003-of-00003.gguf", 3000)
+
+	first := filepath.Join(dir, "Model-00001-of-00003.gguf")
+	if got := ggufSetSizeBytes(first, 1000); got != 4000 {
+		t.Errorf("got %d bytes, want 4000 (shard 2 absent)", got)
+	}
+}
+
+// An unsharded gguf keeps its own size, and a name that only looks shard-ish is
+// not treated as a set.
+func TestGgufSetSizeBytes_Unsharded(t *testing.T) {
+	dir := t.TempDir()
+	writeStub(t, dir, "Model-Q4_K_M.gguf", 1000)
+
+	cases := []string{
+		filepath.Join(dir, "Model-Q4_K_M.gguf"),
+		filepath.Join(dir, "Model-001-of-004.gguf"), // not the 5-digit split form
+		filepath.Join(dir, "Model-00001-of-00001.gguf"),
+	}
+	for _, p := range cases {
+		if got := ggufSetSizeBytes(p, 1000); got != 1000 {
+			t.Errorf("%s: got %d bytes, want the file's own 1000", filepath.Base(p), got)
+		}
+	}
+}
+
+// End to end: discovery collapses a split set to shard 1 but must report the
+// whole set's size on the row, since every sizing path charges it as weights.
+func TestDiscoverGgufModels_SplitSetChargesWholeSet(t *testing.T) {
+	dir := t.TempDir()
+	writeStub(t, dir, "Big-MoE-Q4_K_XL-00001-of-00004.gguf", 10_000_000)
+	writeStub(t, dir, "Big-MoE-Q4_K_XL-00002-of-00004.gguf", 20_000_000)
+	writeStub(t, dir, "Big-MoE-Q4_K_XL-00003-of-00004.gguf", 20_000_000)
+	writeStub(t, dir, "Big-MoE-Q4_K_XL-00004-of-00004.gguf", 20_000_000)
+
+	rows, err := DiscoverGgufModels(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 served row (a split set is one model), got %d", len(rows))
+	}
+	if want := round(float64(70_000_000)/gib, 2); rows[0].SizeGB != want {
+		t.Errorf("SizeGB=%v, want %v (all four shards)", rows[0].SizeGB, want)
+	}
+	if filepath.Base(rows[0].FullPath) != "Big-MoE-Q4_K_XL-00001-of-00004.gguf" {
+		t.Errorf("FullPath=%q, want the real first shard", rows[0].FullPath)
+	}
+}


### PR DESCRIPTION
Discovery represents a split set (`<model>-00001-of-00004.gguf`) by its first shard, which is right for llama-server since it opens the siblings itself. But the size charged as weights came from stat'ing that one file, so an 80B MoE in four shards was sized as a quarter of itself: it fit the card, so the plan offloaded it whole (`-ngl 99`, no `--n-cpu-moe`) and spent the phantom slack on a 262k context. On Windows the driver spills the overflow into system RAM instead of failing the allocation, so the only symptom was a very slow run.

- `ggufSetSizeBytes` sums the shards; `ReadGgufMetadata` feeds it `FileSizeGB`, so every disk-backed sizing path is fixed at once
- `GgufRow.SizeGB` reports the set too: image/embedding/tts/vllm and the setup disk probe charge it directly
- a missing sibling is skipped rather than fatal, and the metadata cache's shard-1 fingerprint is documented
- `genVersion` v62, since the emitted argv changes for inputs that did not

Verified on a real four-way split made with `llama-gguf-split`: charged 0.232 GB before, 0.876 GB after, matching the unsplit original exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)