### PR TITLE
autogen: measure the VRAM/RAM budgets instead of shipping a 7/24 default

### DIFF
--- a/internal/autogen/examplebudgets_test.go
+++ b/internal/autogen/examplebudgets_test.go
@@ -1,0 +1,38 @@
+package autogen
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The shipped example is what package-windows seeds a runtime generate file
+// from and what the setup wizard copies, so a literal budget in it is not
+// documentation: it is the value every install starts with. It also DISABLES
+// the measurement, because seedHardwareBudgets only fills a knob that is still
+// zero (overrides.go) - a written 7 is indistinguishable from a user who chose
+// 7. That shipped pair is how a 16 GB card ended up budgeted at 7 GB, and a
+// 16 GB box at a 24 GB RAM ceiling it could never honour. Both knobs must stay
+// commented out; pin one only by editing this test too.
+func TestExampleGenerate_LeavesBudgetsUnset(t *testing.T) {
+	raw, err := os.ReadFile("../../quartermaster-generate.example.yaml")
+	if err != nil {
+		t.Fatalf("read example: %v", err)
+	}
+	var gf struct {
+		Settings struct {
+			TargetVramGB float64 `yaml:"targetVramGB"`
+			MaxRamGB     float64 `yaml:"maxRamGB"`
+		} `yaml:"settings"`
+	}
+	if err := yaml.Unmarshal(raw, &gf); err != nil {
+		t.Fatalf("parse example: %v", err)
+	}
+	if gf.Settings.TargetVramGB != 0 {
+		t.Errorf("example pins targetVramGB=%v; leave it commented out so the box is measured", gf.Settings.TargetVramGB)
+	}
+	if gf.Settings.MaxRamGB != 0 {
+		t.Errorf("example pins maxRamGB=%v; leave it commented out so the box is measured", gf.Settings.MaxRamGB)
+	}
+}

--- a/internal/setup/run.go
+++ b/internal/setup/run.go
@@ -152,16 +152,19 @@ func ensureGenerate(path string) (created bool, err error) {
 }
 
 // seedBudgets writes this machine's measured VRAM/RAM budgets into a
-// just-created generate file. Every failure is a warning: an unmeasurable box
-// (no GPU telemetry, a locked-down OS) still gets a working install on the
-// built-in placeholders, and the Settings page can fix either number in a click.
+// just-created generate file. Every failure is a warning, and a soft one now
+// that the example file ships both knobs commented out: a box that cannot be
+// measured here leaves them unset, which is what makes the runtime probe
+// (seedHardwareBudgets) measure them again on every startup. Writing them into
+// the file is still worth doing, so the numbers are visible where the user
+// edits them and so a later boot with a busy GPU cannot shrink the budget.
 func (w *Wizard) seedBudgets(genPath string) {
 	if gb, ok := autogen.RecommendedVramGB(); ok {
 		if err := setSettingsKey(genPath, "targetVramGB", formatGB(gb)); err != nil {
 			w.warn(fmt.Sprintf("could not set targetVramGB: %v", err))
 		}
 	} else {
-		w.warn("no GPU reading; keeping the built-in VRAM budget (set it in Settings)")
+		w.warn("no GPU reading; the VRAM budget will be measured at startup instead (or set it in Settings)")
 	}
 	if gb, ok := autogen.RecommendedRamGB(); ok {
 		if err := setSettingsKey(genPath, "maxRamGB", formatGB(gb)); err != nil {

--- a/quartermaster-generate.example.yaml
+++ b/quartermaster-generate.example.yaml
@@ -12,11 +12,13 @@ settings:
   # Path to llama.cpp's llama-server executable.
   serverExe: llama-server
   # targetVramGB: the VRAM a model's whole footprint (weights + KV + compute
-  # buffers + overhead) must fit under. The setup wizard MEASURES this on first
-  # run and rewrites the line below with your card's free VRAM; delete the line
-  # entirely and it is re-measured at every startup instead. The value here is
-  # only the fallback for a box with no GPU telemetry.
-  targetVramGB: 7
+  # buffers + overhead) must fit under. Left UNSET on purpose: with no value
+  # here the budget is measured from your card's free VRAM, by the setup wizard
+  # on first run and at every startup otherwise, so a card of any size is used
+  # in full. Uncomment it only to pin a ceiling BELOW what the card has - a
+  # number written here is read as your deliberate choice and is never
+  # re-measured behind your back.
+  # targetVramGB: 7
   # autoVram: measure free VRAM at startup and cap targetVramGB at it. The
   # reading is used in full - vramOverheadGB is charged inside the plan, not
   # deducted again here. Only ever tightens: a smaller static targetVramGB above
@@ -28,9 +30,12 @@ settings:
   # VRAM, so this does NOT need to reserve room for the OS — keep it small.
   vramOverheadGB: 0.5
   # maxRamGB: the RAM ceiling a plan may spill CPU-offloaded weights and KV into.
-  # Measured and rewritten by the setup wizard the same way as targetVramGB, from
-  # the memory actually available on this machine.
-  maxRamGB: 24
+  # Unset and measured exactly like targetVramGB above, from the memory actually
+  # available on this machine. A shipped 24 was worse than no value at all on a
+  # 16 GB box: a ceiling the machine cannot honour never binds, so the guard that
+  # is supposed to stop a plan from swapping stopped nothing. Uncomment only to
+  # pin a lower ceiling.
+  # maxRamGB: 24
   moeCtxTarget: 65536
   # denseCtxLadder: the TOP rung is the context ceiling the sizer may grow a dense
   # model to; within it the largest window whose KV cache fits the VRAM budget


### PR DESCRIPTION
Reported: a 16 GB card was budgeted at 7 GB by default, instead of the ~15 GB the probe would have measured.

The example generate file carried `targetVramGB: 7` and `maxRamGB: 24`, the author's old desktop written down, and `package-windows` seeds a runtime generate file straight from it. Those literals do not just start every install on the wrong number, they DISABLE the measurement built to replace them: `seedHardwareBudgets` only fills a knob still equal to zero (`overrides.go:1018`), so a written 7 is indistinguishable from a user who deliberately chose 7. The 16 GB box was therefore given a 24 GB RAM ceiling it cannot honour, which means the guard meant to stop a plan from swapping never bound anything.

The wizard's own seeding only covered a first install that could read the GPU right then. The zip bundle, an upgrade over an existing config, and a box whose driver was not ready all fell through to the shipped literals.

- comment both knobs out in the example, so an unseeded install lands on 0 and is measured at every startup until someone pins a value on purpose
- correct the wizard warning: with the knob unset, an unmeasurable install now gets measured at startup rather than keeping a placeholder
- guard it with a test that parses the shipped example, since nothing else would catch a literal creeping back in