### PR TITLE
autogen: re-measure the budgets on installs that shipped 7/24

### DIFF
--- a/internal/autogen/hash.go
+++ b/internal/autogen/hash.go
@@ -176,7 +176,7 @@ const hashCacheSuffix = ".modelhash"
 //	     quarter of itself, so the plan offloaded it whole and spent the phantom
 //	     slack on context. Every split model's -ngl/--n-cpu-moe/-c changes for
 //	     inputs that did not.
-const genVersion = "v62"
+const genVersion = "v63"
 
 // InputsHash digests everything that can change the generated config: the set of
 // gguf files under modelsRoot (path + size + mtime) plus the raw bytes of the

--- a/internal/autogen/legacybudgets_test.go
+++ b/internal/autogen/legacybudgets_test.go
@@ -1,0 +1,30 @@
+package autogen
+
+import "testing"
+
+// The pre-1.0.4 example shipped targetVramGB: 7 / maxRamGB: 24 as literals, so
+// every install made before that carries them whether or not anyone chose them.
+// LoadGenerateFile reads exactly that pair as "unset" and measures the box
+// instead; anything else is a number somebody typed and is left alone.
+func TestIsShippedLegacyBudgets(t *testing.T) {
+	cases := []struct {
+		name string
+		vram float64
+		ram  float64
+		want bool
+	}{
+		{"the shipped pair", 7, 24, true},
+		{"unset (a post-fix file)", 0, 0, false},
+		{"vram tuned, ram still shipped", 12, 24, false},
+		{"ram tuned, vram still shipped", 7, 64, false},
+		{"both tuned", 15.9, 110, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := isShippedLegacyBudgets(Settings{TargetVramGB: c.vram, MaxRamGB: c.ram})
+			if got != c.want {
+				t.Errorf("isShippedLegacyBudgets(vram=%v, ram=%v) = %v, want %v", c.vram, c.ram, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/autogen/overrides.go
+++ b/internal/autogen/overrides.go
@@ -926,7 +926,7 @@ func (s *Settings) applyDefaults() {
 	// reading — deliberately small, because the cost of guessing low is a model
 	// sized conservatively and the cost of guessing high is a load that OOMs.
 	if s.TargetVramGB == 0 {
-		s.TargetVramGB = 7
+		s.TargetVramGB = fallbackVramGB
 	}
 	// vramOverheadGB is pure allocator slack: targetVramGB is already the free
 	// VRAM, so the desktop's own usage is outside the budget rather than
@@ -960,7 +960,7 @@ func (s *Settings) applyDefaults() {
 		s.VisionCtx = 8192
 	}
 	if s.MaxRamGB == 0 {
-		s.MaxRamGB = 24 // placeholder; see TargetVramGB above
+		s.MaxRamGB = fallbackRamGB // placeholder; see TargetVramGB above
 	}
 	if s.MoeCtxTarget == 0 {
 		s.MoeCtxTarget = 65536
@@ -1000,6 +1000,30 @@ func (s *Settings) applyDefaults() {
 	}
 }
 
+// fallbackVramGB / fallbackRamGB are the last-resort budgets applyDefaults
+// writes when nothing measured the box, and (because the pre-1.0.4 example
+// shipped them as literals) also the fingerprint isShippedLegacyBudgets looks
+// for. Changing either number changes what counts as an untouched file, so the
+// two uses have to move together.
+const (
+	fallbackVramGB = 7.0
+	fallbackRamGB  = 24.0
+)
+
+// isShippedLegacyBudgets reports whether a generate file carries EXACTLY the
+// budget pair the pre-1.0.4 example shipped, which is the fingerprint of a file
+// nobody has tuned rather than a decision anyone made.
+//
+// Both must match. The example always wrote the two together, so a file that
+// agrees on one and not the other has been edited by hand, and a hand-edited
+// number is the user's. That is also the escape hatch for a box where 7/24
+// happens to be right: change either value, or set it in Settings (which pins
+// it in the sidecar, checked separately below). The alternative to a rule this
+// blunt is leaving every existing install on a budget measured from nothing.
+func isShippedLegacyBudgets(s Settings) bool {
+	return s.TargetVramGB == fallbackVramGB && s.MaxRamGB == fallbackRamGB
+}
+
 // LoadGenerateFile reads and validates an autogen control file. Settings
 // defaults are applied. modelsDirOverride (from --models-dir) wins over the
 // file's modelsRoot when non-empty.
@@ -1016,6 +1040,17 @@ func LoadGenerateFile(path, modelsDirOverride string) (GenerateFile, error) {
 	// applyDefaults writes its placeholders over the zero values, so
 	// seedHardwareBudgets below can tell an unset knob from a deliberate one.
 	vramUnset, ramUnset := gf.Settings.TargetVramGB == 0, gf.Settings.MaxRamGB == 0
+	// ... and treat the pair the OLD example shipped as saying nothing either.
+	// Commenting the knobs out of the example fixed the file a NEW install
+	// writes, and nothing else: the installer preserves config/ on purpose and
+	// the in-app updater only swaps the binary, so every install made before
+	// that change still carries a literal 7/24 that the probe below then
+	// correctly declines to overwrite. Left alone, the one machine the numbers
+	// were ever right for is the author's, and everyone else stays pinned to a
+	// budget nothing measured.
+	if isShippedLegacyBudgets(gf.Settings) {
+		vramUnset, ramUnset = true, true
+	}
 	// Overlay UI-owned backend-exe paths BEFORE applyDefaults so an empty
 	// sd/tts-server derives as a sibling of the (possibly UI-set) llama exe.
 	be, err := LoadSidecarBackends(path)


### PR DESCRIPTION
Commenting the budget knobs out of the example (#19) only fixed the file a **new** install writes. The installer preserves `config/` and the in-app updater swaps only the binary, so every install made before that still carries a literal `targetVramGB: 7` / `maxRamGB: 24`, which the runtime probe then correctly declines to overwrite as a deliberate choice. Reproduced on a 24 GB box: reinstalled, still 7.

`LoadGenerateFile` now reads exactly that pair as "the file said nothing" and measures the box. Both values must match: a file that agrees on one and not the other has been hand-edited, and a hand-edited number is the user's. A value set in Settings pins it in the sidecar and is unaffected either way.

- `isShippedLegacyBudgets` + `fallbackVramGB`/`fallbackRamGB` constants
- `genVersion` v62 -> v63, so the stale `config.yaml` is regenerated against the measured budget instead of surviving on an unchanged inputs hash