### PR TITLE
autogen: close the gap between estimated and measured VRAM

### DIFF
--- a/internal/autogen/cmdknobs_test.go
+++ b/internal/autogen/cmdknobs_test.go
@@ -245,9 +245,10 @@ func TestDraftOverheadGB_kindGate(t *testing.T) {
 	const dflashGB = 1.06
 	mtpSpec := "draft-mtp+ngram-mod"
 
-	// DFlash sidecar in the dir, running on the baked-in MTP head -> flat 0.34.
-	if got := draftOverheadGB(mtpSpec, matchedDraftSizeGB(mtpSpec, "dflash", dflashGB)); got != 0.34 {
-		t.Fatalf("draft-mtp with a dflash sidecar charged %.2f GB, want the baked-in 0.34", got)
+	// DFlash sidecar in the dir, running on the baked-in MTP head -> the baked-in
+	// compute pad only (its KV is ctx-scaled by mtpDraftSlopeFor, not charged here).
+	if got := draftOverheadGB(mtpSpec, matchedDraftSizeGB(mtpSpec, "dflash", dflashGB)); got != mtpDraftPadGB {
+		t.Fatalf("draft-mtp with a dflash sidecar charged %.2f GB, want the baked-in pad %.2f", got, mtpDraftPadGB)
 	}
 	// Explicitly selected: the drafter really loads, charge its weights + pad.
 	if got := draftOverheadGB("draft-dflash", matchedDraftSizeGB("draft-dflash", "dflash", dflashGB)); math.Abs(got-(dflashGB+0.1)) > 1e-9 {

--- a/internal/autogen/engineknobs_test.go
+++ b/internal/autogen/engineknobs_test.go
@@ -139,7 +139,7 @@ func TestEmitProfile_AdvancedKnobs(t *testing.T) {
 	// Unset: none of the advanced flags appear.
 	var def strings.Builder
 	emitProfile(&def, s, meta, row, profile{Name: "foo"}, 8192, 10, 0, LoadPlan{}, "q8_0", "q8_0", false, &Override{})
-	for _, unwanted := range []string{"-tb ", "--prio", "-dio", "--no-op-offload", "--no-repack", "--cache-reuse", "-cram", "--cache-idle-slots", "--swa-full", "--context-shift", "--spec-draft-n-min", "-sps", "--rope-scaling", "-sm ", "-ts ", "-mg ", "-ot "} {
+	for _, unwanted := range []string{"-tb ", "--prio", "-dio", "--no-op-offload", "--no-repack", "--cache-reuse", "-lv ", "-cram", "--cache-idle-slots", "--swa-full", "--context-shift", "--spec-draft-n-min", "-sps", "--rope-scaling", "-sm ", "-ts ", "-mg ", "-ot "} {
 		if strings.Contains(def.String(), unwanted) {
 			t.Errorf("unexpected %q emitted for a blank override:\n%s", unwanted, def.String())
 		}
@@ -154,7 +154,7 @@ func TestEmitProfile_AdvancedKnobs(t *testing.T) {
 	// Set: each flag renders.
 	ov := &Override{
 		ThreadsBatch: 12, Prio: 2, DirectIo: true, NoOpOffload: true, NoRepack: true,
-		CacheReuse: 256, CacheRamMB: 4096, CacheIdleSlots: "off", SwaFull: true,
+		CacheReuse: 256, LogVerbosity: 5, CacheRamMB: 4096, CacheIdleSlots: "off", SwaFull: true,
 		CheckpointMinStep: 2048, ContextShift: "on", SpecDraftNMin: 1, SlotPromptSimilarity: 0.5,
 		RopeScaling: "yarn", RopeScale: 2, RopeFreqBase: 1000000, YarnOrigCtx: 4096,
 		SplitMode: "row", TensorSplit: "3,1", MainGpu: 1, OverrideTensor: "exps=CPU",
@@ -162,7 +162,7 @@ func TestEmitProfile_AdvancedKnobs(t *testing.T) {
 	var on strings.Builder
 	emitProfile(&on, s, meta, row, profile{Name: "foo"}, 8192, 10, 0, LoadPlan{}, "q8_0", "q8_0", false, ov)
 	out := on.String()
-	for _, want := range []string{"-tb 12", "--prio 2", "--no-op-offload", "--no-repack", "--cache-reuse 256", "--load-mode dio", "-cram 4096", "--no-cache-idle-slots", "--swa-full", "-cms 2048", "--context-shift", "--spec-draft-n-min 1", "-sps 0.5", "--rope-scaling yarn", "--rope-scale 2", "--rope-freq-base 1e+06", "--yarn-orig-ctx 4096", "-sm row", "-ts 3,1", "-mg 1", "-ot exps=CPU"} {
+	for _, want := range []string{"-tb 12", "--prio 2", "--no-op-offload", "--no-repack", "--cache-reuse 256", "-lv 5", "--load-mode dio", "-cram 4096", "--no-cache-idle-slots", "--swa-full", "-cms 2048", "--context-shift", "--spec-draft-n-min 1", "-sps 0.5", "--rope-scaling yarn", "--rope-scale 2", "--rope-freq-base 1e+06", "--yarn-orig-ctx 4096", "-sm row", "-ts 3,1", "-mg 1", "-ot exps=CPU"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q in emit:\n%s", want, out)
 		}

--- a/internal/autogen/engineknobs_test.go
+++ b/internal/autogen/engineknobs_test.go
@@ -59,11 +59,18 @@ func TestComputeBufferGB(t *testing.T) {
 		t.Errorf("missing dims: got %.3f, want fallback %.3f", fb, computeFallbackGB)
 	}
 
-	// Non-CUDA GPU (Vulkan/ROCm) drops the fixed CUDA-context constant.
+	// A non-CUDA GPU (Vulkan/ROCm) swaps the runtime constant rather than
+	// dropping it: measured per-process, the HIP runtime reserves MORE than the
+	// CUDA one, so charging 0 there under-committed by ~0.4 GB per model.
 	cudaGPU.Store(false)
 	defer cudaGPU.Store(true)
-	if d := got - computeBufferGB(meta, 1024, 1.0); d < computeCudaCtxGB-0.001 || d > computeCudaCtxGB+0.001 {
-		t.Errorf("non-CUDA should drop the %.2f CUDA-ctx constant, dropped %.3f", computeCudaCtxGB, d)
+	want := computeHipCtxGB - computeCudaCtxGB
+	if d := computeBufferGB(meta, 1024, 1.0) - got; math.Abs(d-want) > 0.001 {
+		t.Errorf("non-CUDA should swap in the %.2f HIP-ctx constant (delta %+.2f), got %+.3f", computeHipCtxGB, want, d)
+	}
+	// The fallback is a whole-buffer figure, so it must not move with the backend.
+	if fb := computeBufferGB(Metadata{}, 1024, 1.0); fb != computeFallbackGB {
+		t.Errorf("non-CUDA fallback: got %.3f, want %.3f", fb, computeFallbackGB)
 	}
 }
 

--- a/internal/autogen/estimate.go
+++ b/internal/autogen/estimate.go
@@ -56,14 +56,16 @@ type EstimateResult struct {
 	// from model weights).
 	CheckpointGB float64 `json:"checkpointGB"`
 	// DraftGB is the VRAM charged for the speculative draft / MTP nextn layer: a
-	// baked-in nextn head costs its compute pad plus its OWN ctx-scaled KV cache
-	// (a second llama_context over the same model at the same window), a separate
-	// draft gguf its weights + pad. Folded into
+	// baked-in nextn head costs its compute pad, its own compute GRAPH and its
+	// OWN ctx-scaled KV cache (a second llama_context over the same model at the
+	// same window), a separate draft gguf its weights + pad. Folded into
 	// EstVramGB via overhead; broken out so the UI can attribute it separately
 	// from the main model weights. 0 when no draft-mtp spec is active.
 	DraftGB float64 `json:"draftGB"`
-	// ComputeBufGB is the GPU compute buffer (logits + activations + the CUDA
-	// context constant when a CUDA GPU is in use). MmprojGB is a "-vision" twin's
+	// ComputeBufGB is the GPU compute buffer: the main context's graph (logits +
+	// activations) plus the fixed per-process runtime constant for the backend in
+	// use (see runtimeCtxGB). A baked-in MTP drafter's own graph is NOT in here,
+	// it is charged to DraftGB. MmprojGB is a "-vision" twin's
 	// projector weights + CLIP reserve (0 for non-vision). OverheadGB is the global
 	// vramOverheadGB safety headroom. All three are folded into EstVramGB via
 	// overhead; broken out so the UI can label them separately from the model
@@ -148,8 +150,13 @@ func EstimatePlan(s Settings, meta Metadata, in EstimateInput) (EstimateResult, 
 	// Charge the ub the launch will actually run with: effectiveUb reads the
 	// override's pinned value, and passing nil here made the preview size a
 	// different compute buffer than emit did for the same model.
-	computeBufGB := computeBufferGB(meta, effectiveUb(meta, prof, &Override{Ub: in.Ub}, prof.Ctx, target), s.ComputeBufFactor)
-	prof.Overhead += computeBufGB
+	computeUb := effectiveUb(meta, prof, &Override{Ub: in.Ub}, prof.Ctx, target)
+	computeBufGB := computeBufferGB(meta, computeUb, s.ComputeBufFactor)
+	// The baked-in drafter's second context allocates a graph of its own at the
+	// same ub. It is reported under Draft rather than folded into the compute
+	// buffer, so the UI keeps attributing it to the thing that caused it.
+	draftComputeGB := mtpDraftComputeGB(meta, spec, draftGB, computeUb, s.ComputeBufFactor)
+	prof.Overhead += computeBufGB + draftComputeGB
 	prof.Overhead += in.MmprojGB // "-vision" projector weights + CLIP compute reserve
 
 	ctx, plan, kvReserve, planCkptGB, err := sizeProfile(meta, s, prof, perTokGB, kvConstGB, modelMax, in.KvInRam)
@@ -213,7 +220,7 @@ func EstimatePlan(s Settings, meta Metadata, in EstimateInput) (EstimateResult, 
 		MaxRamGB:     s.MaxRamGB,
 		KvReserveGB:  kvReserve,
 		CheckpointGB: checkpointGB,
-		DraftGB:      specOh + draftKvGB,
+		DraftGB:      specOh + draftComputeGB + draftKvGB,
 		ComputeBufGB: computeBufGB,
 		MmprojGB:     in.MmprojGB,
 		OverheadGB:   s.VramOverheadGB,

--- a/internal/autogen/estimate.go
+++ b/internal/autogen/estimate.go
@@ -29,6 +29,12 @@ type EstimateInput struct {
 	// per-model Override.Ub charged a buffer the real launch never has. 0 => the
 	// same auto pick emit makes (effectiveUb).
 	Ub int
+	// KvKDraft/KvVDraft pin the draft context's cache type (-ctkd/-ctvd). Empty
+	// means "whatever the emitter would default to", i.e. the main K/V quant. A
+	// caller reconstructing a HAND-WRITTEN argv that carries -ctk but no -ctkd
+	// must pass "f16" explicitly, because that is what llama uses there.
+	KvKDraft string
+	KvVDraft string
 	// DraftKind is the paired draft sidecar's kind ("mtp"/"dflash", "" for none),
 	// as DraftSidecarForDir reports it. Only consulted when Spec is empty, to
 	// resolve the same auto spec the emitter picks — see EstimatePlan.
@@ -49,8 +55,10 @@ type EstimateResult struct {
 	// EstVramGB via overhead, broken out so the UI can attribute it separately
 	// from model weights).
 	CheckpointGB float64 `json:"checkpointGB"`
-	// DraftGB is the VRAM charged for the speculative draft / MTP nextn layer
-	// (baked-in ~0.34 GB or a separate draft gguf's weights + pad). Folded into
+	// DraftGB is the VRAM charged for the speculative draft / MTP nextn layer: a
+	// baked-in nextn head costs its compute pad plus its OWN ctx-scaled KV cache
+	// (a second llama_context over the same model at the same window), a separate
+	// draft gguf its weights + pad. Folded into
 	// EstVramGB via overhead; broken out so the UI can attribute it separately
 	// from the main model weights. 0 when no draft-mtp spec is active.
 	DraftGB float64 `json:"draftGB"`
@@ -77,9 +85,9 @@ func EstimatePlan(s Settings, meta Metadata, in EstimateInput) (EstimateResult, 
 	// the preview's KV reserve matches what a save would emit.
 	// An empty spec means AUTO, not "no drafter" — the emitter runs every model
 	// through effectiveSpec, which hands an MTP-capable gguf draft-mtp+ngram-mod
-	// and charges its 0.34 GB (or the sidecar's real weights). The preview used to
-	// read "" as no spec and charge 0, so a model left on auto spec previewed
-	// 0.34 GB lighter than it bakes. On a tight budget that is the whole margin:
+	// and charges its drafter (the pad plus its ctx-scaled KV, or the sidecar's
+	// real weights). The preview used to read "" as no spec and charge 0, so a
+	// model left on auto spec previewed a whole drafter lighter than it bakes. On a tight budget that is the whole margin:
 	// Qwen3.8-27B at 106k previewed -ngl 99 / 0 GB RAM and emitted -ngl 64 / 0.32.
 	spec := in.Spec
 	if spec == "" {
@@ -112,11 +120,16 @@ func EstimatePlan(s Settings, meta Metadata, in EstimateInput) (EstimateResult, 
 		target = in.TargetVramGB
 	}
 
-	// Draft overhead: baked-in MTP nextn layer ~0.34 GB (KV+compute). A separate
-	// draft file (Gemma-4's MTP sidecar, or any DFlash drafter — always separate)
-	// instead charges its real on-disk weights + a small KV/compute pad, so big
-	// drafts scale up rather than under-counting at 0.34.
+	// Draft overhead: a baked-in MTP nextn layer costs its compute pad here. A
+	// separate draft file (Gemma-4's MTP sidecar, or any DFlash drafter, always
+	// separate) instead charges its real on-disk weights + a small KV/compute pad,
+	// so big drafts scale up rather than under-counting.
 	specOh := draftOverheadGB(spec, draftGB)
+	// ...plus, for a baked-in nextn head, its own KV over the whole window. That
+	// part is a slope, so it has to reach the sizer as one: charging it as flat
+	// overhead would price it at a ctx the sizer had not picked yet.
+	dKvK, dKvV := draftKvPair(in.KvKDraft, in.KvVDraft, kvK, kvV)
+	draftSlopeGB := mtpDraftSlopeFor(meta, spec, dKvK, dKvV, draftGB)
 
 	prof := profile{
 		Name:     "estimate",
@@ -130,6 +143,7 @@ func EstimatePlan(s Settings, meta Metadata, in EstimateInput) (EstimateResult, 
 
 		CtxCheckpoints:    in.CtxCheckpoints,
 		CheckpointMinStep: in.CheckpointMinStep,
+		DraftSlopeGB:      draftSlopeGB,
 	}
 	// Charge the ub the launch will actually run with: effectiveUb reads the
 	// override's pinned value, and passing nil here made the preview size a
@@ -177,6 +191,18 @@ func EstimatePlan(s Settings, meta Metadata, in EstimateInput) (EstimateResult, 
 		checkpointGB *= gpuFrac
 	}
 
+	// sizeProfile folds the drafter's KV into kvReserve (it sizes against the
+	// combined slope). Split it back out so the UI's KV segment stays the main
+	// cache and the Draft segment shows what the drafter actually costs.
+	// KV-in-RAM is the exception: that branch sizes against the main slope alone
+	// (the reserve it reports is a flat RAM-side placeholder), so there is
+	// nothing folded in to take back out.
+	draftKvGB := 0.0
+	if !in.KvInRam {
+		draftKvGB = min(draftSlopeGB*float64(ctx), kvReserve)
+		kvReserve -= draftKvGB
+	}
+
 	return EstimateResult{
 		Ctx:          ctx,
 		Ngl:          ngl,
@@ -187,7 +213,7 @@ func EstimatePlan(s Settings, meta Metadata, in EstimateInput) (EstimateResult, 
 		MaxRamGB:     s.MaxRamGB,
 		KvReserveGB:  kvReserve,
 		CheckpointGB: checkpointGB,
-		DraftGB:      specOh,
+		DraftGB:      specOh + draftKvGB,
 		ComputeBufGB: computeBufGB,
 		MmprojGB:     in.MmprojGB,
 		OverheadGB:   s.VramOverheadGB,

--- a/internal/autogen/generate.go
+++ b/internal/autogen/generate.go
@@ -54,6 +54,12 @@ type profile struct {
 	// prompt-prefix checkpoint cache). nil => inherit the model-wide value, else
 	// the llama-server default (32). See effectiveCtxCheckpoints.
 	CtxCheckpoints *int
+	// DraftSlopeGB is the per-token VRAM (GB) the baked-in MTP drafter's own KV
+	// cache adds on top of the main model's, at this profile's draft KV quant.
+	// See mtpDraftSlopeGB: the drafter is a second llama_context over the same
+	// model at the SAME n_ctx, so its cost scales with the window and has to be
+	// part of the slope the sizer solves ctx against, not a flat overhead.
+	DraftSlopeGB float64
 	// CheckpointMinStep, when > 0, is the resolved -cms (checkpoint spacing in
 	// prompt tokens) for this profile. 0 => the arch default from
 	// defaultCheckpointMinStep. Both the emitted flag and the VRAM reserve read
@@ -507,6 +513,21 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 		if pSlots > 1 {
 			ptg *= float64(pSlots)
 			kcg *= float64(pSlots)
+		}
+
+		// A baked-in MTP head runs as a second context over the same model at the
+		// same window, so its KV is a per-token cost on top of ptg, not a flat
+		// overhead (draftOverheadGB now only charges its compute pad). Resolve it
+		// per profile: a variant can carry its own spec chain and its own kv quant,
+		// and -ctkd follows the effective main quant.
+		pspec := modelSpec
+		if prof.Spec != "" {
+			pspec = prof.Spec
+		}
+		pdKvK, pdKvV := draftKvPair(override.KvKDraft, override.KvVDraft, ekvK, ekvV)
+		prof.DraftSlopeGB = mtpDraftSlopeFor(meta, pspec, pdKvK, pdKvV, matchedDraftSizeGB(pspec, row.DraftKind, row.DraftSizeGB))
+		if pSlots > 1 {
+			prof.DraftSlopeGB *= float64(pSlots)
 		}
 
 		ctx, plan, kvReserve, planCkptGB, err := sizeProfile(meta, s, prof, ptg, kcg, pModelMax, pkvInRam)

--- a/internal/autogen/generate.go
+++ b/internal/autogen/generate.go
@@ -459,12 +459,20 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 		}
 	}
 
-	// Charge the GPU compute buffer (logits + activations + CUDA runtime) per
-	// profile; it scales with the physical batch and lives on the GPU regardless
-	// of CPU expert offload, so it's flat VRAM overhead. Replaces the old flat
-	// 0.17 GB ubSoloOh fudge.
+	// Charge the GPU compute buffer (logits + activations + the GPU runtime
+	// constant) per profile; it scales with the physical batch and lives on the
+	// GPU regardless of CPU expert offload, so it's flat VRAM overhead. Replaces
+	// the old flat 0.17 GB ubSoloOh fudge. A baked-in MTP drafter runs a second
+	// llama_context and is charged its own graph on top, at the same ub.
 	for i := range profiles {
-		profiles[i].Overhead += computeBufferGB(meta, effectiveUb(meta, profiles[i], ov, profiles[i].Ctx, s.TargetVramGB), s.ComputeBufFactor)
+		ub := effectiveUb(meta, profiles[i], ov, profiles[i].Ctx, s.TargetVramGB)
+		pspec := modelSpec
+		if profiles[i].Spec != "" {
+			pspec = profiles[i].Spec
+		}
+		pDraftGB := matchedDraftSizeGB(pspec, row.DraftKind, row.DraftSizeGB)
+		profiles[i].Overhead += computeBufferGB(meta, ub, s.ComputeBufFactor) +
+			mtpDraftComputeGB(meta, pspec, pDraftGB, ub, s.ComputeBufFactor)
 	}
 
 	for _, prof := range profiles {

--- a/internal/autogen/generate_cmd.go
+++ b/internal/autogen/generate_cmd.go
@@ -707,7 +707,11 @@ func RenderSoloCmd(s Settings, meta Metadata, row GgufRow, ov Override) (string,
 
 		CheckpointMinStep: ov.CheckpointMinStep,
 	}
-	prof.Overhead += computeBufferGB(meta, effectiveUb(meta, prof, &ov, prof.Ctx, s.TargetVramGB), s.ComputeBufFactor)
+	soloUb := effectiveUb(meta, prof, &ov, prof.Ctx, s.TargetVramGB)
+	// ...plus the second llama_context a baked-in MTP drafter runs, which
+	// allocates a graph of its own at that same ub (see mtpDraftComputeGB).
+	prof.Overhead += computeBufferGB(meta, soloUb, s.ComputeBufFactor) +
+		mtpDraftComputeGB(meta, soloSpec, soloDraftGB, soloUb, s.ComputeBufFactor)
 	// The baked-in MTP drafter's own KV scales with the window, so it belongs in
 	// the slope the sizer solves ctx against (see mtpDraftSlopeFor).
 	sdKvK, sdKvV := draftKvPair(ov.KvKDraft, ov.KvVDraft, kvK, kvV)

--- a/internal/autogen/generate_cmd.go
+++ b/internal/autogen/generate_cmd.go
@@ -537,6 +537,9 @@ func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ng
 		if ov.CacheRamMB > 0 {
 			lines = append(lines, fmt.Sprintf("-cram %d", ov.CacheRamMB))
 		}
+		if ov.LogVerbosity > 0 {
+			lines = append(lines, fmt.Sprintf("-lv %d", ov.LogVerbosity))
+		}
 		switch ov.CacheIdleSlots {
 		case "on":
 			lines = append(lines, "--cache-idle-slots")

--- a/internal/autogen/generate_cmd.go
+++ b/internal/autogen/generate_cmd.go
@@ -405,16 +405,21 @@ func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ng
 		if row.DraftPath != "" && mdMatches {
 			lines = append(lines, fmt.Sprintf("-md %s", strings.ReplaceAll(row.DraftPath, "\\", "/")))
 			lines = append(lines, "-ngld 99")
-			// Draft KV quant (-ctkd/-ctvd). "" => llama's f16 default; a matched
-			// quant here shrinks the resident draft's KV VRAM (fa is global, so the
-			// same flash-attn that gates main quant KV covers the draft too).
-			if ov != nil && ov.KvKDraft != "" {
-				lines = append(lines, fmt.Sprintf("-ctkd %s", ov.KvKDraft))
-			}
-			if ov != nil && ov.KvVDraft != "" {
-				lines = append(lines, fmt.Sprintf("-ctvd %s", ov.KvVDraft))
-			}
 		}
+		// Draft KV quant (-ctkd/-ctvd), defaulted to the model's OWN -ctk/-ctv.
+		// This is not "draft models only": a baked-in MTP head has no -md and
+		// still gets a full second context whose cache type comes from this same
+		// field, and llama's default for it is f16 no matter what -ctk says. On
+		// Qwen3.8-27B at 160k that lone nextn layer was paying 0.61 GB of f16 KV
+		// while the main cache ran q8_0; matching them halves it for free. Flash
+		// attention is global, so the same fa that licenses a quantized main KV
+		// covers the draft's. An override still wins on either side.
+		ovDraftK, ovDraftV := "", ""
+		if ov != nil {
+			ovDraftK, ovDraftV = ov.KvKDraft, ov.KvVDraft
+		}
+		dKvK, dKvV := draftKvPair(ovDraftK, ovDraftV, kvK, kvV)
+		lines = append(lines, fmt.Sprintf("-ctkd %s -ctvd %s", dKvK, dKvV))
 	}
 	if specHas(spec, "ngram-map-k4v") && ov != nil {
 		if ov.SpecDefault {
@@ -703,6 +708,10 @@ func RenderSoloCmd(s Settings, meta Metadata, row GgufRow, ov Override) (string,
 		CheckpointMinStep: ov.CheckpointMinStep,
 	}
 	prof.Overhead += computeBufferGB(meta, effectiveUb(meta, prof, &ov, prof.Ctx, s.TargetVramGB), s.ComputeBufFactor)
+	// The baked-in MTP drafter's own KV scales with the window, so it belongs in
+	// the slope the sizer solves ctx against (see mtpDraftSlopeFor).
+	sdKvK, sdKvV := draftKvPair(ov.KvKDraft, ov.KvVDraft, kvK, kvV)
+	prof.DraftSlopeGB = mtpDraftSlopeFor(meta, soloSpec, sdKvK, sdKvV, soloDraftGB)
 	ctx, plan, kvReserve, _, err := sizeProfile(meta, s, prof, perTokGB, kvConstGB, modelMax, ov.KvInRam)
 	if err != nil {
 		return "", err

--- a/internal/autogen/generate_sizing.go
+++ b/internal/autogen/generate_sizing.go
@@ -430,9 +430,20 @@ func estForOffload(meta Metadata, prof profile, kvReserve, ckptGB float64, ngl, 
 const (
 	computeActCopies    = 8.0
 	computeCudaCtxGB    = 0.3
+	computeHipCtxGB     = 0.4
 	computeLogitsTokens = 1024.0
 	computeFallbackGB   = 0.17 // vocab/embd dims missing => prior flat estimate
 )
+
+// computeHipCtxGB is the same fixed per-PROCESS runtime cost for a non-CUDA
+// (ROCm/HIP, Vulkan) build: the runtime's own context, its kernel code objects
+// and the BLAS workspace, none of which the analytic graph term below covers.
+// It used to be charged as 0, on the reasoning that the CUDA figure would not
+// transfer. Measured on an RX 7900 XTX (ROCm gfx1100 build) against PDH
+// per-process dedicated VRAM: qwen3-4b-instruct Q6_K at ctx 16384 held 5.00 GiB
+// against 4.60 GiB of modeled components, and a Qwen3.8-27B measured earlier
+// left the same ~0.4 GiB unexplained. Two unrelated models landing on the same
+// figure is what promoted this from a ponytail to a constant.
 
 // Do NOT scale this model down on Vulkan/ROCm without measuring PEAK, not idle.
 // An idle process (post-load, one short prompt) holds ~1.9GB less than the same
@@ -444,30 +455,47 @@ const (
 // peak-modeling estimate makes the compute term look ~1.6GB fat when it is not,
 // and a factor derived that way plans straight into a driver spill.
 
-// computeBufferGB estimates the GPU compute buffer (logits + activations + CUDA
-// runtime) for a given physical batch (ub). This lives on the GPU regardless of
-// CPU expert offload, so it is charged as flat VRAM overhead.
-func computeBufferGB(meta Metadata, ub int, factor float64) float64 {
+// computeGraphGB is the per-CONTEXT half of the compute buffer: the logits
+// tensor plus a handful of n_ubatch*n_embd activation copies. It is split out
+// from computeBufferGB because a second llama_context over the same model (the
+// baked-in MTP drafter, see mtpDraftComputeGB) allocates its own graph while
+// sharing the process-wide runtime constant. ok=false means the gguf carried no
+// vocab/embd dims to model it with.
+func computeGraphGB(meta Metadata, ub int, factor float64) (float64, bool) {
 	if factor <= 0 {
 		factor = 1.0
 	}
 	embd := float64(meta.EmbeddingLength)
 	vocab := float64(meta.VocabSize)
 	if embd <= 0 || vocab <= 0 || ub <= 0 {
-		return computeFallbackGB
+		return 0, false
 	}
 	logits := vocab * math.Min(float64(ub), computeLogitsTokens) * 4.0
 	acts := float64(ub) * embd * computeActCopies * 4.0
-	// The fixed CUDA-context constant is a CUDA-runtime cost; only charge it when a
-	// CUDA (NVIDIA) GPU is actually in use. On Vulkan/ROCm (AMD/Intel) the runtime
-	// context buffer differs, so charging the CUDA figure over-counts.
-	// ponytail: Vulkan/ROCm get 0 here rather than their own constant — add a
-	// per-backend value if a non-CUDA build's context buffer proves to matter.
-	ctxOh := 0.0
+	return factor * (logits + acts) / gib, true
+}
+
+// runtimeCtxGB is the fixed per-PROCESS GPU-runtime cost, picked by the backend
+// actually in use: the two runtimes reserve different amounts, and both were
+// measured rather than assumed. Charged once per llama-server, NOT once per
+// llama_context - a second context (the MTP drafter) shares the process.
+func runtimeCtxGB() float64 {
 	if usingCudaGPU() {
-		ctxOh = computeCudaCtxGB
+		return computeCudaCtxGB
 	}
-	return ctxOh + factor*(logits+acts)/gib
+	return computeHipCtxGB
+}
+
+// computeBufferGB estimates the GPU compute buffer for a given physical batch
+// (ub): the main context's graph plus the process-wide runtime constant. This
+// lives on the GPU regardless of CPU expert offload, so it is charged as flat
+// VRAM overhead.
+func computeBufferGB(meta Metadata, ub int, factor float64) float64 {
+	graph, ok := computeGraphGB(meta, ub, factor)
+	if !ok {
+		return computeFallbackGB
+	}
+	return runtimeCtxGB() + graph
 }
 
 // clipComputeBufferGB models the CLIP vision tower's peak GPU compute buffer from
@@ -550,11 +578,13 @@ func cpuMmprojWins(gpuPlan LoadPlan, gpuCtx int, cpuPlan LoadPlan, cpuCtx int) b
 	return cpuCtx > gpuCtx && float64(gpuCtx) < cpuMmprojGainCtx*float64(cpuCtx)
 }
 
-// mtpDraftPadGB is the CONSTANT part of a baked-in MTP drafter's footprint: its
-// own compute buffer and graph allocations. The KV part is deliberately not
-// here, it is ctx-scaled by mtpDraftSlopeGB and carried in profile.DraftSlopeGB.
-// The flat 0.34 GB this replaces tried to be both at once and was ~3x too fat at
-// a 32k window while under-charging by half at 160k.
+// mtpDraftPadGB is what is left of a baked-in MTP drafter's footprint once the
+// two modeled parts are taken out: its KV is ctx-scaled by mtpDraftSlopeGB and
+// carried in profile.DraftSlopeGB, its compute graph is modeled from the gguf
+// dims by mtpDraftComputeGB. This pad covers only the second llama_context's
+// remaining fixed allocations (its scheduler, its state buffers). The flat
+// 0.34 GB it replaced tried to be all three at once and was ~3x too fat at a 32k
+// window while under-charging by half at 160k.
 const mtpDraftPadGB = 0.15
 
 // draftOverheadGB returns the CTX-INDEPENDENT VRAM overhead to charge for the
@@ -618,6 +648,41 @@ func mtpDraftSlopeFor(meta Metadata, spec, kvKDraft, kvVDraft string, draftSizeG
 		return 0
 	}
 	return mtpDraftSlopeGB(meta, kvKDraft, kvVDraft)
+}
+
+// mtpDraftComputeGB is the compute-graph VRAM the BAKED-IN MTP drafter's own
+// llama_context allocates, on top of the main model's. Same gate as
+// mtpDraftSlopeFor: only the baked-in nextn head runs a second context over the
+// target model, and only when no separate draft gguf is attached.
+//
+// It is charged the FULL graph term, not a share of it. The drafter runs one
+// nextn layer instead of sixty-five, but the graph is dominated by the logits
+// tensor (n_vocab * ub * 4), and the draft context inherits params_base, so it
+// projects over the SAME vocabulary at the SAME ubatch as the target: on
+// Qwen3.8-27B (vocab 248320, ub 512) that term alone is 0.47 GiB of the 0.55 GiB
+// buffer. The activation half is layer-independent too (ggml-alloc reuses one
+// set of n_ubatch*n_embd scratch tensors down the stack), so the only thing this
+// over-charges is a rounding error's worth of per-layer scratch.
+//
+// What this replaces: mtpDraftPadGB alone, a flat 0.15 GB that was meant to
+// cover exactly this and was ~4x short. Measured against PDH per-process
+// dedicated VRAM on an RX 7900 XTX (ROCm), Qwen3.8-27B at ctx 114688 held
+// 15.82 GiB against 13.95 GiB of modeled components; ~0.4 of that gap is the
+// process runtime constant (computeHipCtxGB) and the drafter's graph is the
+// largest single piece of what is left. The pad stays on top for the second
+// context's non-graph allocations (its scheduler, its own state buffers).
+//
+// Returns 0 when the dims are missing, leaving draftOverheadGB's flat pad as the
+// whole charge, exactly as computeBufferGB falls back to computeFallbackGB.
+func mtpDraftComputeGB(meta Metadata, spec string, draftSizeGB float64, ub int, factor float64) float64 {
+	if !specHas(spec, "draft-mtp") || draftSizeGB > 0 {
+		return 0
+	}
+	graph, ok := computeGraphGB(meta, ub, factor)
+	if !ok {
+		return 0
+	}
+	return graph
 }
 
 // draftKvPair resolves the -ctkd/-ctvd pair a launch will run with: the model's

--- a/internal/autogen/generate_sizing.go
+++ b/internal/autogen/generate_sizing.go
@@ -89,6 +89,15 @@ func sizeProfile(meta Metadata, s Settings, prof profile, perTokGB, kvConstGB fl
 		kvReserve = KvReserveGB(ctx, perTokGB, kvConstGB)
 
 	case perTokGB > 0:
+		// The baked-in MTP drafter's KV is a second cache over the same window, so
+		// every ctx-vs-VRAM decision below solves against slope+draftSlope, not the
+		// main slope alone. Checkpoints keep the pure perTokGB: a checkpoint is a
+		// snapshot of the MAIN KV cache only, the drafter has none.
+		//
+		// kvReserve therefore comes back including the drafter's share. Callers
+		// that report a separate "Draft" figure subtract DraftSlopeGB*ctx again
+		// (see EstimatePlan); the sizing itself only cares about the total.
+		sizeSlope := perTokGB + prof.DraftSlopeGB
 		ckptCtxCeil := modelMax
 		if prof.Ctx != 0 {
 			ckptCtxCeil = min(ckptCtxCeil, prof.Ctx)
@@ -120,13 +129,13 @@ func sizeProfile(meta Metadata, s Settings, prof profile, perTokGB, kvConstGB fl
 					if kvBudget < 0.1 {
 						kvBudget = 0.1
 					}
-					ctx = RoundedCtx(float64(min(modelMax, MaxCtxForBudget(kvBudget, perTokGB, kvConstGB))))
+					ctx = RoundedCtx(float64(min(modelMax, MaxCtxForBudget(kvBudget, sizeSlope, kvConstGB))))
 				} else {
 					maxKvVram := target - nonExpert - overhead
 					if maxKvVram < 0.1 {
 						maxKvVram = 0.1
 					}
-					maxCtxVram := MaxCtxForBudget(maxKvVram, perTokGB, kvConstGB)
+					maxCtxVram := MaxCtxForBudget(maxKvVram, sizeSlope, kvConstGB)
 					ctx = RoundedCtx(float64(min(min(modelMax, s.MoeCtxTarget), maxCtxVram)))
 				}
 			}
@@ -140,7 +149,7 @@ func sizeProfile(meta Metadata, s Settings, prof profile, perTokGB, kvConstGB fl
 			// Size ctx conservatively against the checkpoint cost (overhead+ckpt),
 			// but keep ckpt out of overhead so placement can split it per-layer.
 			d := GetDenseCtx(DenseCtxParams{
-				ModelMax: modelMax, PerTokGB: perTokGB, KvConstGB: kvConstGB,
+				ModelMax: modelMax, PerTokGB: sizeSlope, KvConstGB: kvConstGB,
 				FileSizeGB: meta.FileSizeGB, TargetVramGB: target, Overhead: overhead + ckpt,
 				Ladder: ladder, MinCtx: minCtx, AllowOffload: prof.Ctx != 0,
 			})
@@ -150,7 +159,7 @@ func sizeProfile(meta Metadata, s Settings, prof profile, perTokGB, kvConstGB fl
 			}
 			placementCkpt = ckpt
 		}
-		kvReserve = KvReserveGB(ctx, perTokGB, kvConstGB)
+		kvReserve = KvReserveGB(ctx, sizeSlope, kvConstGB)
 		plan, err = GetLoadPlan(meta, planOpt(target, s.MaxRamGB, kvReserve+placementCkpt, overhead))
 		if err != nil {
 			return
@@ -541,9 +550,17 @@ func cpuMmprojWins(gpuPlan LoadPlan, gpuCtx int, cpuPlan LoadPlan, cpuCtx int) b
 	return cpuCtx > gpuCtx && float64(gpuCtx) < cpuMmprojGainCtx*float64(cpuCtx)
 }
 
-// draftOverheadGB returns the VRAM overhead to charge for the active spec
-// chain's draft model. A baked-in MTP nextn layer with no separate weights
-// file is a flat ~0.34 GB (KV+compute). A separate draft gguf — an MTP
+// mtpDraftPadGB is the CONSTANT part of a baked-in MTP drafter's footprint: its
+// own compute buffer and graph allocations. The KV part is deliberately not
+// here, it is ctx-scaled by mtpDraftSlopeGB and carried in profile.DraftSlopeGB.
+// The flat 0.34 GB this replaces tried to be both at once and was ~3x too fat at
+// a 32k window while under-charging by half at 160k.
+const mtpDraftPadGB = 0.15
+
+// draftOverheadGB returns the CTX-INDEPENDENT VRAM overhead to charge for the
+// active spec chain's draft model. A baked-in MTP nextn layer with no separate
+// weights file costs only the compute pad here (mtpDraftPadGB); its KV rides on
+// the ctx-scaled slope instead, see mtpDraftSlopeFor. A separate draft gguf — an MTP
 // sidecar (Gemma-4) or any DFlash block-diffusion drafter, which is always a
 // separate file — charges its real on-disk weight size plus a small
 // KV/compute pad instead, so large drafts scale up rather than under-counting.
@@ -560,7 +577,7 @@ func draftOverheadGB(spec string, draftSizeGB float64) float64 {
 		if draftSizeGB > 0 {
 			return draftSizeGB + 0.1
 		}
-		return 0.34
+		return mtpDraftPadGB
 	default:
 		return 0
 	}
@@ -573,12 +590,39 @@ func draftOverheadGB(spec string, draftSizeGB float64) float64 {
 // Both conditions matter: a model dir can hold a DFlash drafter while the model
 // runs on a baked-in MTP head (Qwen3.8-27B does). Charging the sidecar there
 // reserved ~1 GB of VRAM for a draft the emitted cmd never attaches, which cost
-// real -ngl/ctx. Feeding 0 through drops draftOverheadGB back to the baked-in
-// 0.34 GB, which is what actually loads.
+// real -ngl/ctx. Feeding 0 through drops the charge back to the baked-in head
+// (draftOverheadGB's pad plus the ctx-scaled mtpDraftSlopeFor), which is what
+// actually loads.
 func matchedDraftSizeGB(spec, draftKind string, draftSizeGB float64) float64 {
 	if (specHas(spec, "draft-mtp") && draftKind == "mtp") ||
 		(specHas(spec, "draft-dflash") && draftKind == "dflash") {
 		return draftSizeGB
 	}
 	return 0
+}
+
+// mtpDraftSlopeFor returns the per-token VRAM slope (GB/token) that the active
+// spec chain's BAKED-IN MTP drafter adds on top of the main KV cache, or 0 when
+// no such drafter loads.
+//
+// Only the baked-in case scales this way: a separate draft gguf is a different
+// model with its own dims, charged its on-disk weights plus a pad by
+// draftOverheadGB, so a non-zero draftSizeGB means "not our case".
+//
+// kvKDraft/kvVDraft are the DRAFT cache types (-ctkd/-ctvd), which buildCmdLines
+// now emits defaulted to the model's own -ctk/-ctv. Pass what will actually be
+// emitted rather than the main quant: llama's own default for the draft context
+// is f16 whatever -ctk says, so a hand-written argv with no -ctkd really pays f16.
+func mtpDraftSlopeFor(meta Metadata, spec, kvKDraft, kvVDraft string, draftSizeGB float64) float64 {
+	if !specHas(spec, "draft-mtp") || draftSizeGB > 0 {
+		return 0
+	}
+	return mtpDraftSlopeGB(meta, kvKDraft, kvVDraft)
+}
+
+// draftKvPair resolves the -ctkd/-ctvd pair a launch will run with: the model's
+// own K/V quant unless the override pins the draft side separately.
+// buildCmdLines emits exactly this pair, so sizing and emission cannot drift.
+func draftKvPair(ovKvKDraft, ovKvVDraft, kvK, kvV string) (string, string) {
+	return resolveKvPair(ovKvKDraft, ovKvVDraft, kvK, kvV)
 }

--- a/internal/autogen/gguf.go
+++ b/internal/autogen/gguf.go
@@ -144,6 +144,13 @@ type Metadata struct {
 	// can use --spec-type draft-mtp.
 	IsMTP bool
 
+	// NextnLayers is how many of those layers there are. It is not a detail:
+	// llama-server builds the baked-MTP drafter as a SECOND context over the same
+	// model, whose KV cache covers exactly these layers at the target's full
+	// n_ctx, so the draft's VRAM scales with the context window. See
+	// mtpDraftSlopeGB.
+	NextnLayers int64
+
 	// ExpertWeightShare is the fraction of on-disk weight bytes in expert
 	// tensors (*_exps.weight), derived from the tensor section. 0 when not MoE
 	// or the tensor section could not be sized. Replaces the per-arch heuristic.
@@ -1030,6 +1037,7 @@ func ReadGgufMetadataFrom(rs io.ReadSeeker, path string, sizeBytes int64) (Metad
 		PoolingType:       deref(poolingType),
 		IsMoE:             expertCount != nil && *expertCount > 0,
 		IsMTP:             nextnLayers != nil && *nextnLayers > 0,
+		NextnLayers:       deref(nextnLayers),
 		ExpertWeightShare: expertShare,
 		VisionImageSize:   deref(visImageSize),
 		VisionPatchSize:   deref(visPatchSize),

--- a/internal/autogen/kvcost.go
+++ b/internal/autogen/kvcost.go
@@ -189,6 +189,35 @@ func GetKvCostModel(meta Metadata, kvK, kvV string) KvCostModel {
 	}
 }
 
+// mtpDraftSlopeGB is the per-token VRAM cost (GB) of the BAKED-IN MTP drafter's
+// own KV cache — i.e. what --spec-type draft-mtp reserves on top of the main
+// model's when the gguf carries its own nextn layers and no separate -md file is
+// attached.
+//
+// llama-server does not run the nextn head inside the main context. It creates a
+// second llama_context over the SAME model
+// (server-context.cpp, "creating MTP draft context against the target model"),
+// inheriting the target's cparams — n_ctx included — and filtering its KV cache
+// to the nextn layers only (llama-model.cpp: `il >= hparams.n_layer()`; on
+// hybrid qwen35 that cache is plain attention, not the hybrid wrapper, so there
+// is no second copy of the recurrent state). So the drafter costs
+// nextn_layers worth of full-attention KV over the WHOLE context window, which
+// is why the old flat 0.34 GB charge was wrong in both directions: ~3x too fat at
+// a 32k tier and ~2x too thin at 160k.
+//
+// kvK/kvV are the DRAFT cache types (-ctkd/-ctvd), not the main ones: the draft
+// context takes params.speculative.draft.cache_type_k, which llama defaults to
+// f16 regardless of -ctk. See draftKvPair.
+func mtpDraftSlopeGB(meta Metadata, kvK, kvV string) float64 {
+	nextn := meta.NextnLayers
+	kvHeads := meta.HeadCountKv
+	if nextn <= 0 || kvHeads <= 0 || meta.KeyLength <= 0 || meta.ValueLength <= 0 {
+		return 0
+	}
+	perTok := float64(kvHeads) * (float64(meta.KeyLength)*kvByteWidth(kvK) + float64(meta.ValueLength)*kvByteWidth(kvV))
+	return float64(nextn) * perTok / gib
+}
+
 // MaxCtxForBudget returns the largest ctx that fits a VRAM/RAM budget given the
 // slope+const KV model. 0 when nothing fits.
 func MaxCtxForBudget(budgetGB, slopeGB, constGB float64) int {

--- a/internal/autogen/liveoffload.go
+++ b/internal/autogen/liveoffload.go
@@ -106,10 +106,15 @@ func LiveOffloadArgs(s Settings, args []string, freeGB float64, freeOK bool, log
 	}
 
 	in := EstimateInput{
-		Ctx:          atoiFlag(args, "-c", "--ctx-size"),
-		KvK:          flagStr(args, "-ctk", "--cache-type-k"),
-		KvV:          flagStr(args, "-ctv", "--cache-type-v"),
-		KvInRam:      hasFlag(args, "--no-kv-offload"),
+		Ctx:     atoiFlag(args, "-c", "--ctx-size"),
+		KvK:     flagStr(args, "-ctk", "--cache-type-k"),
+		KvV:     flagStr(args, "-ctv", "--cache-type-v"),
+		KvInRam: hasFlag(args, "--no-kv-offload"),
+		// Draft cache type. An argv without -ctkd really does run the draft
+		// context on f16 (llama's own default is independent of -ctk), so pin f16
+		// rather than letting the sizer assume the emitter's matched default.
+		KvKDraft:     flagStrDef(args, "f16", "-ctkd", "--cache-type-k-draft"),
+		KvVDraft:     flagStrDef(args, "f16", "-ctvd", "--cache-type-v-draft"),
 		Spec:         specTypes(args),
 		RopeScaling:  flagStr(args, "--rope-scaling"),
 		TargetVramGB: budgetGB, // EstimatePlan subtracts overhead via s
@@ -149,8 +154,8 @@ func LiveOffloadArgs(s Settings, args []string, freeGB float64, freeOK bool, log
 		}
 	}
 	// A separate draft gguf (-md: MTP sidecar or any DFlash drafter) has real
-	// weights on disk; charge its actual size instead of the flat 0.34 GB
-	// baked-in-MTP default so a big drafter doesn't get under-charged here.
+	// weights on disk; charge its actual size instead of the small baked-in-MTP
+	// pad so a big drafter doesn't get under-charged here.
 	if md, i := argVal(args, "-md"); i >= 0 {
 		if fi, statErr := os.Stat(md); statErr == nil {
 			in.DraftGB = float64(fi.Size()) / gib
@@ -396,6 +401,15 @@ func argVal(args []string, names ...string) (string, int) {
 func flagStr(args []string, names ...string) string {
 	v, _ := argVal(args, names...)
 	return v
+}
+
+// flagStrDef is flagStr with a fallback for a flag the argv omits, for the cases
+// where "absent" means a specific llama default rather than "let us choose".
+func flagStrDef(args []string, def string, names ...string) string {
+	if v, idx := argVal(args, names...); idx >= 0 && v != "" {
+		return v
+	}
+	return def
 }
 
 func atoiFlag(args []string, names ...string) int {

--- a/internal/autogen/liveoffload.md
+++ b/internal/autogen/liveoffload.md
@@ -61,9 +61,11 @@ and spills as before.
 
 - A `-md` in the argv (separate MTP sidecar or DFlash drafter) is stat'd for its real
   on-disk size into `EstimateInput.DraftGB`, matching what generate-time bakes into the
-  model's `Overhead` via `draftOverheadGB`. This previously used the flat 0.34 GB
-  baked-in-MTP default regardless of the file's actual size, undercharging a
-  multi-hundred-MB drafter.
+  model's `Overhead` via `draftOverheadGB`. This previously used a flat baked-in-MTP
+  default regardless of the file's actual size, undercharging a multi-hundred-MB drafter.
+- `-ctkd`/`-ctvd` are read off the argv too, defaulting to **f16** when absent (llama's own
+  default for the draft context, whatever `-ctk` says) so the baked-in MTP drafter's KV is
+  priced at what the launch really runs.
 - A `--mmproj` charges the projector's weights (its gguf size) **plus**
   `settings.visionOverheadGB` (default 1.0 GB) for the CLIP compute buffer — via
   `EstimateInput.MmprojGB` (`mmprojVramGB`), the same footprint generate-time bakes into the

--- a/internal/autogen/mtpdraft_test.go
+++ b/internal/autogen/mtpdraft_test.go
@@ -1,0 +1,124 @@
+package autogen
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// qwen38Meta is Qwen3.8-27B-UD-Q2_K_XL as its gguf reports it: a hybrid
+// GatedDeltaNet with one full-attention layer in four, and ONE baked-in nextn
+// (MTP) layer. It is the model that exposed the flat draft charge.
+func qwen38Meta() Metadata {
+	return Metadata{
+		Architecture: "qwen35", BlockCount: 65, HeadCountKv: 4,
+		KeyLength: 256, ValueLength: 256, FullAttnInterval: 4,
+		FileSizeGB: 9.154, ContextLength: 262144,
+		IsMTP: true, NextnLayers: 1,
+	}
+}
+
+// The baked-in MTP drafter is a second context over the same model at the same
+// n_ctx, so its KV is a per-token cost over its nextn layers, not a constant.
+func TestMtpDraftSlopeGB(t *testing.T) {
+	meta := qwen38Meta()
+
+	// 1 nextn layer x 4 kv heads x (256 K + 256 V) x 2 bytes = 4096 B/token.
+	wantF16 := 4096.0 / gib
+	if got := mtpDraftSlopeGB(meta, "f16", "f16"); math.Abs(got-wantF16) > 1e-12 {
+		t.Fatalf("f16 slope=%g want %g", got, wantF16)
+	}
+	// Matching the draft cache to a q8_0 main cache is what -ctkd buys: at the
+	// 159744-token window this model sizes to, 0.61 GB becomes 0.32 GB.
+	q8 := mtpDraftSlopeGB(meta, "q8_0", "q8_0")
+	if ratio := q8 / wantF16; math.Abs(ratio-1.0625/2) > 1e-9 {
+		t.Fatalf("q8_0/f16 slope ratio=%g want %g", ratio, 1.0625/2)
+	}
+	if gb := wantF16 * 159744; math.Abs(gb-0.6094) > 1e-3 {
+		t.Fatalf("f16 draft KV at 159744 ctx = %.4f GB, want ~0.61", gb)
+	}
+
+	// No nextn layers (or no dims): nothing to charge.
+	plain := meta
+	plain.NextnLayers, plain.IsMTP = 0, false
+	if got := mtpDraftSlopeGB(plain, "f16", "f16"); got != 0 {
+		t.Fatalf("non-MTP model charged %g", got)
+	}
+
+	// The gate follows the emitter: a baked-in head scales, a separate draft
+	// gguf does not (it is charged its own weights by draftOverheadGB), and a
+	// spec chain without draft-mtp charges nothing at all.
+	if got := mtpDraftSlopeFor(meta, "draft-mtp+ngram-mod", "f16", "f16", 0); got != mtpDraftSlopeGB(meta, "f16", "f16") {
+		t.Fatalf("baked-in MTP not charged: %g", got)
+	}
+	if got := mtpDraftSlopeFor(meta, "draft-mtp+ngram-mod", "f16", "f16", 0.46); got != 0 {
+		t.Fatalf("sidecar draft charged the baked-in slope: %g", got)
+	}
+	if got := mtpDraftSlopeFor(meta, "ngram-mod", "f16", "f16", 0); got != 0 {
+		t.Fatalf("non-draft spec charged %g", got)
+	}
+}
+
+// The drafter's KV must scale with the window in the estimate, and must be
+// reported under Draft rather than inflating the main KV segment.
+func TestEstimatePlan_mtpDraftIsCtxScaled(t *testing.T) {
+	meta := qwen38Meta()
+	s := Settings{TargetVramGB: 40, VramOverheadGB: 1, ComputeBufFactor: 1}
+	s.applyDefaults()
+	slope := mtpDraftSlopeGB(meta, "q8_0", "q8_0") // -ctkd defaults to the main quant
+
+	small, err := EstimatePlan(s, meta, EstimateInput{Ctx: 32768, KvK: "q8_0", KvV: "q8_0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	big, err := EstimatePlan(s, meta, EstimateInput{Ctx: 131072, KvK: "q8_0", KvV: "q8_0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if small.Ctx != 32768 || big.Ctx != 131072 {
+		t.Fatalf("ctx not honored: %d / %d", small.Ctx, big.Ctx)
+	}
+	wantDelta := slope * float64(big.Ctx-small.Ctx)
+	if got := big.DraftGB - small.DraftGB; math.Abs(got-wantDelta) > 1e-9 {
+		t.Fatalf("draft charge delta=%.4f want %.4f (flat charge would be 0)", got, wantDelta)
+	}
+	// Pad + KV, not one or the other.
+	wantSmall := mtpDraftPadGB + slope*float64(small.Ctx)
+	if math.Abs(small.DraftGB-wantSmall) > 1e-9 {
+		t.Fatalf("draft charge=%.4f want %.4f", small.DraftGB, wantSmall)
+	}
+	// The KV segment stays the MAIN cache: the drafter's share is split back out.
+	m := GetKvCostModel(meta, "q8_0", "q8_0")
+	if want := KvReserveGB(big.Ctx, m.SlopeGB, m.ConstGB); math.Abs(big.KvReserveGB-want) > 1e-9 {
+		t.Fatalf("kv reserve=%.4f want %.4f (drafter must not land in the KV segment)", big.KvReserveGB, want)
+	}
+}
+
+// -ctkd/-ctvd are emitted for ANY active draft spec, defaulted to the model's
+// own -ctk/-ctv. A baked-in MTP head attaches no -md but still gets a draft
+// context, and llama defaults that context's cache to f16 whatever -ctk says.
+func TestBuildCmdLines_draftKvFollowsMain(t *testing.T) {
+	s := Settings{}
+	s.applyDefaults()
+	prof := profile{Name: "t", Ctx: 8192}
+	join := func(meta Metadata, ov *Override) string {
+		return strings.Join(buildCmdLines(s, meta, GgufRow{FullPath: "/m.gguf"}, prof, 8192, 99, 0, "q8_0", "q8_0", false, ov), " ")
+	}
+
+	got := join(qwen38Meta(), &Override{})
+	if !strings.Contains(got, "--spec-type draft-mtp") {
+		t.Fatalf("test assumption broken, no MTP spec: %s", got)
+	}
+	if !strings.Contains(got, "-ctkd q8_0 -ctvd q8_0") {
+		t.Fatalf("baked-in MTP draft KV not matched to the main quant: %s", got)
+	}
+	// An explicit override still wins on either side.
+	got = join(qwen38Meta(), &Override{KvKDraft: "f16", KvVDraft: "f16"})
+	if !strings.Contains(got, "-ctkd f16 -ctvd f16") {
+		t.Fatalf("draft KV override ignored: %s", got)
+	}
+	// No draft backend in the chain: no draft context, no flags.
+	if got := join(Metadata{Architecture: "qwen35"}, &Override{}); strings.Contains(got, "-ctkd") {
+		t.Fatalf("draft KV emitted without a draft spec: %s", got)
+	}
+}

--- a/internal/autogen/mtpdraft_test.go
+++ b/internal/autogen/mtpdraft_test.go
@@ -122,3 +122,65 @@ func TestBuildCmdLines_draftKvFollowsMain(t *testing.T) {
 		t.Fatalf("draft KV emitted without a draft spec: %s", got)
 	}
 }
+
+// qwen38MetaDims is the same model with the two dims a compute graph needs. The
+// gguf carries them; qwen38Meta leaves them off so the KV tests above exercise
+// the KV math alone.
+func qwen38MetaDims() Metadata {
+	m := qwen38Meta()
+	m.EmbeddingLength, m.VocabSize = 5120, 248320
+	return m
+}
+
+// The baked-in drafter is a second llama_context over the same model, inheriting
+// n_ctx and n_ubatch, so it allocates a second compute graph: same vocabulary,
+// same physical batch, hence the same size. It is charged only when the drafter
+// really is baked in - an external draft gguf is already priced by its weights.
+func TestMtpDraftComputeGB(t *testing.T) {
+	meta := qwen38MetaDims()
+	graph, ok := computeGraphGB(meta, 512, 1.0)
+	if !ok || graph <= 0 {
+		t.Fatalf("test assumption broken: graph=%g ok=%v", graph, ok)
+	}
+
+	if got := mtpDraftComputeGB(meta, "draft-mtp", 0, 512, 1.0); got != graph {
+		t.Errorf("baked-in MTP: got %.4f, want the full graph %.4f", got, graph)
+	}
+	// A matched draft gguf: its context is a different, much smaller model.
+	if got := mtpDraftComputeGB(meta, "draft-mtp", 1.2, 512, 1.0); got != 0 {
+		t.Errorf("external draft model should not be charged the target graph, got %.4f", got)
+	}
+	// No draft backend at all.
+	if got := mtpDraftComputeGB(meta, "ngram", 0, 512, 1.0); got != 0 {
+		t.Errorf("no draft-mtp spec: got %.4f, want 0", got)
+	}
+	// Missing dims leave draftOverheadGB's flat pad as the whole charge.
+	if got := mtpDraftComputeGB(qwen38Meta(), "draft-mtp", 0, 512, 1.0); got != 0 {
+		t.Errorf("missing dims: got %.4f, want 0 (pad only)", got)
+	}
+}
+
+// The drafter's graph rides in DraftGB, not ComputeBufGB: the UI attributes it
+// to the draft segment, and the process-wide runtime constant is charged once.
+func TestEstimatePlan_mtpDraftChargesItsOwnGraph(t *testing.T) {
+	meta := qwen38MetaDims()
+	s := Settings{TargetVramGB: 40, VramOverheadGB: 1, ComputeBufFactor: 1}
+	s.applyDefaults()
+
+	got, err := EstimatePlan(s, meta, EstimateInput{Ctx: 32768, KvK: "q8_0", KvV: "q8_0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ComputeBufGB is runtime + ONE graph, so the graph the drafter copies is
+	// recoverable from it without having to re-derive the effective ubatch.
+	graph := got.ComputeBufGB - runtimeCtxGB()
+	if graph <= 0 {
+		t.Fatalf("compute buffer %.4f is below the runtime constant %.4f", got.ComputeBufGB, runtimeCtxGB())
+	}
+	slope := mtpDraftSlopeGB(meta, "q8_0", "q8_0")
+	want := mtpDraftPadGB + graph + slope*float64(got.Ctx)
+	if math.Abs(got.DraftGB-want) > 1e-9 {
+		t.Fatalf("draft charge=%.4f want %.4f (pad %.2f + graph %.4f + KV %.4f)",
+			got.DraftGB, want, mtpDraftPadGB, graph, slope*float64(got.Ctx))
+	}
+}

--- a/internal/autogen/overrides.go
+++ b/internal/autogen/overrides.go
@@ -590,7 +590,9 @@ type Override struct {
 	//   DirectIo:     -dio (faster cold load)
 	//   NoOpOffload:  --no-op-offload
 	//   NoRepack:     --no-repack
-	//   KvKDraft/KvVDraft: "" => llama f16       (-ctkd/-ctvd, draft KV quant; draft models only)
+	//   KvKDraft/KvVDraft: "" => match -ctk/-ctv  (-ctkd/-ctvd, draft KV quant; also
+	//                     applies to a baked-in MTP head, whose own context llama
+	//                     would otherwise run on f16)
 	//   CacheReuse:   0 => off                   (--cache-reuse N, prefix KV-shift reuse)
 	//   CacheRamMB:   0 => llama default (8192)  (-cram, prompt-cache size MiB)
 	//   CacheIdleSlots: "" | "on" | "off"        (--cache-idle-slots / --no-)

--- a/internal/autogen/overrides.go
+++ b/internal/autogen/overrides.go
@@ -596,6 +596,9 @@ type Override struct {
 	//   CacheReuse:   0 => off                   (--cache-reuse N, prefix KV-shift reuse)
 	//   CacheRamMB:   0 => llama default (8192)  (-cram, prompt-cache size MiB)
 	//   CacheIdleSlots: "" | "on" | "off"        (--cache-idle-slots / --no-)
+	//   LogVerbosity: 0 => backend default       (-lv N, log verbosity threshold;
+	//                     raise it to make llama-server print its load-time buffer
+	//                     report, which some builds hide at their own default)
 	//   SwaFull:      --swa-full (full SWA cache)
 	//   CheckpointMinStep: 0 => llama default    (-cms, ctx-checkpoint spacing)
 	//   ContextShift: "" | "on" | "off"          (--context-shift / --no-)
@@ -619,6 +622,7 @@ type Override struct {
 	CacheReuse           int     `yaml:"cacheReuse"`
 	CacheRamMB           int     `yaml:"cacheRamMB"`
 	CacheIdleSlots       string  `yaml:"cacheIdleSlots"`
+	LogVerbosity         int     `yaml:"logVerbosity"`
 	SwaFull              bool    `yaml:"swaFull"`
 	CheckpointMinStep    int     `yaml:"checkpointMinStep"`
 	ContextShift         string  `yaml:"contextShift"`

--- a/internal/autogen/sizing.md
+++ b/internal/autogen/sizing.md
@@ -174,8 +174,20 @@ on these archs).
   overrides either.
 - **Never opt in on dense/CPU-bound models:** on Dense-27B it merely ties mtp on decode, costs
   1.43 GB resident, and the draft's own prefill craters pp by −55%.
-- Any separate draft file is charged via `draftOverheadGB` = real on-disk size + 0.1 GB pad
-  (the flat 0.34 GB is only for a baked-in MTP nextn layer with no file).
+- Any separate draft file is charged via `draftOverheadGB` = real on-disk size + 0.1 GB pad.
+- A **baked-in MTP nextn layer** (no file) is charged in two parts: a flat `mtpDraftPadGB`
+  (0.15 GB, its compute buffer) plus a **ctx-scaled KV slope**, `mtpDraftSlopeGB` =
+  `nextn_predict_layers x n_kv_heads x (k_len*bK + v_len*bV)`, carried in
+  `profile.DraftSlopeGB` and added to the per-token slope the sizer solves ctx against.
+  llama-server does not run the nextn head inside the main context: it builds a **second
+  `llama_context` over the same model** at the target's full `n_ctx`, filtered to the nextn
+  layers, so the drafter's KV grows with the window. The old flat 0.34 GB was ~3x too fat at
+  32k and half the real cost at 160k (Qwen3.8-27B: 1 nextn layer, 0.61 GB of f16 KV at
+  159744).
+- That second context takes its cache type from `-ctkd`/`-ctvd`, which llama defaults to
+  **f16 regardless of `-ctk`**. `buildCmdLines` therefore emits both for ANY active draft
+  spec (not just when a `-md` file is attached), defaulted to the model's own `-ctk`/`-ctv`,
+  which halves the drafter's KV on a q8_0 model. `Override.KvKDraft/KvVDraft` still win.
 
 ## RoPE scaling
 

--- a/internal/autogen/sizing.md
+++ b/internal/autogen/sizing.md
@@ -8,11 +8,23 @@ or any `estVramGB` producer. Spawn-time re-sizing lives in
 ## Compute buffer
 
 **Modeled, not a flat fudge.** `computeBufferGB` (`generate_sizing.go`) =
-logits (`VocabSize*min(ub,computeLogitsTokens)*4`) + activations
-(`ub*EmbeddingLength*~8*4`) + a fixed CUDA-ctx constant (`computeCudaCtxGB=0.3`,
-charged only when `usingCudaGPU()`), scaled by `settings.computeBufFactor`.
+`runtimeCtxGB()` + `computeGraphGB()`, scaled by `settings.computeBufFactor`.
 Replaced a flat `ubSoloOh=0.17` that undercounted by >1 GB on large-vocab models
 and drove VRAM spillover.
+
+- **`computeGraphGB` is per-CONTEXT**: logits (`VocabSize*min(ub,computeLogitsTokens)*4`)
+  + activations (`ub*EmbeddingLength*~8*4`). Split out because a second
+  `llama_context` over the same model (the baked-in MTP drafter) allocates its
+  own graph, see the drafter section below.
+- **`runtimeCtxGB` is per-PROCESS**, charged once per llama-server whatever the
+  context count: `computeCudaCtxGB=0.3` (CUDA runtime + cuBLAS workspace) when
+  `usingCudaGPU()`, else `computeHipCtxGB=0.4`. The non-CUDA figure used to be
+  **0**, on the reasoning that a CUDA number would not transfer. It transfers and
+  then some: measured against PDH per-process dedicated VRAM on an RX 7900 XTX
+  (ROCm gfx1100), qwen3-4b-instruct Q6_K at ctx 16384 held 5.00 GiB against
+  4.60 GiB of modeled components, and a Qwen3.8-27B left the same ~0.4 GiB
+  unexplained. Two unrelated models landing on the same figure is what promoted
+  it from a ponytail to a constant.
 
 - **`computeLogitsTokens` is 1024, not 256.** llama.cpp sizes the output *tensor*
   by `n_outputs`, but the measured CUDA compute buffer still grows with the
@@ -175,15 +187,25 @@ on these archs).
 - **Never opt in on dense/CPU-bound models:** on Dense-27B it merely ties mtp on decode, costs
   1.43 GB resident, and the draft's own prefill craters pp by −55%.
 - Any separate draft file is charged via `draftOverheadGB` = real on-disk size + 0.1 GB pad.
-- A **baked-in MTP nextn layer** (no file) is charged in two parts: a flat `mtpDraftPadGB`
-  (0.15 GB, its compute buffer) plus a **ctx-scaled KV slope**, `mtpDraftSlopeGB` =
+- A **baked-in MTP nextn layer** (no file) is charged in three parts: its own compute
+  **graph** (`mtpDraftComputeGB`, = `computeGraphGB` at the same ub, since the draft
+  context inherits `params_base` and so projects over the same vocabulary at the same
+  physical batch: on Qwen3.8-27B that logits term alone is 0.47 GiB of a 0.55 GiB
+  buffer), a flat `mtpDraftPadGB` (0.15 GB, now only the second context's non-graph
+  allocations: its scheduler and state buffers), plus a **ctx-scaled KV slope**,
+  `mtpDraftSlopeGB` =
   `nextn_predict_layers x n_kv_heads x (k_len*bK + v_len*bV)`, carried in
   `profile.DraftSlopeGB` and added to the per-token slope the sizer solves ctx against.
   llama-server does not run the nextn head inside the main context: it builds a **second
   `llama_context` over the same model** at the target's full `n_ctx`, filtered to the nextn
   layers, so the drafter's KV grows with the window. The old flat 0.34 GB was ~3x too fat at
   32k and half the real cost at 160k (Qwen3.8-27B: 1 nextn layer, 0.61 GB of f16 KV at
-  159744).
+  159744). The graph charge replaced `mtpDraftPadGB` carrying all of it, which was ~4x
+  short: Qwen3.8-27B at ctx 114688 measured 15.82 GiB per-process against 13.95 GiB of
+  modeled components. It rides in `EstimateResult.DraftGB`, not `ComputeBufGB`, and is
+  skipped for a separate draft gguf (already priced by its weights) or when the gguf
+  carries no vocab/embd dims (pad only, as `computeBufferGB` falls back to
+  `computeFallbackGB`).
 - That second context takes its cache type from `-ctkd`/`-ctvd`, which llama defaults to
   **f16 regardless of `-ctk`**. `buildCmdLines` therefore emits both for ANY active draft
   spec (not just when a `-md` file is attached), defaulted to the model's own `-ctk`/`-ctv`,

--- a/internal/autogen/vram.go
+++ b/internal/autogen/vram.go
@@ -13,10 +13,11 @@ import (
 	"github.com/quartermaster-labs/quartermaster/internal/perf"
 )
 
-// cudaGPU records whether the serving GPU is CUDA (NVIDIA). It gates the fixed
-// CUDA-context term in computeBufferGB — that cost is a CUDA-runtime figure and
-// shouldn't be charged on Vulkan/ROCm (AMD/Intel). Defaults to true (assume
-// CUDA) so NVIDIA boxes and tests are unchanged until DetectGpuCompute flips it.
+// cudaGPU records whether the serving GPU is CUDA (NVIDIA). It picks which
+// fixed per-process runtime constant runtimeCtxGB charges: computeCudaCtxGB for
+// the CUDA runtime + cuBLAS workspace, computeHipCtxGB for a Vulkan/ROCm one
+// (AMD/Intel), which measured LARGER, not zero. Defaults to true (assume CUDA)
+// so NVIDIA boxes and tests are unchanged until DetectGpuCompute flips it.
 var cudaGPU atomic.Bool
 
 func init() { cudaGPU.Store(true) }

--- a/internal/server/configapi_dto.go
+++ b/internal/server/configapi_dto.go
@@ -191,6 +191,7 @@ type overrideDTO struct {
 	CacheReuse           int     `json:"cacheReuse"`
 	CacheRamMB           int     `json:"cacheRamMB"`
 	CacheIdleSlots       string  `json:"cacheIdleSlots"`
+	LogVerbosity         int     `json:"logVerbosity"`
 	SwaFull              bool    `json:"swaFull"`
 	CheckpointMinStep    int     `json:"checkpointMinStep"`
 	ContextShift         string  `json:"contextShift"`
@@ -314,7 +315,8 @@ func toOverrideDTO(o autogen.Override) *overrideDTO {
 		SpecNgramSizeN: o.SpecNgramSizeN, SpecNgramSizeM: o.SpecNgramSizeM, SpecNgramMinHits: o.SpecNgramMinHits,
 		ThreadsBatch: o.ThreadsBatch, Prio: o.Prio, DirectIo: o.DirectIo, NoOpOffload: o.NoOpOffload, NoRepack: o.NoRepack,
 		KvKDraft: o.KvKDraft, KvVDraft: o.KvVDraft, CacheReuse: o.CacheReuse, CacheRamMB: o.CacheRamMB, CacheIdleSlots: o.CacheIdleSlots,
-		SwaFull: o.SwaFull, CheckpointMinStep: o.CheckpointMinStep, ContextShift: o.ContextShift,
+		LogVerbosity: o.LogVerbosity,
+		SwaFull:      o.SwaFull, CheckpointMinStep: o.CheckpointMinStep, ContextShift: o.ContextShift,
 		SpecDraftNMin: o.SpecDraftNMin, SlotPromptSimilarity: o.SlotPromptSimilarity,
 		RopeScaling: o.RopeScaling, RopeScale: o.RopeScale, RopeFreqBase: o.RopeFreqBase, YarnOrigCtx: o.YarnOrigCtx,
 		SplitMode: o.SplitMode, TensorSplit: o.TensorSplit, MainGpu: o.MainGpu, OverrideTensor: o.OverrideTensor,
@@ -416,6 +418,7 @@ func applyOverrideDTO(ov *autogen.Override, body overrideDTO) {
 	ov.CacheReuse = body.CacheReuse
 	ov.CacheRamMB = body.CacheRamMB
 	ov.CacheIdleSlots = body.CacheIdleSlots
+	ov.LogVerbosity = body.LogVerbosity
 	ov.SwaFull = body.SwaFull
 	ov.CheckpointMinStep = body.CheckpointMinStep
 	ov.ContextShift = body.ContextShift

--- a/internal/server/configapi_estimate.go
+++ b/internal/server/configapi_estimate.go
@@ -90,6 +90,14 @@ func estimateInputFromCmd(cmd string) autogen.EstimateInput {
 			if v, ok := next(); ok {
 				in.KvV = v
 			}
+		case "-ctkd", "--cache-type-k-draft":
+			if v, ok := next(); ok {
+				in.KvKDraft = v
+			}
+		case "-ctvd", "--cache-type-v-draft":
+			if v, ok := next(); ok {
+				in.KvVDraft = v
+			}
 		case "--no-kv-offload":
 			in.KvInRam = true
 		case "-md", "--model-draft", "--spec-draft-model":
@@ -107,6 +115,15 @@ func estimateInputFromCmd(cmd string) autogen.EstimateInput {
 	// cmds always carry both flags; this only catches hand-written ones.
 	if in.CheckpointMinStep <= 0 {
 		in.CheckpointMinStep = autogen.LlamaDefaultCheckpointMinStep
+	}
+	// Same rule for the draft cache type: a cmd with no -ctkd runs the MTP draft
+	// context on llama's f16 default whatever -ctk says, so the preview must
+	// charge f16 rather than the emitter's matched-to-main default.
+	if in.KvKDraft == "" {
+		in.KvKDraft = "f16"
+	}
+	if in.KvVDraft == "" {
+		in.KvVDraft = "f16"
 	}
 	if in.CtxCheckpoints == nil {
 		n := autogen.LlamaDefaultCtxCheckpoints

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,10 +47,11 @@ type Server struct {
 
 	perf *perf.Monitor
 	// systemVramMB is the idle system VRAM floor (MiB) on the largest GPU: the
-	// min used-VRAM observed while zero models were running. Sampled by a
-	// background goroutine off the perf monitor so it's captured even when no
-	// dashboard tab is open, and surfaced in /api/performance for the UI gauge.
-	// 0 = never observed an idle moment yet. See trackSystemVram.
+	// min used-VRAM observed across the MOST RECENT idle stretch (a run of perf
+	// samples with zero models running). Sampled by a background goroutine off
+	// the perf monitor so it's captured even when no dashboard tab is open, and
+	// surfaced in /api/performance for the UI gauge. 0 = never observed a long
+	// enough idle stretch yet. See trackSystemVram.
 	systemVramMB atomic.Int64
 
 	// vramGuard publishes the live VRAM ceiling the router admits against and
@@ -560,19 +561,44 @@ func (s *Server) freeVramGB() (float64, bool) {
 	return float64(free) / 1024.0, true
 }
 
+// idleFloorMinSamples is how many consecutive idle GPU samples an idle stretch
+// must produce before its minimum is published as the system floor. The first
+// sample after an unload is untrustworthy — the driver has not necessarily freed
+// the model's VRAM yet — so publishing it would pin the floor a whole model too
+// high. Two samples (~10s at the perf monitor's cadence) is enough for the
+// reading to settle without making a short idle gap unmeasurable.
+const idleFloorMinSamples = 2
+
 // trackSystemVram records the idle system-VRAM floor by subscribing to the perf
-// monitor and, on every GPU sample taken while no model is running, keeping the
-// MINIMUM used-VRAM seen on the largest GPU. Runs independent of the dashboard
-// so the floor is captured even with no UI tab open (the old browser-only
-// baseline never ran unless the VRAM widget was mounted). ponytail: ceiling — if
-// a model stays resident from boot with no idle gap, the floor is never sampled
-// and the UI falls back to its estimate; captured on the first unload.
+// monitor and keeping the MINIMUM used-VRAM seen on the largest GPU across the
+// current idle stretch — a run of samples with zero models running. Runs
+// independent of the dashboard so the floor is captured even with no UI tab open
+// (the old browser-only baseline never ran unless the VRAM widget was mounted).
+//
+// The floor is per-stretch, not all-time, and is republished (UP as well as
+// down) at the end of every idle gap. An all-time minimum silently rots: it gets
+// pinned at whatever the desktop cost during its quietest moment — typically
+// right after startup, before the app window, a browser and the compositor have
+// claimed theirs — and is never revised. Everything the desktop grows past that
+// point then lands in the dashboard's "Overhead" segment, which is a residual
+// (measured model slice - estimate) and so inherits the whole error. Measured on
+// an idle RX 7900 XTX: floor stuck at 616 MB while the card actually idled at
+// 1729 MB, inflating a model's unexplained overhead by 1.1 GB.
+//
+// ponytail: ceiling — if a model stays resident from boot with no idle gap, the
+// floor is never sampled and the UI falls back to its estimate; captured on the
+// first unload. vramGuard.foreignFloorMB is an all-time minimum of the same
+// shape and has the same rot; it is a budget input rather than a display
+// residual, so it is left alone here.
 func (s *Server) trackSystemVram(ctx context.Context) {
 	if s.perf == nil {
 		return
 	}
 	_, gpuCh, unsub := s.perf.Subscribe()
 	defer unsub()
+	// Minimum used-VRAM within the current idle stretch, and how many samples it
+	// has seen. stretchMin < 0 = not currently idle (or the stretch just reset).
+	stretchMin, stretchN := int64(-1), 0
 	for {
 		select {
 		case <-ctx.Done():
@@ -582,6 +608,9 @@ func (s *Server) trackSystemVram(ctx context.Context) {
 				return
 			}
 			if len(s.local.RunningModels()) != 0 {
+				// A model is resident: end the stretch. The published floor stays
+				// as it was until the next idle stretch qualifies.
+				stretchMin, stretchN = -1, 0
 				continue
 			}
 			// Largest-GPU used VRAM, matching freeVramGB's GPU choice.
@@ -600,8 +629,12 @@ func (s *Server) trackSystemVram(ctx context.Context) {
 				continue
 			}
 			used := int64(bestStat.MemUsedMB)
-			if cur := s.systemVramMB.Load(); cur == 0 || used < cur {
-				s.systemVramMB.Store(used)
+			if stretchMin < 0 || used < stretchMin {
+				stretchMin = used
+			}
+			stretchN++
+			if stretchN >= idleFloorMinSamples {
+				s.systemVramMB.Store(stretchMin)
 			}
 		}
 	}

--- a/ui-svelte/src/components/ModelConfigModal.svelte
+++ b/ui-svelte/src/components/ModelConfigModal.svelte
@@ -163,7 +163,7 @@
   // Numeric fields hold "" (=inherit/omit) or a number; tri-states hold ""/"on"/"off".
   type AdvKnobs = {
     threadsBatch: number | ""; prio: number | ""; directIo: boolean; noOpOffload: boolean; noRepack: boolean;
-    kvKDraft: string; kvVDraft: string; cacheReuse: number | ""; cacheRamMB: number | ""; cacheIdleSlots: string;
+    kvKDraft: string; kvVDraft: string; cacheReuse: number | ""; logVerbosity: number | ""; cacheRamMB: number | ""; cacheIdleSlots: string;
     swaFull: boolean; checkpointMinStep: number | ""; contextShift: string; specDraftNMin: number | "";
     slotPromptSimilarity: number | ""; ropeScaling: string; ropeScale: number | ""; ropeFreqBase: number | "";
     yarnOrigCtx: number | ""; splitMode: string; tensorSplit: string; mainGpu: number | ""; overrideTensor: string;
@@ -177,7 +177,7 @@
   function blankAdv(): AdvKnobs {
     return {
       threadsBatch: "", prio: "", directIo: false, noOpOffload: false, noRepack: false,
-      kvKDraft: "", kvVDraft: "", cacheReuse: "", cacheRamMB: "", cacheIdleSlots: "",
+      kvKDraft: "", kvVDraft: "", cacheReuse: "", logVerbosity: "", cacheRamMB: "", cacheIdleSlots: "",
       swaFull: false, checkpointMinStep: "", contextShift: "", specDraftNMin: "",
       slotPromptSimilarity: "", ropeScaling: "", ropeScale: "", ropeFreqBase: "",
       yarnOrigCtx: "", splitMode: "", tensorSplit: "", mainGpu: "", overrideTensor: "",
@@ -192,7 +192,7 @@
       threadsBatch: o?.threadsBatch || "", prio: o?.prio || "", directIo: o?.directIo ?? false,
       noOpOffload: o?.noOpOffload ?? false, noRepack: o?.noRepack ?? false,
       kvKDraft: o?.kvKDraft ?? "", kvVDraft: o?.kvVDraft ?? "",
-      cacheReuse: o?.cacheReuse || "", cacheRamMB: o?.cacheRamMB || "", cacheIdleSlots: o?.cacheIdleSlots ?? "",
+      cacheReuse: o?.cacheReuse || "", logVerbosity: o?.logVerbosity || "", cacheRamMB: o?.cacheRamMB || "", cacheIdleSlots: o?.cacheIdleSlots ?? "",
       swaFull: o?.swaFull ?? false, checkpointMinStep: o?.checkpointMinStep || "", contextShift: o?.contextShift ?? "",
       specDraftNMin: o?.specDraftNMin || "", slotPromptSimilarity: o?.slotPromptSimilarity || "",
       ropeScaling: o?.ropeScaling ?? "", ropeScale: o?.ropeScale || "", ropeFreqBase: o?.ropeFreqBase || "",
@@ -216,7 +216,7 @@
     return {
       threadsBatch: n(adv.threadsBatch), prio: n(adv.prio), directIo: adv.directIo,
       noOpOffload: adv.noOpOffload, noRepack: adv.noRepack, kvKDraft: adv.kvKDraft, kvVDraft: adv.kvVDraft,
-      cacheReuse: n(adv.cacheReuse), cacheRamMB: n(adv.cacheRamMB), cacheIdleSlots: adv.cacheIdleSlots,
+      cacheReuse: n(adv.cacheReuse), logVerbosity: n(adv.logVerbosity), cacheRamMB: n(adv.cacheRamMB), cacheIdleSlots: adv.cacheIdleSlots,
       swaFull: adv.swaFull, checkpointMinStep: n(adv.checkpointMinStep), contextShift: adv.contextShift,
       specDraftNMin: n(adv.specDraftNMin), slotPromptSimilarity: n(adv.slotPromptSimilarity),
       ropeScaling: adv.ropeScaling, ropeScale: n(adv.ropeScale), ropeFreqBase: n(adv.ropeFreqBase),
@@ -2534,6 +2534,10 @@
             <label class="flex items-center gap-2">
               <span class="text-txtsecondary flex items-center gap-1">Cache reuse {@render hint("--cache-reuse N. Min chunk reused from the prompt cache via KV-shifting. 0 = off.")}</span>
               <input type="number" min="0" step="64" bind:value={adv.cacheReuse} use:wheelAdjust class="cfg-input w-20 ml-auto" placeholder="off" />
+            </label>
+            <label class="flex items-center gap-2">
+              <span class="text-txtsecondary flex items-center gap-1">Log verbosity {@render hint("-lv N. llama-server log verbosity threshold. Raise it to capture the load-time buffer-size report in the model log. Empty = backend default.")}</span>
+              <input type="number" min="0" step="1" bind:value={adv.logVerbosity} use:wheelAdjust class="cfg-input w-20 ml-auto" placeholder="default" />
             </label>
             <label class="flex items-center gap-2">
               <span class="text-txtsecondary flex items-center gap-1">Cache RAM (MiB) {@render hint("-cram. Max prompt-cache size in MiB. Empty = llama default (8192).")}</span>

--- a/ui-svelte/src/components/ModelConfigModal.svelte
+++ b/ui-svelte/src/components/ModelConfigModal.svelte
@@ -2556,11 +2556,11 @@
               <input type="number" min="0" step="1" bind:value={adv.mainGpu} use:wheelAdjust class="cfg-input w-20 ml-auto" placeholder="0" />
             </label>
             <label class="flex items-center gap-2">
-              <span class="text-txtsecondary flex items-center gap-1">Draft KV-K {@render hint("-ctkd. Draft/spec model K cache type. Empty = f16.")}</span>
+              <span class="text-txtsecondary flex items-center gap-1">Draft KV-K {@render hint("-ctkd. Draft/spec context K cache type, including a baked-in MTP head. Empty = match KV-K.")}</span>
               <input type="text" bind:value={adv.kvKDraft} class="cfg-input w-20 ml-auto" placeholder="f16" />
             </label>
             <label class="flex items-center gap-2">
-              <span class="text-txtsecondary flex items-center gap-1">Draft KV-V {@render hint("-ctvd. Draft/spec model V cache type. Empty = f16.")}</span>
+              <span class="text-txtsecondary flex items-center gap-1">Draft KV-V {@render hint("-ctvd. Draft/spec context V cache type, including a baked-in MTP head. Empty = match KV-V.")}</span>
               <input type="text" bind:value={adv.kvVDraft} class="cfg-input w-20 ml-auto" placeholder="f16" />
             </label>
             <label class="flex items-center gap-2">

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -438,6 +438,7 @@ export interface ModelOverride {
   cacheReuse?: number;
   cacheRamMB?: number;
   cacheIdleSlots?: string;
+  logVerbosity?: number;
   swaFull?: boolean;
   checkpointMinStep?: number;
   contextShift?: string;

--- a/ui-svelte/src/stores/vram.test.ts
+++ b/ui-svelte/src/stores/vram.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { loadedSegments } from "./vram";
+import type { PlanEstimate } from "./api";
+
+// A plausible estimate: 10 GB total = 6 weights + 2 KV + 0.5 draft + 0.5
+// compute + 0.5 ckpt + 0.5 headroom.
+function est(p: Partial<PlanEstimate> = {}): PlanEstimate {
+  return {
+    ctx: 32768, ngl: 99, nCpuMoe: 0,
+    estVramGB: 10, estRamGB: 0, targetVramGB: 24, maxRamGB: 64,
+    kvReserveGB: 2, checkpointGB: 0.5, draftGB: 0.5, computeBufGB: 0.5,
+    mmprojGB: 0, overheadGB: 0.5, ramExceeded: false, isMoE: false,
+    ...p,
+  };
+}
+const labels = (segs: { label: string }[] | null) => (segs ?? []).map((s) => s.label);
+const mb = (segs: { label: string; mb: number }[] | null, label: string) =>
+  (segs ?? []).find((s) => s.label === label)?.mb ?? 0;
+
+describe("loadedSegments", () => {
+  // The bug: with two models loaded the rail fell back to one flat "Model(s)"
+  // block, losing the whole component breakdown exactly when the card is
+  // fullest. Components are summed across models, not dropped.
+  it("splits by component with two models loaded", () => {
+    const segs = loadedSegments(
+      [{ id: "a", name: "alpha" }, { id: "b", name: "beta" }],
+      { a: est(), b: est({ estVramGB: 5, kvReserveGB: 1, ctx: 8192 }) },
+      15 * 1024,
+    );
+    expect(labels(segs)).toEqual([
+      "Weights", "Draft", "Compute buffer", "KV cache", "Checkpoints", "Headroom",
+    ]);
+    expect(mb(segs, "KV cache")).toBeCloseTo(3 * 1024, 6); // 2 + 1
+    // 10 + 5 estimated, 15 measured: nothing unaccounted, so no surplus.
+    expect(mb(segs, "Overhead")).toBe(0);
+    // The hover says whose VRAM shares the segment, with each model's own ctx.
+    const kv = (segs ?? []).find((s) => s.label === "KV cache")!;
+    expect(kv.detail).toContain("alpha + beta");
+    expect(kv.detail).toContain("alpha ctx 32768");
+    expect(kv.detail).toContain("beta ctx 8192");
+  });
+
+  it("charges the unexplained remainder to Overhead", () => {
+    const segs = loadedSegments([{ id: "a" }], { a: est() }, 10.5 * 1024);
+    expect(mb(segs, "Overhead")).toBeCloseTo(0.5 * 1024, 6);
+    expect(mb(segs, "Weights")).toBeCloseTo(6 * 1024, 6);
+  });
+
+  it("scales components down when the measurement is under the estimate", () => {
+    const segs = loadedSegments([{ id: "a" }], { a: est() }, 5 * 1024);
+    expect(mb(segs, "Weights")).toBeCloseTo(3 * 1024, 6); // half of 6
+    expect(mb(segs, "Overhead")).toBe(0);
+  });
+
+  // A model mid-load has no estimate yet: the caller needs the null so it can
+  // paint the flat slice rather than a split that leaves that model's VRAM out.
+  it("gives up when any loaded model has no estimate", () => {
+    expect(loadedSegments([{ id: "a" }, { id: "b" }], { a: est() }, 15 * 1024)).toBeNull();
+    expect(loadedSegments([], {}, 0)).toBeNull();
+  });
+});

--- a/ui-svelte/src/stores/vram.ts
+++ b/ui-svelte/src/stores/vram.ts
@@ -8,9 +8,11 @@ import { models, estimatePlan, type PlanEstimate } from "./api";
 // model usage ≈ live used − baseline. Before the first idle sample the baseline
 // is unknown, so everything is attributed to system (safe under-report).
 //
-// When a single model is loaded we further break its slice into model weights /
-// KV cache / CUDA-runtime overhead using the load-plan estimate (the only source
-// we have for the component split — the driver only reports a single total).
+// Whenever we hold a load-plan estimate for EVERY loaded model we further break
+// their slice into model weights / KV cache / runtime overhead (the estimate is
+// the only source we have for the component split — the driver only reports a
+// single total). With two models loaded this used to give up and paint one flat
+// "Model(s)" block, which is exactly when the split is most useful.
 let baselineMb: number | null = null;
 
 export interface VramSegment {
@@ -62,26 +64,125 @@ export function estimateSegments(est: PlanEstimate, kvInRam = false): VramSegmen
   return segs;
 }
 
-// Plan estimate for the currently loaded model, refreshed when the active model
-// changes. Drives the weights/KV/overhead component split.
-const activeEstimate = writable<{ id: string; est: PlanEstimate } | null>(null);
-let estFetchId: string | null = null;
+// Plan estimates for the loaded models, keyed by model id. Refreshed as models
+// come and go: an id already fetched (or in flight) is never re-fetched, and an
+// id that leaves the ready set is dropped, so a swap costs exactly one request
+// for the model that actually arrived.
+const activeEstimates = writable<Record<string, PlanEstimate>>({});
+let estCache: Record<string, PlanEstimate> = {};
+// In-flight ids double as the "do we still want this?" flag: an id deleted here
+// by an unload makes the late-arriving response drop on the floor instead of
+// resurrecting a model that is gone.
+const estInflight = new Set<string>();
 
 models.subscribe(($models) => {
-  const ready = $models.filter((m) => m.state === "ready");
-  if (ready.length === 1) {
-    const id = ready[0].id;
-    if (estFetchId !== id) {
-      estFetchId = id;
-      estimatePlan(id, { actual: true })
-        .then((est) => activeEstimate.set({ id, est }))
-        .catch(() => activeEstimate.set(null));
+  const ready = $models.filter((m) => m.state === "ready").map((m) => m.id);
+  const readySet = new Set(ready);
+  let dropped = false;
+  for (const id of Object.keys(estCache)) {
+    if (!readySet.has(id)) {
+      delete estCache[id];
+      dropped = true;
     }
-  } else {
-    estFetchId = null;
-    activeEstimate.set(null);
+  }
+  for (const id of [...estInflight]) if (!readySet.has(id)) estInflight.delete(id);
+  if (dropped) {
+    estCache = { ...estCache };
+    activeEstimates.set(estCache);
+  }
+  for (const id of ready) {
+    if (estCache[id] || estInflight.has(id)) continue;
+    estInflight.add(id);
+    estimatePlan(id, { actual: true })
+      .then((est) => {
+        if (!estInflight.delete(id)) return; // unloaded while we were fetching
+        estCache = { ...estCache, [id]: est };
+        activeEstimates.set(estCache);
+      })
+      .catch(() => {
+        estInflight.delete(id);
+      });
   }
 });
+
+/** The bits of a Model this store needs, so the split can be unit-tested. */
+export interface VramModelRef {
+  id: string;
+  name?: string;
+}
+
+// loadedSegments splits the measured model slice (modelMb) into per-component
+// segments, summing the same component across ALL loaded models: two models put
+// their weights in one "Weights" segment, their caches in one "KV cache", and so
+// on. Aggregating by component rather than by model keeps the legend the same
+// seven colors no matter how many models are resident, and keeps the bar
+// readable when a third one loads.
+//
+// Returns null when any loaded model has no estimate yet (mid-load, or the
+// estimate request failed), which is the caller's cue to fall back to the flat
+// undifferentiated slice.
+export function loadedSegments(
+  live: VramModelRef[],
+  estimates: Record<string, PlanEstimate>,
+  modelMb: number,
+): VramSegment[] | null {
+  if (live.length === 0) return null;
+  const ests = live.map((m) => estimates[m.id]);
+  if (ests.some((e) => !e)) return null;
+
+  const parts = ests.map((e) => {
+    const kv = Math.max(0, e.kvReserveGB * 1024);
+    const ckpt = Math.max(0, (e.checkpointGB ?? 0) * 1024);
+    // Draft/MTP is charged in VRAM whatever the KV placement, so it is its own
+    // slice rather than part of KV.
+    const draft = Math.max(0, (e.draftGB ?? 0) * 1024);
+    const compute = Math.max(0, (e.computeBufGB ?? 0) * 1024);
+    const mmproj = Math.max(0, (e.mmprojGB ?? 0) * 1024);
+    const headroom = Math.max(0, (e.overheadGB ?? 0) * 1024);
+    const total = Math.max(0, e.estVramGB * 1024);
+    // estVramGB folds every reserve in; subtract each to leave the pure
+    // model-file weights share (why the total exceeds the raw gguf size).
+    const weights = Math.max(0, total - kv - ckpt - draft - compute - mmproj - headroom);
+    return { kv, ckpt, draft, compute, mmproj, headroom, total, weights, ctx: e.ctx };
+  });
+  const sum = (pick: (p: (typeof parts)[number]) => number) =>
+    parts.reduce((a, p) => a + pick(p), 0);
+  const estTotalMb = sum((p) => p.total);
+
+  // Fit the estimated components inside the measured model slice. If the
+  // measurement exceeds the estimate, the surplus is unaccounted runtime
+  // overhead. If it's under, scale the components down proportionally.
+  let scale = 1;
+  let surplusMb = 0;
+  if (estTotalMb <= modelMb) {
+    surplusMb = modelMb - estTotalMb;
+  } else {
+    scale = estTotalMb > 0 ? modelMb / estTotalMb : 0;
+  }
+
+  const names = live.map((m) => m.name || m.id);
+  // One model reads as "<name> ...", several as "<a> + <b> ...", so a hover on
+  // the shared segment still says whose VRAM is in it.
+  const who = names.join(" + ");
+  const ctxDetail =
+    parts.length === 1
+      ? `ctx ${parts[0].ctx}`
+      : names.map((n, i) => `${n} ctx ${parts[i].ctx}`).join(", ");
+
+  const segments: VramSegment[] = [];
+  const push = (label: string, mb: number, cls: string, detail: string) => {
+    if (mb > 0) segments.push({ label, mb, class: cls, detail });
+  };
+  push("Weights", sum((p) => p.weights) * scale, "bg-primary", `${who} model file weights on GPU`);
+  push("Vision projector", sum((p) => p.mmproj) * scale, "bg-primary/60", `${who} mmproj weights + CLIP compute reserve`);
+  push("Draft", sum((p) => p.draft) * scale, "bg-primary/40", `${who} speculative draft / MTP model on GPU`);
+  push("Compute buffer", sum((p) => p.compute) * scale, "bg-success", `${who} logits + activations`);
+  push("KV cache", sum((p) => p.kv) * scale, "bg-warning", `${who} attention cache (${ctxDetail})`);
+  push("Checkpoints", sum((p) => p.ckpt) * scale, "bg-error", `${who} context-checkpoint KV snapshots`);
+  push("Headroom", sum((p) => p.headroom) * scale, "bg-txtsecondary/30", "reserved safety headroom (vramOverheadGB)");
+  push("Overhead", surplusMb, "bg-success/60", "measured runtime overhead beyond the estimate");
+  return segments;
+}
 
 // foreignSeg builds the red "Foreign" segment for VRAM held by a llama-server
 // we didn't spawn. Returns [] when none detected.
@@ -99,8 +200,8 @@ function foreignSeg(mb: number, procs?: { name: string }[]): VramSegment[] {
 }
 
 export const vramBreakdown = derived(
-  [latestGpu, models, activeEstimate, foreignVram, systemVram],
-  ([$gpu, $models, $est, $foreign, $sysVram]): VramBreakdown | null => {
+  [latestGpu, models, activeEstimates, foreignVram, systemVram],
+  ([$gpu, $models, $ests, $foreign, $sysVram]): VramBreakdown | null => {
     if (!$gpu) return null;
 
     const live = $models.filter(
@@ -133,10 +234,16 @@ export const vramBreakdown = derived(
       };
     }
 
+    // Total estimated VRAM across the loaded models, or null while any of them
+    // is still missing an estimate (a model mid-load has none yet).
+    const estTotalMb = live.every((m) => $ests[m.id])
+      ? live.reduce((a, m) => a + $ests[m.id].estVramGB * 1024, 0)
+      : null;
+
     // System floor. Prefer the server-measured idle floor (sampled even with no
     // dashboard open), then the browser's own idle baseline. If neither caught an
-    // idle sample (e.g. a model was already resident at page load) but we have a
-    // load-plan estimate for the single loaded model, fall back to
+    // idle sample (e.g. a model was already resident at page load) but we have
+    // load-plan estimates for everything loaded, fall back to
     // used − estimated-model-VRAM so the model slice still shows instead of
     // being attributed entirely to "System".
     let sysFloor: number;
@@ -145,8 +252,8 @@ export const vramBreakdown = derived(
       sysFloor = Math.min($sysVram, used);
     } else if (baselineMb !== null) {
       sysFloor = Math.min(baselineMb, used);
-    } else if ($est && live.length === 1 && live[0].id === $est.id) {
-      sysFloor = Math.max(0, used - $est.est.estVramGB * 1024);
+    } else if (estTotalMb !== null) {
+      sysFloor = Math.max(0, used - estTotalMb);
       measured = false;
     } else {
       sysFloor = used;
@@ -161,60 +268,15 @@ export const vramBreakdown = derived(
       detail: "OS, other apps" + (measured ? "" : " (estimated - no idle baseline yet)"),
     };
 
-    // Component split when we have a fresh estimate for the single loaded model.
-    if (modelMb > 0 && $est && live.length === 1 && live[0].id === $est.id) {
-      const estTotalMb = $est.est.estVramGB * 1024;
-      const kvEstMb = Math.max(0, $est.est.kvReserveGB * 1024);
-      const ckptEstMb = Math.max(0, ($est.est.checkpointGB ?? 0) * 1024);
-      const draftEstMb = Math.max(0, ($est.est.draftGB ?? 0) * 1024);
-      const computeEstMb = Math.max(0, ($est.est.computeBufGB ?? 0) * 1024);
-      const mmprojEstMb = Math.max(0, ($est.est.mmprojGB ?? 0) * 1024);
-      const headroomEstMb = Math.max(0, ($est.est.overheadGB ?? 0) * 1024);
-      // estVramGB folds KV, checkpoints, draft, compute buffer, vision projector and
-      // headroom in; subtract each to leave the pure model-file weights share.
-      const weightsEstMb = Math.max(0, estTotalMb - kvEstMb - ckptEstMb - draftEstMb - computeEstMb - mmprojEstMb - headroomEstMb);
-
-      // Fit the estimated components inside the measured model slice. If the
-      // measurement exceeds the estimate, the surplus is unaccounted runtime
-      // overhead. If it's under, scale the components down proportionally.
-      let scale = 1;
-      let surplusMb = 0;
-      if (estTotalMb <= modelMb) {
-        surplusMb = modelMb - estTotalMb;
-      } else {
-        scale = estTotalMb > 0 ? modelMb / estTotalMb : 0;
-      }
-      const weightsMb = weightsEstMb * scale;
-      const kvMb = kvEstMb * scale;
-      const ckptMb = ckptEstMb * scale;
-      const draftMb = draftEstMb * scale;
-      const computeMb = computeEstMb * scale;
-      const mmprojMb = mmprojEstMb * scale;
-      const headroomMb = headroomEstMb * scale;
-
-      const name = live[0].name || live[0].id;
-      const segments: VramSegment[] = [systemSeg];
-      if (weightsMb > 0)
-        segments.push({ label: "Weights", mb: weightsMb, class: "bg-primary", detail: `${name} model file weights on GPU` });
-      if (mmprojMb > 0)
-        segments.push({ label: "Vision projector", mb: mmprojMb, class: "bg-primary/60", detail: `${name} mmproj weights + CLIP compute reserve` });
-      if (draftMb > 0)
-        segments.push({ label: "Draft", mb: draftMb, class: "bg-primary/40", detail: `${name} speculative draft / MTP model on GPU` });
-      if (computeMb > 0)
-        segments.push({ label: "Compute buffer", mb: computeMb, class: "bg-success", detail: `${name} logits + activations` });
-      if (kvMb > 0)
-        segments.push({ label: "KV cache", mb: kvMb, class: "bg-warning", detail: `${name} attention cache (ctx ${$est.est.ctx})` });
-      if (ckptMb > 0)
-        segments.push({ label: "Checkpoints", mb: ckptMb, class: "bg-error", detail: `${name} context-checkpoint KV snapshots` });
-      if (headroomMb > 0)
-        segments.push({ label: "Headroom", mb: headroomMb, class: "bg-txtsecondary/30", detail: "reserved safety headroom (vramOverheadGB)" });
-      if (surplusMb > 0)
-        segments.push({ label: "Overhead", mb: surplusMb, class: "bg-success/60", detail: "measured runtime overhead beyond the estimate" });
-      segments.push(...foreign);
-      return { usedMb: rawUsed, totalMb: $gpu.mem_total_mb, segments };
+    // Component split whenever every loaded model has a fresh estimate, however
+    // many that is.
+    const split = modelMb > 0 ? loadedSegments(live, $ests, modelMb) : null;
+    if (split) {
+      return { usedMb: rawUsed, totalMb: $gpu.mem_total_mb, segments: [systemSeg, ...split, ...foreign] };
     }
 
-    // Fallback: undifferentiated model slice (no estimate, or >1 model).
+    // Fallback: undifferentiated model slice (a model still loading, or an
+    // estimate request that failed).
     const modelNames = live.map((m) => m.name || m.id);
     return {
       usedMb: rawUsed,


### PR DESCRIPTION
Chased the dashboard''s residual Overhead segment (1.2 GB with two models
loaded) down to unpriced VRAM charges and a measurement bug. All figures come
from PDH per-process dedicated VRAM on an RX 7900 XTX (ROCm gfx1100).

- Keep the idle VRAM floor per idle stretch instead of all-time, so a floor
  sampled while a model was resident never deflates a later reading.
- Price the baked-in MTP drafter by context: it is a second `llama_context` at
  the target''s full `n_ctx`, so its KV is a ctx-scaled slope, not a flat charge.
- Split `computeBufferGB` into a per-CONTEXT `computeGraphGB` and a per-PROCESS
  `runtimeCtxGB`, then charge the MTP drafter its own graph. It inherits
  `params_base`, so it projects over the same vocabulary at the same ubatch:
  0.55 GiB on Qwen3.8-27B, against the flat 0.15 GB pad meant to cover it.
- `computeHipCtxGB = 0.4`: the non-CUDA per-process runtime was charged 0. Two
  unrelated models each left the same ~0.4 GiB unexplained.
- Keep the dashboard VRAM breakdown when more than one model is loaded.
- Add a per-model `logVerbosity` override emitting `-lv N`, so llama-server''s
  load-time buffer report can settle these questions by reading rather than by
  arithmetic.