### PR TITLE
setup: install headlessly and configure the admin gate from argv

### DIFF
--- a/cmd/quartermaster-setup/headless.go
+++ b/cmd/quartermaster-setup/headless.go
@@ -1,0 +1,118 @@
+package main
+
+// The no-UI install path.
+//
+// The wizard's normal shape is a window (or a browser) driving an HTTP API on
+// loopback, which is exactly what a headless server does not have: there is no
+// display for the window, no browser for the fallback, and the API is bound to
+// 127.0.0.1 and Host-checked, so it cannot be driven from the operator's
+// desktop either. Before this, installing on such a box meant running the
+// server binary by hand and writing the generate file yourself.
+//
+// So this mode answers the wizard's questions from argv and runs the same
+// install, reporting to stderr. It shares every step with the interactive path:
+// the same Choices struct, the same Wizard.Start, the same backend downloads.
+// Only the source of the answers and the reporting surface differ.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/quartermaster-labs/quartermaster/internal/setup"
+)
+
+// statusPoll is how often the run is sampled for progress. The interactive UI
+// polls at a similar rate; a terminal needs no faster, and every sample that
+// reports the same step prints nothing.
+const statusPoll = 250 * time.Millisecond
+
+// headlessChoices fills a Choices from the command line, taking anything the
+// operator did not name from the same probe the wizard's first screen shows.
+//
+// Defaulting to the probe rather than to a fixed list is what keeps the two
+// paths honest: a headless install picks the compute backend this machine would
+// have been offered, including the platform fallbacks (no CUDA build exists for
+// Linux, so an NVIDIA box there is recommended Vulkan, not a download that
+// cannot happen).
+func headlessChoices(dir, modelsRoot, variant, components string) setup.Choices {
+	probe := setup.NewProbe(dir)
+
+	c := setup.Choices{
+		Dir:        dir,
+		ModelsRoot: modelsRoot,
+		Variant:    variant,
+	}
+	if c.Variant == "" {
+		c.Variant = probe.Variant
+	}
+
+	switch strings.TrimSpace(components) {
+	case "":
+		for _, comp := range probe.Components {
+			if comp.Selected {
+				c.Components = append(c.Components, comp.ID)
+			}
+		}
+	case "none":
+		// Explicitly nothing: the operator wants the files and the config, and
+		// will pick backends from Settings later.
+	default:
+		for _, id := range strings.Split(components, ",") {
+			if id = strings.TrimSpace(id); id != "" {
+				c.Components = append(c.Components, id)
+			}
+		}
+	}
+	return c
+}
+
+// runHeadless performs the install and returns the process exit code.
+//
+// Progress is printed only when it changes, so a log captured by a service
+// manager or an SSH session stays readable: an install is minutes of backend
+// downloads, and a line per poll would be thousands of them.
+func runHeadless(wiz *setup.Wizard, c setup.Choices, launch bool) int {
+	report := func(format string, args ...any) {
+		fmt.Fprintf(os.Stderr, "setup: "+format+"\n", args...)
+	}
+	report("installing into %s", c.Dir)
+	if len(c.Components) > 0 {
+		report("backends: %s (%s)", strings.Join(c.Components, ", "), c.Variant)
+	}
+
+	if err := wiz.Start(context.Background(), c); err != nil {
+		report("could not start: %v", err)
+		return 1
+	}
+
+	last := ""
+	for {
+		st := wiz.Status()
+		if line := strings.TrimSpace(st.Step + " " + st.Detail); line != last && line != "" {
+			report("%s", line)
+			last = line
+		}
+		switch st.Phase {
+		case setup.PhaseError:
+			report("failed: %s", st.Error)
+			return 1
+		case setup.PhaseDone:
+			for _, w := range st.Warnings {
+				report("warning: %s", w)
+			}
+			// Finish runs Options.Launch, which is the whole point on a server:
+			// the install is useless until something starts it, and there is no
+			// window here to click "Launch" in.
+			if err := wiz.Finish(launch); err != nil {
+				report("install completed but launching failed: %v", err)
+				return 1
+			}
+			report("done")
+			return 0
+		}
+		time.Sleep(statusPoll)
+	}
+}

--- a/cmd/quartermaster-setup/headless_test.go
+++ b/cmd/quartermaster-setup/headless_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The components flag is the one piece of headlessChoices with real parsing:
+// empty means "the recommended set", which is hardware-derived and therefore
+// not asserted here, while an explicit list and "none" must be exact.
+func TestHeadlessChoices_Components(t *testing.T) {
+	t.Run("an explicit list is taken verbatim", func(t *testing.T) {
+		c := headlessChoices("/opt/qm", "/models", "vulkan", "llama-server, sd-server")
+		if got := strings.Join(c.Components, ","); got != "llama-server,sd-server" {
+			t.Errorf("components = %q", got)
+		}
+		if c.Dir != "/opt/qm" || c.ModelsRoot != "/models" || c.Variant != "vulkan" {
+			t.Errorf("choices = %+v", c)
+		}
+	})
+
+	t.Run("none installs nothing", func(t *testing.T) {
+		if c := headlessChoices("/opt/qm", "", "cpu", "none"); len(c.Components) != 0 {
+			t.Errorf("components = %v, want none", c.Components)
+		}
+	})
+
+	// An empty models folder is a legitimate answer ("I'll choose in the
+	// dashboard"), so it must not be turned into a path.
+	t.Run("an empty models root stays empty", func(t *testing.T) {
+		if c := headlessChoices("/opt/qm", "", "cpu", "none"); c.ModelsRoot != "" {
+			t.Errorf("modelsRoot = %q, want empty", c.ModelsRoot)
+		}
+	})
+}

--- a/cmd/quartermaster-setup/main.go
+++ b/cmd/quartermaster-setup/main.go
@@ -28,6 +28,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/quartermaster-labs/quartermaster/internal/autogen"
 	"github.com/quartermaster-labs/quartermaster/internal/setup"
 )
 
@@ -45,8 +46,49 @@ func main() {
 		dir     = flag.String("dir", defaultInstallDir(), "default install directory")
 		browser = flag.Bool("browser", false, "skip the native window and use the default browser")
 		verbose = flag.Bool("v", false, "log progress to stderr")
+
+		// Headless install: no window, no browser, answers from argv.
+		headless   = flag.Bool("headless", false, "install without a UI, taking every answer from these flags (for servers with no display)")
+		modelsDir  = flag.String("models-dir", "", "where the models live; empty means choose later in the dashboard")
+		variant    = flag.String("variant", "", "compute backend variant (vulkan, cuda, rocm, metal, cpu); default: the one recommended for this machine")
+		components = flag.String("components", "", "comma-separated backends to install, or \"none\"; default: the recommended set")
+		noLaunch   = flag.Bool("no-launch", false, "do not start Quartermaster when the install finishes")
+
+		// Process-level settings written into the install's generate file. A
+		// server published beyond loopback serves its admin surface to itself
+		// only, so an install meant to be administered from another machine has
+		// to be told so here: the dashboard, the other place to set this, is
+		// behind the very gate being configured.
+		adminAllow = flag.String("admin-allow", "", "extra IPs/CIDRs (comma separated) allowed to reach the dashboard/admin endpoints, e.g. 192.168.1.0/24")
+		adminOpen  = flag.Bool("admin-open", false, "serve the unauthenticated dashboard/admin endpoints to every remote host")
+		tlsCert    = flag.String("tls-cert-file", "", "TLS certificate file for the installed server")
+		tlsKey     = flag.String("tls-key-file", "", "TLS key file for the installed server")
 	)
 	flag.Parse()
+
+	// Both or neither: quartermaster exits at startup with one of them, and a
+	// remote install that refuses to boot is the worst thing this binary can
+	// leave behind. Fail here, where the operator is still watching.
+	// A headless run has nobody to show a dialog to, and on Windows fatal()
+	// would otherwise block on a message box no one can dismiss.
+	noDialog = *headless
+
+	if (*tlsCert == "") != (*tlsKey == "") {
+		fatal("-tls-cert-file and -tls-key-file must be given together")
+	}
+	app := autogen.AppSettings{
+		AdminAllow:  *adminAllow,
+		TlsCertFile: *tlsCert,
+		TlsKeyFile:  *tlsKey,
+	}
+	// Only a flag the operator actually typed becomes a stored value: the
+	// setting is tri-state, and writing adminOpen: false on every run would
+	// overwrite a deliberate true on the next repair install.
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "admin-open" {
+			app.AdminOpen = adminOpen
+		}
+	})
 
 	logf := func(string) {}
 	if *verbose {
@@ -58,8 +100,13 @@ func main() {
 		DefaultDir: *dir,
 		Place:      place,
 		Launch:     launch,
+		App:        app,
 		Log:        logf,
 	})
+
+	if *headless {
+		os.Exit(runHeadless(wiz, headlessChoices(*dir, *modelsDir, *variant, *components), !*noLaunch))
+	}
 
 	url, stop, err := wiz.Listen()
 	if err != nil {
@@ -120,6 +167,12 @@ func defaultInstallDir() string {
 func fatal(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	_, _ = io.WriteString(os.Stderr, msg+"\n")
-	showError(msg)
+	if !noDialog {
+		showError(msg)
+	}
 	os.Exit(1)
 }
+
+// noDialog suppresses fatal's message box. Set for -headless, where stderr is
+// the only surface the operator can see.
+var noDialog bool

--- a/cmd/quartermaster/appflags.go
+++ b/cmd/quartermaster/appflags.go
@@ -45,6 +45,13 @@ func applyAppSettings(fs *flag.FlagSet, argvGiven map[string]bool, app autogen.A
 	if app.AdminOpen != nil {
 		set("admin-open", strconv.FormatBool(*app.AdminOpen))
 	}
+	// Both or neither: the server exits when only one is set, and filling in a
+	// lone stored half under a -tls-cert-file the user typed would turn a
+	// deliberate override into a startup failure.
+	if app.TlsCertFile != "" && app.TlsKeyFile != "" {
+		set("tls-cert-file", app.TlsCertFile)
+		set("tls-key-file", app.TlsKeyFile)
+	}
 	if app.WatchModels != nil {
 		set("watch-models", strconv.FormatBool(*app.WatchModels))
 	}

--- a/cmd/quartermaster/appflags_tls_test.go
+++ b/cmd/quartermaster/appflags_tls_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/quartermaster-labs/quartermaster/internal/autogen"
+)
+
+// Stored TLS files reach the flags as a pair. A lone half is dropped rather
+// than applied: the server exits when only one is set, so filling in half of a
+// pair would turn stored settings into a startup failure.
+func TestAppSettings_TlsPairing(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		app               autogen.AppSettings
+		wantCert, wantKey string
+	}{
+		{
+			name:     "both are applied",
+			app:      autogen.AppSettings{TlsCertFile: "/etc/ssl/qm.pem", TlsKeyFile: "/etc/ssl/qm.key"},
+			wantCert: "/etc/ssl/qm.pem",
+			wantKey:  "/etc/ssl/qm.key",
+		},
+		{
+			name: "a lone cert is ignored",
+			app:  autogen.AppSettings{TlsCertFile: "/etc/ssl/qm.pem"},
+		},
+		{
+			name: "a lone key is ignored",
+			app:  autogen.AppSettings{TlsKeyFile: "/etc/ssl/qm.key"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := newBundleFlags()
+			if err := fs.Parse(nil); err != nil {
+				t.Fatal(err)
+			}
+			applyAppSettings(fs, map[string]bool{}, tc.app)
+			if got := valueOf(t, fs, "tls-cert-file"); got != tc.wantCert {
+				t.Errorf("tls-cert-file = %q, want %q", got, tc.wantCert)
+			}
+			if got := valueOf(t, fs, "tls-key-file"); got != tc.wantKey {
+				t.Errorf("tls-key-file = %q, want %q", got, tc.wantKey)
+			}
+		})
+	}
+}
+
+// argv still wins, which is what makes a flag the way to rescue an install
+// whose stored certificate has expired or moved.
+func TestAppSettings_ArgvTlsWins(t *testing.T) {
+	fs := newBundleFlags()
+	if err := fs.Parse([]string{"-tls-cert-file", "/tmp/mine.pem", "-tls-key-file", "/tmp/mine.key"}); err != nil {
+		t.Fatal(err)
+	}
+	given := map[string]bool{"tls-cert-file": true, "tls-key-file": true}
+	applyAppSettings(fs, given, autogen.AppSettings{TlsCertFile: "/etc/ssl/qm.pem", TlsKeyFile: "/etc/ssl/qm.key"})
+	if got := valueOf(t, fs, "tls-cert-file"); got != "/tmp/mine.pem" {
+		t.Errorf("tls-cert-file = %q, want the argv value", got)
+	}
+}

--- a/cmd/quartermaster/bundle_test.go
+++ b/cmd/quartermaster/bundle_test.go
@@ -24,6 +24,8 @@ func newBundleFlags() *flag.FlagSet {
 	fs.Bool("tray", false, "")
 	fs.String("admin-allow", "", "")
 	fs.Bool("admin-open", false, "")
+	fs.String("tls-cert-file", "", "")
+	fs.String("tls-key-file", "", "")
 	fs.Bool("watch-models", true, "")
 	fs.Duration("watch-models-interval", 5*time.Second, "")
 	fs.Bool("no-update-check", false, "")

--- a/internal/autogen/appsettings.go
+++ b/internal/autogen/appsettings.go
@@ -45,6 +45,12 @@ type AppSettings struct {
 	// password, so this hands config editing and the model hub to anyone who can
 	// reach the port. Restart to apply.
 	AdminOpen *bool `yaml:"adminOpen,omitempty"`
+	// TlsCertFile and TlsKeyFile serve the API and dashboard over HTTPS. Both
+	// are required together; the server refuses to start with one of them. Paths
+	// are read by the server process, so they must be readable by the account it
+	// runs as. Restart to apply.
+	TlsCertFile string `yaml:"tlsCertFile,omitempty"`
+	TlsKeyFile  string `yaml:"tlsKeyFile,omitempty"`
 	// WatchModels re-scans the models folder periodically and hot-reloads when it
 	// changes. Defaults to on.
 	WatchModels *bool `yaml:"watchModels,omitempty"`
@@ -118,6 +124,12 @@ func mergeAppSettings(base, next AppSettings) AppSettings {
 	}
 	if next.AdminOpen != nil {
 		out.AdminOpen = next.AdminOpen
+	}
+	if next.TlsCertFile != "" {
+		out.TlsCertFile = next.TlsCertFile
+	}
+	if next.TlsKeyFile != "" {
+		out.TlsKeyFile = next.TlsKeyFile
 	}
 	if next.WatchModels != nil {
 		out.WatchModels = next.WatchModels

--- a/internal/setup/CLAUDE.md
+++ b/internal/setup/CLAUDE.md
@@ -32,9 +32,10 @@ everywhere and the 20 MB installer blob stays in the binary that ships it.
 | `api.go` | `Handler()` (the five `/api/setup/*` endpoints), `guard` (token + loopback Host), `serveUI` (embedded bundle, token injected into `index.html`), `Listen()`. `//go:embed all:ui_dist`. |
 | `run.go` | The install itself: `Start`, `run`, `ensureGenerate` (reports whether it created the file), `seedBudgets` (measures this box's VRAM/RAM into the freshly created generate file — first run only, never over a repair run), `installBackends`, `awaitJob`, `registerBackend`, `Finish`. |
 | `probe.go` | Opening state: `GpuNames`, `NewProbe` (variant list from the llama-server catalog entry, `probeComponents`), and `Scan` — the real discovery walk over a candidate models folder. |
-| `yaml.go` | `setSettingsKey` — line-level, comment-preserving edit of `settings.<key>` in the generate file. `minimalGenerate` for when there is no example to seed from. |
+| `yaml.go` | `setSettingsKey` — line-level, comment-preserving edit of `settings.<key>` in the generate file. `setAppKey` — the same one level deeper, for the nested `settings.app.<key>` block. `readYamlLines`/`writeYamlLines` hold the shared line-ending handling. |
+| `cmd/quartermaster-setup/headless.go` | `-headless`: `headlessChoices` (argv + `NewProbe` defaults) and `runHeadless` (poll `Status`, report to stderr, `Finish`). No window, no browser, no HTTP listener. |
 | `ui_dist/` | The built wizard bundle. Holds a committed `.gitkeep` so the `//go:embed` compiles on a tree where the UI was never built. |
-| `cmd/quartermaster-setup/main.go` | `runtime.LockOSThread`, flags (`-dir`, `-browser`, `-v`), `Listen` → `runWindow` → browser fallback, `defaultInstallDir`, `fatal`. |
+| `cmd/quartermaster-setup/main.go` | `runtime.LockOSThread`, flags (`-dir`, `-browser`, `-v`, `-headless` + its answers, and the process-level `-admin-allow`/`-admin-open`/`-tls-*`), `Listen` → `runWindow` → browser fallback, `defaultInstallDir`, `fatal`/`noDialog`. |
 | `cmd/quartermaster-setup/window_windows.go` | `runWindow` — creates the webview, hands it to `nativewin.Attach`, navigates, and closes it when the wizard signals done. The window mechanics themselves live in `internal/nativewin`, shared with the app window. |
 | `cmd/quartermaster-setup/place_windows.go` | `//go:embed inno/setup.exe`, `placeInno` (silent `/VERYSILENT /DIR= /TASKS= /LOG=`), `launch` — starts the installed exe with no arguments (it supplies its own; see `bundle.go`). |
 | `cmd/quartermaster-setup/place_other.go`, `place_common.go` | Unix install: `placeCopy` when a binary sits beside the wizard, else `placeEmbedded` (the `payload/server` embed), else `update.FetchBinary`. `placeCopy` is also the dev-build stand-in on Windows when no installer is embedded. |
@@ -81,6 +82,24 @@ everywhere and the 20 MB installer blob stays in the binary that ships it.
   did).
 - **`runWindow`** (Windows) — creates the webview, strips the caption, applies the icon, binds
   `qmDrag` / `qmMinimize` / `qmMaximize` / `qmClose` / `qmPickFolder`, then navigates.
+
+### Headless installs and the admin gate
+
+`-headless` exists because the interactive path needs three things a server does not have: a
+display for the window, a browser for the fallback, and a local operator for the loopback-bound,
+Host-checked API (`api.go`). It answers the same `Choices` from argv and runs the same
+`Wizard.Start`, so there is one install path, not two.
+
+`Options.App` (`autogen.AppSettings`) carries `-admin-allow`, `-admin-open` and the TLS files into
+`settings.app` of the generate file, via `applyAppSettings` in `run.go`. This is not a convenience:
+as soon as the API binds beyond loopback the admin surface answers only to the server itself, and
+the dashboard, the other place to set `adminAllow`, sits behind that same gate. A remote install
+without these flags comes up unreachable and has to be repaired over SSH.
+
+It writes the **generate file, not the sidecar**. Precedence is
+`argv > sidecar > settings.app > default`, so an installer-written value is a baseline the dashboard
+can still override; writing the sidecar would let a repair run silently overrule the running
+install's own settings.
 
 ## Gotchas / conventions
 

--- a/internal/setup/appsettings_test.go
+++ b/internal/setup/appsettings_test.go
@@ -1,0 +1,160 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/quartermaster-labs/quartermaster/internal/autogen"
+)
+
+// The whole point of setAppKey: what the setup binary writes must be what the
+// server reads back, through autogen's own loader rather than through a string
+// comparison that would pass on a file the server cannot parse.
+func TestApplyAppSettings_RoundTripsThroughAutogen(t *testing.T) {
+	gen := filepath.Join(t.TempDir(), "quartermaster-generate.yaml")
+	if err := os.WriteFile(gen, []byte(autogen.MinimalGenerateFile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	open := true
+	w := New(Options{App: autogen.AppSettings{
+		AdminAllow:  "192.168.1.0/24",
+		AdminOpen:   &open,
+		TlsCertFile: "C:/certs/qm.pem",
+		TlsKeyFile:  "/etc/ssl/qm.key",
+	}})
+	if err := w.applyAppSettings(gen); err != nil {
+		t.Fatalf("applyAppSettings: %v", err)
+	}
+
+	got, err := autogen.LoadAppSettings(gen)
+	if err != nil {
+		t.Fatalf("LoadAppSettings: %v", err)
+	}
+	if got.AdminAllow != "192.168.1.0/24" {
+		t.Errorf("AdminAllow = %q", got.AdminAllow)
+	}
+	if got.AdminOpen == nil || !*got.AdminOpen {
+		t.Errorf("AdminOpen = %v, want true", got.AdminOpen)
+	}
+	// Backslashes are normalised to forward slashes on the way in, which is
+	// what keeps a Windows path from reading as escape sequences in YAML.
+	if got.TlsCertFile != "C:/certs/qm.pem" || got.TlsKeyFile != "/etc/ssl/qm.key" {
+		t.Errorf("TLS = %q, %q", got.TlsCertFile, got.TlsKeyFile)
+	}
+}
+
+// A run that passed no flags must leave the file byte-identical: the common
+// case is a desktop install through the window, and rewriting the operator's
+// commented file for nothing is how comments get lost.
+func TestApplyAppSettings_NoFlagsLeavesTheFileAlone(t *testing.T) {
+	gen := filepath.Join(t.TempDir(), "quartermaster-generate.yaml")
+	if err := os.WriteFile(gen, []byte(autogen.MinimalGenerateFile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(gen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := New(Options{}).applyAppSettings(gen); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(gen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("file changed:\n%s", after)
+	}
+}
+
+// setAppKey edits the nested block, so the cases that matter are the ones
+// setSettingsKey's flat scan cannot express.
+func TestSetAppKey(t *testing.T) {
+	t.Run("creates the app block inside an existing settings block", func(t *testing.T) {
+		gen := writeGen(t, "settings:\n  modelsRoot: \"/models\"\n\noverrides: []\n")
+		if err := setAppKey(gen, "adminAllow", "10.0.0.0/8"); err != nil {
+			t.Fatal(err)
+		}
+		got := read(t, gen)
+		if !strings.Contains(got, "  app:\n    adminAllow: 10.0.0.0/8\n") {
+			t.Errorf("block not created:\n%s", got)
+		}
+		if !strings.Contains(got, "overrides: []") {
+			t.Errorf("trailing top-level key lost:\n%s", got)
+		}
+	})
+
+	t.Run("replaces a value already in the block", func(t *testing.T) {
+		gen := writeGen(t, "settings:\n  app:\n    listen: \"0.0.0.0:1250\"\n    adminAllow: 10.0.0.0/8\n")
+		if err := setAppKey(gen, "adminAllow", "192.168.0.0/16"); err != nil {
+			t.Fatal(err)
+		}
+		got := read(t, gen)
+		if strings.Contains(got, "10.0.0.0/8") {
+			t.Errorf("old value survived:\n%s", got)
+		}
+		if !strings.Contains(got, "    adminAllow: 192.168.0.0/16") {
+			t.Errorf("new value missing:\n%s", got)
+		}
+		if !strings.Contains(got, `    listen: "0.0.0.0:1250"`) {
+			t.Errorf("sibling key disturbed:\n%s", got)
+		}
+	})
+
+	t.Run("adds to an app block that is missing the key", func(t *testing.T) {
+		gen := writeGen(t, "settings:\n  app:\n    listen: \"0.0.0.0:1250\"\n  modelsRoot: \"/models\"\n")
+		if err := setAppKey(gen, "adminOpen", "true"); err != nil {
+			t.Fatal(err)
+		}
+		got := read(t, gen)
+		if !strings.Contains(got, "    listen: \"0.0.0.0:1250\"\n    adminOpen: true\n  modelsRoot:") {
+			t.Errorf("key not appended inside the block:\n%s", got)
+		}
+	})
+
+	t.Run("builds settings when the file has none", func(t *testing.T) {
+		gen := writeGen(t, "overrides: []\n")
+		if err := setAppKey(gen, "adminAllow", "10.0.0.0/8"); err != nil {
+			t.Fatal(err)
+		}
+		if got := read(t, gen); !strings.Contains(got, "settings:\n  app:\n    adminAllow: 10.0.0.0/8") {
+			t.Errorf("settings block not created:\n%s", got)
+		}
+	})
+
+	// Comments are the reason this edits lines instead of round-tripping
+	// through yaml.v3, and a CRLF file is what a Windows operator edits.
+	t.Run("keeps comments and the file's line ending", func(t *testing.T) {
+		gen := writeGen(t, "settings:\r\n  # where the models live\r\n  modelsRoot: \"/models\"\r\n")
+		if err := setAppKey(gen, "adminAllow", "10.0.0.0/8"); err != nil {
+			t.Fatal(err)
+		}
+		got := read(t, gen)
+		if !strings.Contains(got, "# where the models live") {
+			t.Errorf("comment lost:\n%q", got)
+		}
+		if strings.Contains(strings.ReplaceAll(got, "\r\n", ""), "\n") {
+			t.Errorf("mixed line endings:\n%q", got)
+		}
+	})
+}
+
+func writeGen(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "quartermaster-generate.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func read(t *testing.T, p string) string {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/internal/setup/run.go
+++ b/internal/setup/run.go
@@ -120,6 +120,14 @@ func (w *Wizard) run(ctx context.Context, c Choices) error {
 		}
 	}
 
+	// The command line's process-level settings, written after the file exists
+	// and before anything starts it. A failure here is fatal rather than a
+	// warning: the operator passed these because the install is remote, and one
+	// that comes up unreachable cannot be fixed from where they are.
+	if err := w.applyAppSettings(genPath); err != nil {
+		return err
+	}
+
 	if len(c.Components) > 0 {
 		w.step(PhaseBackends, "Downloading backends")
 		w.installBackends(ctx, c, genPath)
@@ -149,6 +157,39 @@ func ensureGenerate(path string) (created bool, err error) {
 		return true, os.WriteFile(path, b, 0o644)
 	}
 	return true, os.WriteFile(path, []byte(autogen.MinimalGenerateFile), 0o644)
+}
+
+// applyAppSettings writes Options.App into the install's generate file.
+//
+// Only non-zero fields are written, so a run that passed none of these flags
+// leaves the file exactly as the example seeded it. They land under
+// settings.app, the lowest-precedence layer above the built-in defaults, which
+// leaves both argv and anything the dashboard later saves free to override
+// them; see autogen.AppSettings for the full order.
+func (w *Wizard) applyAppSettings(genPath string) error {
+	app := w.opts.App
+	for _, kv := range []struct{ key, value string }{
+		{"adminAllow", app.AdminAllow},
+		{"tlsCertFile", app.TlsCertFile},
+		{"tlsKeyFile", app.TlsKeyFile},
+	} {
+		if kv.value == "" {
+			continue
+		}
+		if err := setAppKey(genPath, kv.key, kv.value); err != nil {
+			return fmt.Errorf("setting %s: %w", kv.key, err)
+		}
+	}
+	// A pointer, so "the operator asked for false" stays distinguishable from
+	// "not mentioned", and writing an explicit false is still worth doing: it
+	// pins the closed answer against an example file that could later ship a
+	// different one.
+	if app.AdminOpen != nil {
+		if err := setAppKey(genPath, "adminOpen", strconv.FormatBool(*app.AdminOpen)); err != nil {
+			return fmt.Errorf("setting adminOpen: %w", err)
+		}
+	}
+	return nil
 }
 
 // seedBudgets writes this machine's measured VRAM/RAM budgets into a

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -29,6 +29,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"sync"
+
+	"github.com/quartermaster-labs/quartermaster/internal/autogen"
 )
 
 // Phase is the coarse state of the install, and the only thing the UI switches
@@ -92,6 +94,16 @@ type Options struct {
 	// Launch starts the finished install. Called after the user clicks through
 	// the last step, immediately before the wizard exits.
 	Launch func(dir string) error
+
+	// App holds process-level settings supplied on the setup binary's own
+	// command line, written into the install's generate file before it first
+	// starts. Zero fields are left alone.
+	//
+	// This is how a headless install becomes reachable at all: the admin surface
+	// fails closed the moment the API binds beyond loopback, and the dashboard,
+	// which is the only other place to set adminAllow, sits behind that same
+	// gate. Without this the operator must hand-edit YAML over SSH afterwards.
+	App autogen.AppSettings
 
 	// Log receives progress lines. Optional.
 	Log func(string)

--- a/internal/setup/yaml.go
+++ b/internal/setup/yaml.go
@@ -26,7 +26,7 @@ var topLevelSettingsRe = regexp.MustCompile(`^settings:\s*$`)
 // did) would also rewrite a same-named key inside the trailing `overrides:`
 // list, where per-model entries legitimately repeat setting names.
 func setSettingsKey(path, key, value string) error {
-	raw, err := os.ReadFile(path)
+	lines, nl, trailingNL, err := readYamlLines(path)
 	if err != nil {
 		return err
 	}
@@ -34,21 +34,6 @@ func setSettingsKey(path, key, value string) error {
 	// Windows path with backslashes is a stack of escape sequences to a YAML
 	// double-quoted scalar. Forward slashes work everywhere, including Windows.
 	value = strings.ReplaceAll(value, `\`, `/`)
-
-	// Preserve the file's existing line ending; a CRLF file that grows one LF
-	// line renders as a stray glyph in Notepad, which is where users edit this.
-	nl := "\n"
-	if strings.Contains(string(raw), "\r\n") {
-		nl = "\r\n"
-	}
-	body := strings.ReplaceAll(string(raw), "\r\n", "\n")
-	// Split leaves a trailing "" for any file that ends in a newline, and that
-	// empty element is not a line: appending after it puts a blank line between
-	// the settings block and the new key, and costs the file its final newline.
-	// Strip it here, restore it at the end.
-	trailingNL := strings.HasSuffix(body, "\n")
-	body = strings.TrimSuffix(body, "\n")
-	lines := strings.Split(body, "\n")
 
 	keyRe := settingsKeyRe(key)
 	inSettings, done := false, false
@@ -82,7 +67,123 @@ func setSettingsKey(path, key, value string) error {
 		}
 		out = append(out, "  "+key+": "+quoteScalar(value))
 	}
-	joined := strings.Join(out, nl)
+	return writeYamlLines(path, out, nl, trailingNL)
+}
+
+// appBlockRe matches the "app:" line that opens the process-level block inside
+// settings.
+var appBlockRe = regexp.MustCompile(`^(\s+)app:\s*$`)
+
+// setAppKey sets settings.app.<key> in a generate file, in place.
+//
+// This is setSettingsKey one level deeper, and it exists because the
+// process-level block is nested: ports, TLS files and the remote-access policy
+// live under settings.app (see autogen.AppSettings), while everything
+// setSettingsKey writes is a scalar directly under settings.
+//
+// It writes the GENERATE FILE rather than the dashboard's sidecar, which is a
+// precedence choice, not a convenience one. The order is
+// argv > sidecar > settings.app > default, so a value written here is the
+// install's baseline and anything the operator later saves from the dashboard
+// still wins. Writing the sidecar instead would mean a re-run of the setup
+// binary silently overruling the running install's own settings.
+//
+// The block, and settings itself, are created when absent, so this works on a
+// minimal generate file that carries neither.
+func setAppKey(path, key, value string) error {
+	lines, nl, trailingNL, err := readYamlLines(path)
+	if err != nil {
+		return err
+	}
+	value = strings.ReplaceAll(value, `\`, `/`)
+
+	keyRe := settingsKeyRe(key)
+	inSettings, inApp, done := false, false, false
+	appIndent := ""
+	out := make([]string, 0, len(lines)+2)
+
+	for _, l := range lines {
+		if topLevelSettingsRe.MatchString(l) {
+			inSettings = true
+			out = append(out, l)
+			continue
+		}
+		if inSettings && !inApp && appIndent == "" && appBlockRe.MatchString(l) {
+			inApp = true
+			appIndent = appBlockRe.FindStringSubmatch(l)[1]
+			out = append(out, l)
+			continue
+		}
+		if inApp && strings.TrimSpace(l) != "" {
+			switch {
+			case len(indentOf(l)) > len(appIndent) && !done && keyRe.MatchString(l):
+				out = append(out, indentOf(l)+key+": "+quoteScalar(value))
+				done = true
+				continue
+			case len(indentOf(l)) <= len(appIndent):
+				// Left the app block: the key belongs to it, so it goes in
+				// before whatever starts here.
+				if !done {
+					out = append(out, appIndent+"  "+key+": "+quoteScalar(value))
+					done = true
+				}
+				inApp = false
+			}
+		}
+		if inSettings && !inApp && strings.TrimSpace(l) != "" && indentOf(l) == "" {
+			if !done {
+				out = append(out, "  app:", "    "+key+": "+quoteScalar(value))
+				done = true
+			}
+			inSettings = false
+		}
+		out = append(out, l)
+	}
+	if !done {
+		switch {
+		case inApp:
+			out = append(out, appIndent+"  "+key+": "+quoteScalar(value))
+		case inSettings:
+			out = append(out, "  app:", "    "+key+": "+quoteScalar(value))
+		default:
+			out = append(out, "settings:", "  app:", "    "+key+": "+quoteScalar(value))
+		}
+	}
+	return writeYamlLines(path, out, nl, trailingNL)
+}
+
+// indentOf returns a line's leading whitespace, which is how the nested walk
+// above tells "still inside this block" from "the block ended".
+func indentOf(l string) string {
+	return l[:len(l)-len(strings.TrimLeft(l, " \t"))]
+}
+
+// readYamlLines loads a generate file as lines, reporting the line ending to
+// write back with and whether the file ended in one.
+//
+// Both are preserved rather than normalised: a CRLF file that grows one LF line
+// renders as a stray glyph in Notepad, which is where users edit this, and
+// Split leaves a trailing "" for any file ending in a newline that is not a
+// line at all: appending after it would cost the file its final newline and
+// leave a blank line in the middle.
+func readYamlLines(path string) (lines []string, nl string, trailingNL bool, err error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", false, err
+	}
+	nl = "\n"
+	if strings.Contains(string(raw), "\r\n") {
+		nl = "\r\n"
+	}
+	body := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	trailingNL = strings.HasSuffix(body, "\n")
+	body = strings.TrimSuffix(body, "\n")
+	return strings.Split(body, "\n"), nl, trailingNL, nil
+}
+
+// writeYamlLines is readYamlLines' inverse.
+func writeYamlLines(path string, lines []string, nl string, trailingNL bool) error {
+	joined := strings.Join(lines, nl)
 	if trailingNL {
 		joined += nl
 	}


### PR DESCRIPTION
A server install had no path that worked: the wizard needs a display for its window and a local browser for the loopback, Host-checked fallback, and even once installed the box came up unreachable, because the admin surface fails closed as soon as the API binds beyond loopback and the dashboard, the only other place to set adminAllow, sits behind that same gate.

- `quartermaster-setup -headless` runs the same `Wizard.Start` to completion with no UI, taking `-models-dir`, `-variant`, `-components` and `-no-launch`
- `-admin-allow`, `-admin-open`, `-tls-cert-file` / `-tls-key-file` land in `settings.app` of the generate file, not the dashboard sidecar, so a repair run stays a baseline the dashboard wins over
- `autogen.AppSettings` gains `tlsCertFile`/`tlsKeyFile`; the server applies them both-or-neither
- `setAppKey` edits the nested `settings.app` block in place, creating it (and `settings`) when absent, keeping comments and line endings

Verified end to end on WSL: headless install wrote `adminAllow`, and the installed server logged "restricted to this host (plus 172.24.0.0/20)" and answered `/api/settings` 200 from the non-loopback address.

Closes #23.