### PR TITLE
autogen: multi-GPU follow-ups from issue #4

### DIFF
--- a/internal/autogen/CLAUDE.md
+++ b/internal/autogen/CLAUDE.md
@@ -43,6 +43,7 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
 | `budgets.go` | Hardware-derived STARTING budgets: `RecommendedVramGB` (free VRAM) / `RecommendedRamGB` (available RAM), and `seedHardwareBudgets`, which `LoadGenerateFile` uses to replace `applyDefaults`' 7 GB/24 GB placeholders when neither the file nor the sidecar pinned them. One cached probe per process. |
 | `vram.go` | Live free-VRAM sampling via `internal/perf` (`SampleFreeVramGB`, `resolveAutoVram`) for the `autoVram` setting. POOLED across every eligible adapter since issue #4, via `gpuset.go`. Budgets against the **idle high-water mark** (`noteFreeVramGB`), never the raw sample — autoVram re-resolves on every `EnsureConfig` *and* every estimate preview, both of which run while models are loaded. |
 | `gpuset.go` | Multi-GPU device set (`GpuSet`, `GpuDevice`): eligibility (`gpuSetFromStats`, `EligibleGpuStats`, `LiveGpuSet`), pooled `FreeGB`/`TotalGB`, `MainIndex`, the `--tensor-split` ratio (`TensorSplit`, `FormatSplit`), the extra-device overhead the sizer must charge (`ExtraDeviceOverheadGB`), and `ResolveGpuSet` (60s-cached resolve into `Settings.Gpus`). The header comment carries the split math. |
+| `backenddev.go` | What the BACKEND calls each device (`ListBackendDevices` over `--list-devices`, memoised per binary), and the map from a resolved `GpuSet` onto those ids (`BackendIDs`, `DeviceFlagFor`). Refuses on any unmatched device so the caller degrades to unnamed placement. |
 | `liveoffload.go` | Spawn-time placement recompute (`LiveOffloadArgs`), including the live `--tensor-split` retune (`retuneTensorSplit`). → `liveoffload.md` |
 | `vllm.go` | Backend selection (`resolveBackend`, `resolveBackendPreferring`, `kindClass`) + the vllm emitter. → `backends.md` |
 | `rope.go` | `ropeCeiling`/`ropeFactor` — the only path that lifts the trained-ctx ceiling. → `sizing.md` |
@@ -168,14 +169,39 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
      `--main-gpu` alone while it splits layers and their KV by the ratio;
   3. `-sm layer --main-gpu N --tensor-split a,b` is actually emitted, alongside
      `env: CUDA_DEVICE_ORDER=PCI_BUS_ID`. Without that env the CUDA runtime's `FASTEST_FIRST`
-     default can reverse the pair and apply the ratio backwards, silently.
+     default can reverse the pair and apply the ratio backwards, silently. None of this is
+     CUDA-only: the split flags are vendor-neutral llama.cpp arguments and are field-proven on
+     Vulkan (issue #4). Only the ORDER PIN is CUDA-specific, which is what `--device` replaces.
+
+  **`mainFixedGB` must not include `ExtraDeviceOverheadGB`.** `splitBy` already charges
+  `perDeviceFixedGB` to every non-main device; passing the pooled figure in as the main device's
+  fixed cost billed the secondary card's runtime twice, both times against the main card's side
+  of the ratio, and tipped layers onto the card least able to hold them. `generate.go` takes the
+  main figure before adding the extras; `EstimatePlan` reports it as `FixedGB` and adds the
+  extras to the pool afterwards, so the config and the spawn-time retune derive the same split.
   Adapters below `minGpuVramGB` (3 GB) are dropped: an iGPU reports a slice of system RAM as
   dedicated VRAM, and pooling it invents budget. `multiGpu: false` collapses everything back to
   the single device `MainIndex` picks.
-- **Single-device backends need an explicit pin.** sd-server, tts-server, whisper and the
-  embedding server have no split of their own, so on a multi-GPU box `writeSingleDeviceEnv`
-  emits `CUDA_VISIBLE_DEVICES=<main>` for them. Without it the CUDA runtime picks a card the
-  sizer did not budget, and not necessarily the same one twice. SAM is exempt: it runs on the CPU.
+- **Single-device backends need an explicit pin, and the ordinal in it is the BACKEND's.**
+  sd-server, tts-server, whisper and the embedding server have no split of their own, so on a
+  multi-GPU box `writeSingleDeviceEnv` pins each to the plan's main device. Without it the
+  runtime picks a card the sizer did not budget, and not necessarily the same one twice. SAM is
+  exempt: it runs on the CPU. The variable and its value both come from
+  `singleDeviceEnvFor` -> `backenddev.go`'s probe: a ggml device id ("Vulkan1") names the
+  enumeration to filter and the ordinal to give it, which is the only way to get the Vulkan or
+  ROCm value right, since the telemetry index is a different enumeration. CUDA alone has a
+  fallback when the probe fails, because `CUDA_DEVICE_ORDER=PCI_BUS_ID` makes the runtime's
+  ordinal agree with nvidia-smi's; everything else emits nothing rather than a guess.
+- **The backend's device list is not ours, in order or in set** (`backenddev.go`). `--main-gpu`
+  and `--tensor-split` are positions in the BACKEND's list, but the plan derives them from the
+  telemetry ordinal, and an adapter we filtered out is still counted there. `DeviceFlagFor`
+  closes the gap by emitting `--device <ids>` so the list llama.cpp indexes into is the one we
+  handed it, and `--main-gpu` becomes a position in the resolved `GpuSet`. The probe doubles as
+  the capability check: a build without `--device` has no `--list-devices` either, so it cannot
+  be handed a flag it would reject. Everything refuses rather than guesses -- an unmatched
+  device yields no ids at all -- so a box that cannot be mapped emits exactly what shipped.
+  `retuneTensorSplit` reads the same rule: it rewrites `--main-gpu` as a position when the argv
+  carries `--device`, and as the telemetry index when it does not.
 - **Sidecar SHADOWS the file row, it does not field-merge.** Override resolution is row-level
   first-match (sidecar rows prepended), so a sidecar row replaces the matching file row
   wholesale. A UI save must therefore write a *superset*: the config editor seeds the sidecar

--- a/internal/autogen/CLAUDE.md
+++ b/internal/autogen/CLAUDE.md
@@ -211,7 +211,12 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
   be handed a flag it would reject. Everything refuses rather than guesses -- an unmatched
   device yields no ids at all -- so a box that cannot be mapped emits exactly what shipped.
   `DeviceFlagFor` returns the ORDER it built the list in as well as the ids, and the caller must
-  apply it to `--tensor-split`. `retuneTensorSplit` re-derives that list from the LIVE main
+  apply it to `--tensor-split`. **The probe runs under `CUDA_DEVICE_ORDER=PCI_BUS_ID`
+  (`probeEnv`), because the launch does.** The CUDA runtime defaults to `FASTEST_FIRST`, so a
+  listing read under the inherited environment numbers a mismatched pair the other way round,
+  and the id read off it names the OTHER card once handed to a bus-ordered process: the exact
+  reversal `--device` exists to prevent, arrived at by a different route. Vulkan and ROCm
+  ignore the variable. `retuneTensorSplit` re-derives that list from the LIVE main
   device rather than trusting the baked one (the live main need not be the one generate picked),
   rewrites `--device`, `--tensor-split` and `--main-gpu` together, and rewrites NOTHING when the
   probe fails on an argv that carries `--device`: a split written in set order against a list in

--- a/internal/autogen/CLAUDE.md
+++ b/internal/autogen/CLAUDE.md
@@ -221,6 +221,12 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
   rewrites `--device`, `--tensor-split` and `--main-gpu` together, and rewrites NOTHING when the
   probe fails on an argv that carries `--device`: a split written in set order against a list in
   main-last order would hand each card the other's ratio, which is worse than the stale one.
+  For the same reason `--device` is suppressed entirely when an override pins `tensorSplit`
+  (`pinsOwnSplit`, `generate_cmd.go`): a hand-written ratio is positional against the list the
+  backend would have enumerated by itself, so renaming the list under it re-points the user's
+  own numbers at different cards. Cost is bounded twice over: `backendProbeTimeout` caps one
+  probe, `backendProbeBudget` caps all of them together, since a generate can reach five
+  distinct backend binaries and the per-probe window is deliberately generous.
 - **Sidecar SHADOWS the file row, it does not field-merge.** Override resolution is row-level
   first-match (sidecar rows prepended), so a sidecar row replaces the matching file row
   wholesale. A UI save must therefore write a *superset*: the config editor seeds the sidecar

--- a/internal/autogen/CLAUDE.md
+++ b/internal/autogen/CLAUDE.md
@@ -165,17 +165,18 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
   small card while the sizer reports a comfortable fit:
   1. every device past the main one is charged `ExtraDeviceOverheadGB` into `prof.Overhead`;
   2. `prof.TensorSplit` is derived from the FINISHED `Overhead` (`generate.go`, the compute-buffer
-     loop), because llama.cpp keeps the fixed costs (logits/output buffer, CUDA context) on ONE
-     device while it splits layers and their KV by the ratio. **Which device that is, is an
-     assumption, not an instruction.** `llama-server --help` documents `-mg` as applying to
-     split-mode `none` (the whole model) or `row` (intermediate results and KV) - layer split is
-     not in that list, and layer split is what we always emit, so the `--main-gpu` we emit is
-     inert and llama.cpp picks the carrier itself. The sizer charges those costs to
-     `PlanMainIndex` (the card with the most capacity); on issue #4's box that is also the last
-     device in the split, so the two coincided. A box where they do not would have the fixed
-     costs land on a card the sizer budgeted as carrying only its own runtime. Confirming
-     llama.cpp's actual rule, and if needed ordering the `--device` list so our main device is
-     the one it picks, is open work;
+     loop), because llama.cpp keeps the fixed costs (the output weight matrix, CUDA context) on
+     ONE device while it splits layers and their KV by the ratio. **That device is the LAST one
+     in the device list, and `--main-gpu` has nothing to do with it.** Measured on a Vulkan build
+     (`llama-server -lv 10 -sm layer -ts 0.5,0.5`, two adapters): reversing `--device` moved a
+     ~146 MiB surplus in `load_tensors: ... model buffer size` from one card to the other, while
+     `--main-gpu 0` and `--main-gpu 1` at a fixed list produced byte-identical model, KV and
+     compute buffer lines. So the ORDER is the instruction. `GpuSet.MainLastOrder` puts the
+     sizer's main device (`PlanMainIndex`, the card with the most capacity, the one charged
+     `mainFixedGB`) at the end of the `--device` list, and `PermuteSplit` moves `--tensor-split`
+     with it so both flags still address the same cards. Two incidentals from the same log:
+     `token_embd.weight` falls to `CPU_Mapped` when it cannot use the host buffer type, and the
+     logits output buffer sits on `Vulkan_Host`, not on a device;
   3. `-sm layer --main-gpu N --tensor-split a,b` is actually emitted, alongside
      `env: CUDA_DEVICE_ORDER=PCI_BUS_ID`. Without that env the CUDA runtime's `FASTEST_FIRST`
      default can reverse the pair and apply the ratio backwards, silently. None of this is
@@ -209,8 +210,12 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
   the capability check: a build without `--device` has no `--list-devices` either, so it cannot
   be handed a flag it would reject. Everything refuses rather than guesses -- an unmatched
   device yields no ids at all -- so a box that cannot be mapped emits exactly what shipped.
-  `retuneTensorSplit` reads the same rule: it rewrites `--main-gpu` as a position when the argv
-  carries `--device`, and as the telemetry index when it does not.
+  `DeviceFlagFor` returns the ORDER it built the list in as well as the ids, and the caller must
+  apply it to `--tensor-split`. `retuneTensorSplit` re-derives that list from the LIVE main
+  device rather than trusting the baked one (the live main need not be the one generate picked),
+  rewrites `--device`, `--tensor-split` and `--main-gpu` together, and rewrites NOTHING when the
+  probe fails on an argv that carries `--device`: a split written in set order against a list in
+  main-last order would hand each card the other's ratio, which is worse than the stale one.
 - **Sidecar SHADOWS the file row, it does not field-merge.** Override resolution is row-level
   first-match (sidecar rows prepended), so a sidecar row replaces the matching file row
   wholesale. A UI save must therefore write a *superset*: the config editor seeds the sidecar

--- a/internal/autogen/CLAUDE.md
+++ b/internal/autogen/CLAUDE.md
@@ -165,8 +165,17 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
   small card while the sizer reports a comfortable fit:
   1. every device past the main one is charged `ExtraDeviceOverheadGB` into `prof.Overhead`;
   2. `prof.TensorSplit` is derived from the FINISHED `Overhead` (`generate.go`, the compute-buffer
-     loop), because llama.cpp keeps the fixed costs (logits/output buffer, CUDA context) on
-     `--main-gpu` alone while it splits layers and their KV by the ratio;
+     loop), because llama.cpp keeps the fixed costs (logits/output buffer, CUDA context) on ONE
+     device while it splits layers and their KV by the ratio. **Which device that is, is an
+     assumption, not an instruction.** `llama-server --help` documents `-mg` as applying to
+     split-mode `none` (the whole model) or `row` (intermediate results and KV) - layer split is
+     not in that list, and layer split is what we always emit, so the `--main-gpu` we emit is
+     inert and llama.cpp picks the carrier itself. The sizer charges those costs to
+     `PlanMainIndex` (the card with the most capacity); on issue #4's box that is also the last
+     device in the split, so the two coincided. A box where they do not would have the fixed
+     costs land on a card the sizer budgeted as carrying only its own runtime. Confirming
+     llama.cpp's actual rule, and if needed ordering the `--device` list so our main device is
+     the one it picks, is open work;
   3. `-sm layer --main-gpu N --tensor-split a,b` is actually emitted, alongside
      `env: CUDA_DEVICE_ORDER=PCI_BUS_ID`. Without that env the CUDA runtime's `FASTEST_FIRST`
      default can reverse the pair and apply the ratio backwards, silently. None of this is

--- a/internal/autogen/asr.go
+++ b/internal/autogen/asr.go
@@ -91,7 +91,7 @@ func emitASRModel(b *strings.Builder, s Settings, row GgufRow, ov *Override, nam
 		fmt.Fprintf(b, "      %s\n", line)
 	}
 	fmt.Fprintf(b, "    ttl: %d\n", s.TtlSec)
-	writeSingleDeviceEnv(b, s)
+	writeSingleDeviceEnv(b, s, s.AsrServerExe)
 	// No estVramGB: parakeet runs on the CPU unless a user opts into GPU via
 	// extraArgs, so it occupies no VRAM budget and must never cost a chat model
 	// its residency. A GPU opt-in under-charges — an accepted trade for not

--- a/internal/autogen/audio.go
+++ b/internal/autogen/audio.go
@@ -246,7 +246,7 @@ func emitTTSModel(b *strings.Builder, s Settings, row GgufRow, ov *Override, nam
 		fmt.Fprintf(b, "    useModelName: %q\n", ttscppModelName(row))
 	}
 	fmt.Fprintf(b, "    ttl: %d\n", s.TtlSec)
-	writeSingleDeviceEnv(b, s)
+	writeSingleDeviceEnv(b, s, s.TtsServerExe)
 	// VRAM admission: qwentts runs on the GPU, so charge its talker + codec
 	// weights plus a small pad. TTS.cpp is CPU-only here (no CUDA/ROCm path
 	// upstream, --use-metal is macOS), so it costs no VRAM and gets no estimate

--- a/internal/autogen/backenddev.go
+++ b/internal/autogen/backenddev.go
@@ -53,11 +53,49 @@ type BackendDevice struct {
 	TotalGB float64
 }
 
-// backendProbeTimeout bounds --list-devices. Enumerating adapters initialises
+// backendProbeTimeout bounds ONE --list-devices. Enumerating adapters initialises
 // the compute backend (a driver call, not a model load) and exits, so this is
 // deliberately generous rather than tight: a cold Vulkan loader on a headless
 // box is slow, and a timeout here costs a correct split for the whole config.
 const backendProbeTimeout = 15 * time.Second
+
+// backendProbeBudget bounds ALL of them together. A generate can reach up to
+// five distinct backend binaries (llama, sd-server, tts-server, whisper,
+// embedding), each probed once, so the generous per-probe window multiplies into
+// a startup that visibly hangs on a box where every backend is wedged. The
+// budget is spent by elapsed probe time and never refilled: the first probe
+// still gets the full window (the llama split is the one worth waiting for), and
+// once it is gone the rest fail instantly instead of each paying again.
+//
+// Not a rate limit and not per-exe. Failures are already cached per binary, so
+// this only ever bites on the first pass, which is exactly the pass a user is
+// sitting through.
+const backendProbeBudget = 20 * time.Second
+
+var (
+	probeBudgetMu   sync.Mutex
+	probeBudgetLeft = backendProbeBudget
+)
+
+// takeProbeBudget returns how long the next probe may run, or 0 when the shared
+// budget is exhausted.
+func takeProbeBudget() time.Duration {
+	probeBudgetMu.Lock()
+	defer probeBudgetMu.Unlock()
+	if probeBudgetLeft <= 0 {
+		return 0
+	}
+	if probeBudgetLeft < backendProbeTimeout {
+		return probeBudgetLeft
+	}
+	return backendProbeTimeout
+}
+
+func spendProbeBudget(d time.Duration) {
+	probeBudgetMu.Lock()
+	defer probeBudgetMu.Unlock()
+	probeBudgetLeft -= d
+}
 
 // llamaDeviceRe matches llama-server's listing:
 //
@@ -102,8 +140,8 @@ func ListBackendDevices(exe string) ([]BackendDevice, error) {
 
 	backendDevMu.Lock()
 	// A failed probe is cached too. The failure is a property of this binary (no
-	// such flag, missing runtime), and re-running a 15s probe once per model
-	// would dominate generation on a box where it can never succeed.
+	// such flag, missing runtime), and re-running the probe once per model would
+	// dominate generation on a box where it can never succeed.
 	backendDevCache[key] = devs
 	backendDevMu.Unlock()
 
@@ -122,7 +160,14 @@ func ListBackendDevices(exe string) ([]BackendDevice, error) {
 func probeEnv() []string { return append(os.Environ(), cudaOrderEnv) }
 
 func probeBackendDevices(exe string) ([]BackendDevice, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), backendProbeTimeout)
+	budget := takeProbeBudget()
+	if budget <= 0 {
+		return nil, fmt.Errorf("%s --list-devices: probe budget exhausted", exe)
+	}
+	started := time.Now()
+	defer func() { spendProbeBudget(time.Since(started)) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, exe, "--list-devices")

--- a/internal/autogen/backenddev.go
+++ b/internal/autogen/backenddev.go
@@ -253,3 +253,47 @@ var deviceNameNoise = strings.NewReplacer(
 func normaliseDeviceName(s string) string {
 	return deviceNameNoise.Replace(strings.ToLower(strings.TrimSpace(s)))
 }
+
+// DeviceFlagFor resolves the `--device` value for a multi-GPU launch of exe,
+// together with the POSITION that `--main-gpu` must name once the list is
+// pinned. Returns "" and -1 when the devices cannot be named, and the caller
+// then emits what it emitted before.
+//
+// Naming the devices changes what --main-gpu and --tensor-split index into.
+// Without --device they are positions in the BACKEND's full device list, which
+// includes adapters we filtered out and need not be in our order; with it they
+// are positions in the list we just handed over, so main becomes g's own
+// position rather than a telemetry ordinal.
+//
+// The probe doubles as the capability check. A build old enough to lack
+// --device is also old enough to lack --list-devices, so it fails to parse and
+// gets no flag: there is no version to compare and no way to emit an argument
+// the binary will reject.
+//
+// Cost: one memoised subprocess per backend binary per process. The UI's launch
+// preview renders through the same path, so the first render after a backend
+// swap can pay the probe.
+func DeviceFlagFor(exe string, g GpuSet, mainIndex int) (string, int) {
+	if !g.Multi() {
+		return "", -1
+	}
+	pos := -1
+	for i, d := range g {
+		if d.Index == mainIndex {
+			pos = i
+			break
+		}
+	}
+	if pos < 0 {
+		return "", -1
+	}
+	devs, err := ListBackendDevices(exe)
+	if err != nil {
+		return "", -1
+	}
+	ids := g.BackendIDs(devs)
+	if len(ids) != len(g) {
+		return "", -1
+	}
+	return strings.Join(ids, ","), pos
+}

--- a/internal/autogen/backenddev.go
+++ b/internal/autogen/backenddev.go
@@ -255,15 +255,24 @@ func normaliseDeviceName(s string) string {
 }
 
 // DeviceFlagFor resolves the `--device` value for a multi-GPU launch of exe,
-// together with the POSITION that `--main-gpu` must name once the list is
-// pinned. Returns "" and -1 when the devices cannot be named, and the caller
-// then emits what it emitted before.
+// together with the ORDER that value was built in: a permutation of g's
+// positions (see GpuSet.MainLastOrder) that the caller must apply to
+// --tensor-split so the two flags address the same cards. Returns "" and nil
+// when the devices cannot be named, and the caller then emits what it emitted
+// before.
 //
-// Naming the devices changes what --main-gpu and --tensor-split index into.
+// The order is the point, not just the names. Under -sm layer llama.cpp puts
+// the non-splittable output weight on the device listed LAST and ignores
+// --main-gpu entirely (measured; see MainLastOrder). So naming the devices is
+// what finally makes the sizer's choice of main device an instruction instead
+// of a hope: the plan's main card goes at the end of the list, which is where
+// the fixed cost it was charged actually lands.
+//
+// Naming them also changes what --main-gpu and --tensor-split index into.
 // Without --device they are positions in the BACKEND's full device list, which
 // includes adapters we filtered out and need not be in our order; with it they
-// are positions in the list we just handed over, so main becomes g's own
-// position rather than a telemetry ordinal.
+// are positions in the list we just handed over, so main is always the last
+// one.
 //
 // The probe doubles as the capability check. A build old enough to lack
 // --device is also old enough to lack --list-devices, so it fails to parse and
@@ -273,27 +282,25 @@ func normaliseDeviceName(s string) string {
 // Cost: one memoised subprocess per backend binary per process. The UI's launch
 // preview renders through the same path, so the first render after a backend
 // swap can pay the probe.
-func DeviceFlagFor(exe string, g GpuSet, mainIndex int) (string, int) {
+func DeviceFlagFor(exe string, g GpuSet, mainIndex int) (string, []int) {
 	if !g.Multi() {
-		return "", -1
+		return "", nil
 	}
-	pos := -1
-	for i, d := range g {
-		if d.Index == mainIndex {
-			pos = i
-			break
-		}
-	}
-	if pos < 0 {
-		return "", -1
+	order := g.MainLastOrder(mainIndex)
+	if order == nil {
+		return "", nil
 	}
 	devs, err := ListBackendDevices(exe)
 	if err != nil {
-		return "", -1
+		return "", nil
 	}
 	ids := g.BackendIDs(devs)
 	if len(ids) != len(g) {
-		return "", -1
+		return "", nil
 	}
-	return strings.Join(ids, ","), pos
+	ordered := make([]string, len(order))
+	for i, p := range order {
+		ordered[i] = ids[p]
+	}
+	return strings.Join(ordered, ","), order
 }

--- a/internal/autogen/backenddev.go
+++ b/internal/autogen/backenddev.go
@@ -116,13 +116,27 @@ func ListBackendDevices(exe string) ([]BackendDevice, error) {
 	return devs, nil
 }
 
+// probeEnv is the environment the listing must be read under: the caller's, plus
+// the same bus-order pin every multi-GPU launch carries. Split out so the pin is
+// assertable without running a backend.
+func probeEnv() []string { return append(os.Environ(), cudaOrderEnv) }
+
 func probeBackendDevices(exe string) ([]BackendDevice, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), backendProbeTimeout)
 	defer cancel()
 
+	cmd := exec.CommandContext(ctx, exe, "--list-devices")
+	// The probe MUST enumerate the way the launch will. Every multi-GPU config
+	// we emit carries CUDA_DEVICE_ORDER=PCI_BUS_ID (generate_emit.go, and
+	// writeSingleDeviceEnv), but the CUDA runtime defaults to FASTEST_FIRST, so
+	// a probe run under the inherited environment numbers a mismatched pair the
+	// other way round. Reading "CUDA0" off that listing and handing it back to a
+	// process running under PCI_BUS_ID names the OTHER card, silently: exactly
+	// the reversal --device exists to prevent. Vulkan and ROCm ignore it.
+	cmd.Env = probeEnv()
 	// Some backends print the listing on stderr and the banner on stdout, and
 	// which does what has moved across releases. Read the pair.
-	out, err := exec.CommandContext(ctx, exe, "--list-devices").CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err != nil && len(out) == 0 {
 		return nil, fmt.Errorf("%s --list-devices: %w", exe, err)
 	}

--- a/internal/autogen/backenddev.go
+++ b/internal/autogen/backenddev.go
@@ -1,0 +1,255 @@
+package autogen
+
+// backenddev.go answers a question the rest of the multi-GPU path assumes away:
+// when the plan says "device 1", which card does the BACKEND think that is?
+//
+// gpuset.go derives --tensor-split positions and --main-gpu from the TELEMETRY
+// ordinal (nvidia-smi / rocm-smi / sysfs / DXGI order). The backend enumerates
+// its own devices independently, and the two lists are neither the same order
+// nor the same set:
+//
+//   - Order. On CUDA the runtime defaults to CUDA_DEVICE_ORDER=FASTEST_FIRST,
+//     which cudaOrderEnv pins back to bus order. No such pin exists for Vulkan
+//     or ROCm, where ggml enumerates through the loader and sorts discrete
+//     adapters ahead of integrated ones. A box whose iGPU sorts first in
+//     telemetry gets the whole ratio applied reversed, silently.
+//   - Set. ggml-vulkan reports integrated adapters advertising a slice of system
+//     RAM (16GB is common), which sails over minInferenceVramGB. Worse, a device
+//     WE filter out is still counted by llama.cpp when it reads --tensor-split
+//     and --main-gpu, so filtering shifts every position after it.
+//
+// Both problems disappear once the ordinal stops being implied. llama-server and
+// sd-server each expose --list-devices with stable ids ("CUDA0", "Vulkan1",
+// "ROCm0") and each accept those ids back, llama-server as --device and
+// sd-server as --backend. Naming the devices makes our order authoritative on
+// every backend rather than only on the one that happens to have an env var.
+//
+// The safety property here is refusal. A probe that cannot run, cannot be
+// parsed, or cannot be matched confidently against the resolved GpuSet yields
+// nothing, and the caller emits no device flags at all: the behaviour we had
+// before, rather than a placement built on a guess.
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// BackendDevice is one adapter as the backend binary names it.
+//
+// TotalGB is 0 when the backend reports no size (sd-server lists id and
+// description only), which the matcher reads as "match on name alone".
+type BackendDevice struct {
+	ID      string
+	Name    string
+	TotalGB float64
+}
+
+// backendProbeTimeout bounds --list-devices. Enumerating adapters initialises
+// the compute backend (a driver call, not a model load) and exits, so this is
+// deliberately generous rather than tight: a cold Vulkan loader on a headless
+// box is slow, and a timeout here costs a correct split for the whole config.
+const backendProbeTimeout = 15 * time.Second
+
+// llamaDeviceRe matches llama-server's listing:
+//
+//	Vulkan0: AMD Radeon RX 7900 XTX (24560 MiB, 23748 MiB free)
+//
+// The id is captured apart from the description because the id is what --device
+// accepts and the description is what we match telemetry against.
+var llamaDeviceRe = regexp.MustCompile(`^\s*([A-Za-z][A-Za-z0-9]*[0-9])\s*:\s*(.+?)\s*\((\d+)\s*MiB`)
+
+var (
+	backendDevMu    sync.Mutex
+	backendDevCache = map[string][]BackendDevice{}
+)
+
+// ListBackendDevices runs `exe --list-devices` and parses the result, memoised
+// per binary. The cache key carries size and mtime so a backend upgraded in
+// place is re-probed instead of answering from a stale list.
+//
+// An error is an ordinary outcome, not a fault: older builds have no
+// --list-devices, and a packaged install may name a binary that is not there
+// yet. Callers degrade to unnamed placement.
+func ListBackendDevices(exe string) ([]BackendDevice, error) {
+	if strings.TrimSpace(exe) == "" {
+		return nil, fmt.Errorf("no backend exe")
+	}
+	key := exe
+	if st, err := os.Stat(exe); err == nil {
+		key = fmt.Sprintf("%s|%d|%d", exe, st.Size(), st.ModTime().UnixNano())
+	}
+
+	backendDevMu.Lock()
+	cached, hit := backendDevCache[key]
+	backendDevMu.Unlock()
+	if hit {
+		if len(cached) == 0 {
+			return nil, fmt.Errorf("no devices listed by %s", exe)
+		}
+		return cached, nil
+	}
+
+	devs, err := probeBackendDevices(exe)
+
+	backendDevMu.Lock()
+	// A failed probe is cached too. The failure is a property of this binary (no
+	// such flag, missing runtime), and re-running a 15s probe once per model
+	// would dominate generation on a box where it can never succeed.
+	backendDevCache[key] = devs
+	backendDevMu.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+	if len(devs) == 0 {
+		return nil, fmt.Errorf("no devices listed by %s", exe)
+	}
+	return devs, nil
+}
+
+func probeBackendDevices(exe string) ([]BackendDevice, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), backendProbeTimeout)
+	defer cancel()
+
+	// Some backends print the listing on stderr and the banner on stdout, and
+	// which does what has moved across releases. Read the pair.
+	out, err := exec.CommandContext(ctx, exe, "--list-devices").CombinedOutput()
+	if err != nil && len(out) == 0 {
+		return nil, fmt.Errorf("%s --list-devices: %w", exe, err)
+	}
+	return parseBackendDevices(string(out)), nil
+}
+
+// parseBackendDevices reads both listing shapes we ship against:
+//
+//	llama-server:  "  Vulkan0: AMD Radeon RX 7900 XTX (24560 MiB, 23748 MiB free)"
+//	sd-server:     "vulkan0\tAMD Radeon RX 7900 XTX"
+//
+// CPU entries are dropped. They are never a placement target for a split, and
+// leaving them in would shift every position after them.
+func parseBackendDevices(out string) []BackendDevice {
+	var devs []BackendDevice
+	seen := map[string]bool{}
+
+	add := func(id, name string, totalGB float64) {
+		id, name = strings.TrimSpace(id), strings.TrimSpace(name)
+		if id == "" || seen[id] || isCPUDeviceID(id) {
+			return
+		}
+		seen[id] = true
+		devs = append(devs, BackendDevice{ID: id, Name: name, TotalGB: totalGB})
+	}
+
+	sc := bufio.NewScanner(strings.NewReader(out))
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if m := llamaDeviceRe.FindStringSubmatch(line); m != nil {
+			mib, _ := strconv.ParseFloat(m[3], 64)
+			add(m[1], m[2], mib/1024.0)
+			continue
+		}
+		// sd-server: "id<TAB>description", no size. The tab is the guard, so
+		// prose in the same stream cannot be read as a device.
+		if id, name, ok := strings.Cut(line, "\t"); ok {
+			if strings.TrimSpace(name) != "" && !strings.ContainsAny(strings.TrimSpace(id), " :(") {
+				add(id, name, 0)
+			}
+		}
+	}
+	return devs
+}
+
+// isCPUDeviceID reports whether an id names the CPU backend rather than an
+// adapter. Tested on the id, which is a stable token, not the description.
+func isCPUDeviceID(id string) bool {
+	return strings.HasPrefix(strings.ToLower(id), "cpu")
+}
+
+// backendMatchToleranceGB is how far a backend's reported VRAM may sit from
+// telemetry's and still be the same card. The two read one adapter through
+// different APIs, so they disagree by driver reservations rather than by a lot;
+// a wider gap means a different device.
+const backendMatchToleranceGB = 1.5
+
+// BackendIDs maps the set onto the ids the backend uses, positionally: the
+// result is parallel to g, so it can be emitted beside a --tensor-split derived
+// from the same ordering.
+//
+// Returns nil unless EVERY device matched unambiguously. A partial mapping is
+// the dangerous case rather than a useful one, since a device list missing a
+// card silently drops it from the plan the sizer already budgeted for. The
+// whole mapping is refused and the caller falls back to unnamed placement.
+//
+// Matching is by name, with size as the tiebreak. Identical cards are genuinely
+// interchangeable, so ties resolve in list order: swapping two adapters of the
+// same model and capacity cannot change the outcome.
+func (g GpuSet) BackendIDs(devs []BackendDevice) []string {
+	if len(g) == 0 || len(devs) == 0 {
+		return nil
+	}
+	out := make([]string, len(g))
+	used := make([]bool, len(devs))
+
+	for i, d := range g {
+		best, bestScore := -1, math.Inf(1)
+		for j, bd := range devs {
+			if used[j] || !deviceNamesMatch(d.Name, bd.Name) {
+				continue
+			}
+			// Size is the tiebreak, not the gate: a backend reporting no size
+			// (sd-server) still matches on an unambiguous name.
+			score := 0.0
+			if bd.TotalGB > 0 {
+				if score = math.Abs(bd.TotalGB - d.TotalGB); score > backendMatchToleranceGB {
+					continue
+				}
+			}
+			if score < bestScore {
+				best, bestScore = j, score
+			}
+		}
+		if best < 0 {
+			return nil
+		}
+		used[best] = true
+		out[i] = devs[best].ID
+	}
+	return out
+}
+
+// deviceNamesMatch compares adapter names across two APIs that describe the same
+// silicon differently: nvidia-smi says "NVIDIA GeForce RTX 4070 Ti SUPER" where
+// ggml may drop the vendor, and Windows adds "(TM)". Containment in either
+// direction is the loosest rule that still cannot confuse two cards on one box,
+// since a 4070 beside a 4070 Ti has neither name contained in the other.
+func deviceNamesMatch(a, b string) bool {
+	na, nb := normaliseDeviceName(a), normaliseDeviceName(b)
+	if na == "" || nb == "" {
+		return false
+	}
+	return na == nb || strings.Contains(na, nb) || strings.Contains(nb, na)
+}
+
+// deviceNameNoise strips the parts that differ per API rather than per card:
+// vendor and brand words, trademark marks, and separators. What survives is the
+// model designation, which is what actually distinguishes two adapters.
+var deviceNameNoise = strings.NewReplacer(
+	"(tm)", "", "(r)", "", "®", "", "™", "",
+	"nvidia", "", "amd", "", "intel", "", "corporation", "",
+	"geforce", "", "radeon", "", "arc", "",
+	" ", "", "-", "", "_", "",
+)
+
+func normaliseDeviceName(s string) string {
+	return deviceNameNoise.Replace(strings.ToLower(strings.TrimSpace(s)))
+}

--- a/internal/autogen/backenddev_test.go
+++ b/internal/autogen/backenddev_test.go
@@ -2,6 +2,7 @@ package autogen
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -201,5 +202,37 @@ func TestAutogen_MainLastOrder(t *testing.T) {
 	in := []float64{0.5, 0.5}
 	if got := PermuteSplit(in, []int{0, 2, 1}); len(got) != 2 || got[0] != 0.5 {
 		t.Fatalf("PermuteSplit with a mismatched order = %v, want the input back", got)
+	}
+}
+
+// The probe has to enumerate the way the LAUNCH will. Every multi-GPU config we
+// emit carries CUDA_DEVICE_ORDER=PCI_BUS_ID, while the CUDA runtime defaults to
+// FASTEST_FIRST: a listing read under the inherited environment numbers a
+// mismatched pair the other way round, so "CUDA0" handed back to a bus-ordered
+// process names the OTHER card. That reversal is the exact failure --device
+// exists to prevent, and it is silent.
+func TestAutogen_ProbeEnv_PinsBusOrder(t *testing.T) {
+	var found bool
+	for _, kv := range probeEnv() {
+		if kv == cudaOrderEnv {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("probe environment does not pin %s", cudaOrderEnv)
+	}
+}
+
+// A single-GPU box is the population that never asked for any of this. It must
+// get no probe, no --device and no env block: byte-identical to what shipped.
+func TestAutogen_SingleGpu_EmitsNothingNew(t *testing.T) {
+	one := GpuSet{{Index: 0, Name: "NVIDIA GeForce RTX 4090", TotalGB: 24, FreeGB: 23}}
+	if devs, order := DeviceFlagFor(filepath.Join(t.TempDir(), "nope"), one, 0); devs != "" || order != nil {
+		t.Fatalf("single-GPU DeviceFlagFor = %q,%v, want no flags", devs, order)
+	}
+	var b strings.Builder
+	writeSingleDeviceEnv(&b, Settings{Gpus: one}, filepath.Join(t.TempDir(), "nope"))
+	if b.String() != "" {
+		t.Fatalf("single-GPU writeSingleDeviceEnv emitted %q, want nothing", b.String())
 	}
 }

--- a/internal/autogen/backenddev_test.go
+++ b/internal/autogen/backenddev_test.go
@@ -236,3 +236,50 @@ func TestAutogen_SingleGpu_EmitsNothingNew(t *testing.T) {
 		t.Fatalf("single-GPU writeSingleDeviceEnv emitted %q, want nothing", b.String())
 	}
 }
+
+// A generate reaches up to five distinct backend binaries. The per-probe window
+// is deliberately generous, so without a shared budget a box where every backend
+// is wedged multiplies it into a startup that visibly hangs.
+func TestAutogen_ProbeBudget_BoundsTheWholeGenerate(t *testing.T) {
+	probeBudgetMu.Lock()
+	saved := probeBudgetLeft
+	probeBudgetMu.Unlock()
+	t.Cleanup(func() {
+		probeBudgetMu.Lock()
+		probeBudgetLeft = saved
+		probeBudgetMu.Unlock()
+	})
+
+	if d := takeProbeBudget(); d != backendProbeTimeout {
+		t.Fatalf("first probe window = %v, want the full %v", d, backendProbeTimeout)
+	}
+	spendProbeBudget(backendProbeTimeout)
+	if d := takeProbeBudget(); d <= 0 || d > backendProbeBudget-backendProbeTimeout {
+		t.Fatalf("second probe window = %v, want what is left of %v", d, backendProbeBudget)
+	}
+	spendProbeBudget(backendProbeBudget)
+	if d := takeProbeBudget(); d != 0 {
+		t.Fatalf("exhausted probe window = %v, want 0", d)
+	}
+	if _, err := probeBackendDevices(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Fatal("probe with no budget returned no error")
+	}
+}
+
+// A hand-written --tensor-split is positional against the list the backend would
+// have enumerated on its own. --device replaces that list in main-last order, so
+// emitting both would silently point the user's ratio at a different pair.
+func TestAutogen_PinsOwnSplit(t *testing.T) {
+	if pinsOwnSplit(nil) {
+		t.Fatal("no override pins nothing")
+	}
+	if pinsOwnSplit(&Override{}) {
+		t.Fatal("blank tensorSplit pins nothing")
+	}
+	if pinsOwnSplit(&Override{TensorSplit: "  "}) {
+		t.Fatal("whitespace tensorSplit pins nothing")
+	}
+	if !pinsOwnSplit(&Override{TensorSplit: "3,1"}) {
+		t.Fatal("a hand-written ratio must suppress --device")
+	}
+}

--- a/internal/autogen/backenddev_test.go
+++ b/internal/autogen/backenddev_test.go
@@ -156,18 +156,50 @@ func TestAutogen_DeviceFlagFor_Refusals(t *testing.T) {
 		{Index: 3, Name: "NVIDIA GeForce RTX 4070 Ti SUPER", TotalGB: 16, FreeGB: 15},
 	}
 	// No probe can help a set that isn't split.
-	if devs, pos := DeviceFlagFor("llama-server", GpuSet{two[0]}, 0); devs != "" || pos != -1 {
-		t.Fatalf("single-device DeviceFlagFor = %q,%d, want \"\",-1", devs, pos)
+	if devs, order := DeviceFlagFor("llama-server", GpuSet{two[0]}, 0); devs != "" || order != nil {
+		t.Fatalf("single-device DeviceFlagFor = %q,%v, want \"\",nil", devs, order)
 	}
 	// A main index that names no device in the set: nothing to pin it to.
-	if devs, pos := DeviceFlagFor("llama-server", two, 1); devs != "" || pos != -1 {
-		t.Fatalf("unknown main index = %q,%d, want \"\",-1", devs, pos)
+	if devs, order := DeviceFlagFor("llama-server", two, 1); devs != "" || order != nil {
+		t.Fatalf("unknown main index = %q,%v, want \"\",nil", devs, order)
 	}
 	// A binary that cannot be run at all degrades to unnamed placement rather
-	// than to an error. Note the gap this closes on the way: main is TELEMETRY
-	// index 3, which is position 1 in the set, and only the named form can say
-	// so.
-	if devs, pos := DeviceFlagFor(filepath.Join(t.TempDir(), "not-a-backend"), two, 3); devs != "" || pos != -1 {
-		t.Fatalf("missing exe = %q,%d, want \"\",-1", devs, pos)
+	// than to an error.
+	if devs, order := DeviceFlagFor(filepath.Join(t.TempDir(), "not-a-backend"), two, 3); devs != "" || order != nil {
+		t.Fatalf("missing exe = %q,%v, want \"\",nil", devs, order)
+	}
+}
+
+// The placement rule the whole ordering rests on: measured on a Vulkan build,
+// -sm layer puts the non-splittable output weight on the device listed LAST and
+// ignores --main-gpu. So the main device has to be last, and everything else
+// keeps its relative order (the split vector is only meaningful positionally).
+func TestAutogen_MainLastOrder(t *testing.T) {
+	three := GpuSet{
+		{Index: 0, Name: "a", TotalGB: 12, FreeGB: 11},
+		{Index: 3, Name: "b", TotalGB: 16, FreeGB: 15},
+		{Index: 7, Name: "c", TotalGB: 24, FreeGB: 23},
+	}
+	// Main is telemetry index 3, which is POSITION 1. Only the named form can
+	// say so, and it must end up last.
+	got := three.MainLastOrder(3)
+	if len(got) != 3 || got[0] != 0 || got[1] != 2 || got[2] != 1 {
+		t.Fatalf("MainLastOrder(3) = %v, want [0 2 1]", got)
+	}
+	// Already last: an identity permutation, not a rotation.
+	if got := three.MainLastOrder(7); len(got) != 3 || got[0] != 0 || got[1] != 1 || got[2] != 2 {
+		t.Fatalf("MainLastOrder(7) = %v, want [0 1 2]", got)
+	}
+	if got := three.MainLastOrder(9); got != nil {
+		t.Fatalf("MainLastOrder of an absent index = %v, want nil", got)
+	}
+	// The split must travel with the list or each card gets the other's ratio.
+	if got := PermuteSplit([]float64{0.2, 0.3, 0.5}, []int{0, 2, 1}); got[0] != 0.2 || got[1] != 0.5 || got[2] != 0.3 {
+		t.Fatalf("PermuteSplit = %v, want [0.2 0.5 0.3]", got)
+	}
+	// A length that cannot be mapped is left alone rather than rearranged.
+	in := []float64{0.5, 0.5}
+	if got := PermuteSplit(in, []int{0, 2, 1}); len(got) != 2 || got[0] != 0.5 {
+		t.Fatalf("PermuteSplit with a mismatched order = %v, want the input back", got)
 	}
 }

--- a/internal/autogen/backenddev_test.go
+++ b/internal/autogen/backenddev_test.go
@@ -1,0 +1,145 @@
+package autogen
+
+import "testing"
+
+// Real output from llama-server b10837-vulkan on a box with a discrete card and
+// an APU's integrated adapter. Two things matter here and both are load-bearing:
+// the integrated adapter is listed (and advertises 15.8GB, well over
+// minInferenceVramGB, so an eligibility floor alone will not exclude it), and
+// the discrete card sorts FIRST, which telemetry need not agree with.
+const llamaListDevicesOut = `ggml_vulkan: Found 2 Vulkan devices:
+Available devices:
+  Vulkan0: AMD Radeon RX 7900 XTX (24560 MiB, 23748 MiB free)
+  Vulkan1: AMD Radeon(TM) Graphics (16186 MiB, 15377 MiB free)
+`
+
+func TestAutogen_ParseBackendDevices_Llama(t *testing.T) {
+	devs := parseBackendDevices(llamaListDevicesOut)
+	if len(devs) != 2 {
+		t.Fatalf("parsed %d devices, want 2: %+v", len(devs), devs)
+	}
+	if devs[0].ID != "Vulkan0" || devs[1].ID != "Vulkan1" {
+		t.Fatalf("ids = %q,%q, want Vulkan0,Vulkan1", devs[0].ID, devs[1].ID)
+	}
+	if devs[0].Name != "AMD Radeon RX 7900 XTX" {
+		t.Fatalf("name = %q", devs[0].Name)
+	}
+	// 24560 MiB / 1024, matching gpuSetFromStats' MemTotalMB conversion so the
+	// two figures are comparable without a unit change at the match site.
+	if got := devs[0].TotalGB; got < 23.9 || got > 24.1 {
+		t.Fatalf("TotalGB = %v, want ~23.98", got)
+	}
+	// The banner line ("Found 2 Vulkan devices:") has no MiB group and must not
+	// become a device.
+	for _, d := range devs {
+		if d.ID == "ggml_vulkan" {
+			t.Fatalf("banner parsed as a device: %+v", devs)
+		}
+	}
+}
+
+func TestAutogen_ParseBackendDevices_SdServer(t *testing.T) {
+	// sd-server documents "one 'name<TAB>description' per line". It reports no
+	// size, so these match on name alone.
+	out := "cuda0\tNVIDIA GeForce RTX 4070 Ti SUPER\ncuda1\tNVIDIA GeForce RTX 3060\ncpu\tCPU\n"
+	devs := parseBackendDevices(out)
+	if len(devs) != 2 {
+		t.Fatalf("parsed %d devices, want 2 (cpu dropped): %+v", len(devs), devs)
+	}
+	if devs[0].ID != "cuda0" || devs[1].ID != "cuda1" {
+		t.Fatalf("ids = %q,%q", devs[0].ID, devs[1].ID)
+	}
+	if devs[0].TotalGB != 0 {
+		t.Fatalf("TotalGB = %v, want 0 (unreported)", devs[0].TotalGB)
+	}
+}
+
+// The case the whole file exists for: telemetry and the backend disagree about
+// which card is device 0. Issue #4's reporter has a 3060 beside a 4070 Ti SUPER;
+// give telemetry the 3060 first and the backend the faster card first, which is
+// exactly what CUDA_DEVICE_ORDER=FASTEST_FIRST produces.
+func TestAutogen_BackendIDs_ReversedEnumeration(t *testing.T) {
+	set := GpuSet{
+		{Index: 0, Name: "NVIDIA GeForce RTX 3060", TotalGB: 12, FreeGB: 11},
+		{Index: 1, Name: "NVIDIA GeForce RTX 4070 Ti SUPER", TotalGB: 16, FreeGB: 15},
+	}
+	devs := []BackendDevice{
+		{ID: "CUDA0", Name: "NVIDIA GeForce RTX 4070 Ti SUPER", TotalGB: 16},
+		{ID: "CUDA1", Name: "NVIDIA GeForce RTX 3060", TotalGB: 12},
+	}
+	got := set.BackendIDs(devs)
+	if len(got) != 2 || got[0] != "CUDA1" || got[1] != "CUDA0" {
+		t.Fatalf("BackendIDs = %v, want [CUDA1 CUDA0]: the ids must follow OUR order, not the backend's", got)
+	}
+}
+
+// An adapter we filtered out (an iGPU under minInferenceVramGB, or a card the
+// user excluded) is still in the backend's list. Naming devices is what keeps it
+// out of the split, so the mapping must skip it rather than shift onto it.
+func TestAutogen_BackendIDs_SkipsUnplannedAdapter(t *testing.T) {
+	set := GpuSet{{Index: 1, Name: "AMD Radeon RX 7900 XTX", TotalGB: 23.98, FreeGB: 23}}
+	devs := parseBackendDevices(llamaListDevicesOut)
+	got := set.BackendIDs(devs)
+	if len(got) != 1 || got[0] != "Vulkan0" {
+		t.Fatalf("BackendIDs = %v, want [Vulkan0]", got)
+	}
+}
+
+// Refusal is the safety property: a set we cannot fully place must produce no
+// device list at all, so the caller falls back to unnamed placement instead of
+// emitting one that silently drops a card the sizer budgeted for.
+func TestAutogen_BackendIDs_RefusesPartialMatch(t *testing.T) {
+	set := GpuSet{
+		{Index: 0, Name: "AMD Radeon RX 7900 XTX", TotalGB: 23.98, FreeGB: 23},
+		{Index: 1, Name: "NVIDIA GeForce RTX 3060", TotalGB: 12, FreeGB: 11},
+	}
+	if got := set.BackendIDs(parseBackendDevices(llamaListDevicesOut)); got != nil {
+		t.Fatalf("BackendIDs = %v, want nil when a planned card is not in the backend's list", got)
+	}
+	if got := set.BackendIDs(nil); got != nil {
+		t.Fatalf("BackendIDs with no listing = %v, want nil", got)
+	}
+}
+
+// Same name, same capacity, twice. Either assignment is correct, so the mapping
+// must succeed rather than refuse: two identical cards are interchangeable.
+func TestAutogen_BackendIDs_IdenticalCards(t *testing.T) {
+	set := GpuSet{
+		{Index: 0, Name: "NVIDIA GeForce RTX 3090", TotalGB: 24, FreeGB: 23},
+		{Index: 1, Name: "NVIDIA GeForce RTX 3090", TotalGB: 24, FreeGB: 23},
+	}
+	devs := []BackendDevice{
+		{ID: "CUDA0", Name: "NVIDIA GeForce RTX 3090", TotalGB: 24},
+		{ID: "CUDA1", Name: "NVIDIA GeForce RTX 3090", TotalGB: 24},
+	}
+	got := set.BackendIDs(devs)
+	if len(got) != 2 || got[0] == got[1] {
+		t.Fatalf("BackendIDs = %v, want two distinct ids", got)
+	}
+}
+
+// Vendor prefixes, trademark marks and brand words differ between telemetry and
+// ggml for the same silicon. The model designation is what has to survive.
+func TestAutogen_DeviceNamesMatch(t *testing.T) {
+	match := [][2]string{
+		{"AMD Radeon(TM) Graphics", "Radeon Graphics"},
+		{"NVIDIA GeForce RTX 4070 Ti SUPER", "GeForce RTX 4070 Ti SUPER"},
+		{"AMD Radeon RX 7900 XTX", "Radeon RX 7900 XTX"},
+	}
+	for _, p := range match {
+		if !deviceNamesMatch(p[0], p[1]) {
+			t.Errorf("deviceNamesMatch(%q, %q) = false, want true", p[0], p[1])
+		}
+	}
+	// A 4070 beside a 4070 Ti is the case containment must NOT collapse, since
+	// picking the wrong one hands the split to the wrong card.
+	differ := [][2]string{
+		{"NVIDIA GeForce RTX 4070 Ti SUPER", "NVIDIA GeForce RTX 3060"},
+		{"AMD Radeon RX 7900 XTX", "AMD Radeon(TM) Graphics"},
+	}
+	for _, p := range differ {
+		if deviceNamesMatch(p[0], p[1]) {
+			t.Errorf("deviceNamesMatch(%q, %q) = true, want false", p[0], p[1])
+		}
+	}
+}

--- a/internal/autogen/backenddev_test.go
+++ b/internal/autogen/backenddev_test.go
@@ -1,6 +1,9 @@
 package autogen
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 // Real output from llama-server b10837-vulkan on a box with a discrete card and
 // an APU's integrated adapter. Two things matter here and both are load-bearing:
@@ -141,5 +144,30 @@ func TestAutogen_DeviceNamesMatch(t *testing.T) {
 		if deviceNamesMatch(p[0], p[1]) {
 			t.Errorf("deviceNamesMatch(%q, %q) = true, want false", p[0], p[1])
 		}
+	}
+}
+
+// DeviceFlagFor's refusal paths, which are the ones that decide whether a
+// launch keeps the argv that shipped. The probing path needs a real backend
+// binary and is covered by parseBackendDevices + BackendIDs above.
+func TestAutogen_DeviceFlagFor_Refusals(t *testing.T) {
+	two := GpuSet{
+		{Index: 0, Name: "NVIDIA GeForce RTX 3060", TotalGB: 12, FreeGB: 11},
+		{Index: 3, Name: "NVIDIA GeForce RTX 4070 Ti SUPER", TotalGB: 16, FreeGB: 15},
+	}
+	// No probe can help a set that isn't split.
+	if devs, pos := DeviceFlagFor("llama-server", GpuSet{two[0]}, 0); devs != "" || pos != -1 {
+		t.Fatalf("single-device DeviceFlagFor = %q,%d, want \"\",-1", devs, pos)
+	}
+	// A main index that names no device in the set: nothing to pin it to.
+	if devs, pos := DeviceFlagFor("llama-server", two, 1); devs != "" || pos != -1 {
+		t.Fatalf("unknown main index = %q,%d, want \"\",-1", devs, pos)
+	}
+	// A binary that cannot be run at all degrades to unnamed placement rather
+	// than to an error. Note the gap this closes on the way: main is TELEMETRY
+	// index 3, which is position 1 in the set, and only the named form can say
+	// so.
+	if devs, pos := DeviceFlagFor(filepath.Join(t.TempDir(), "not-a-backend"), two, 3); devs != "" || pos != -1 {
+		t.Fatalf("missing exe = %q,%d, want \"\",-1", devs, pos)
 	}
 }

--- a/internal/autogen/embedding.go
+++ b/internal/autogen/embedding.go
@@ -113,7 +113,7 @@ func emitEmbeddingModel(b *strings.Builder, s Settings, row GgufRow, ov *Overrid
 		fmt.Fprintf(b, "      %s\n", line)
 	}
 	fmt.Fprintf(b, "    ttl: %d\n", s.TtlSec)
-	writeSingleDeviceEnv(b, s)
+	writeSingleDeviceEnv(b, s, s.ServerExe)
 	// Embedders are small, fully offloaded and their KV is one short sequence:
 	// weights plus a flat pad is close enough for admission.
 	writeEstVram(b, row.SizeGB+embeddingOverheadGB)

--- a/internal/autogen/estimate.go
+++ b/internal/autogen/estimate.go
@@ -164,6 +164,18 @@ func EstimatePlan(s Settings, meta Metadata, in EstimateInput) (EstimateResult, 
 	prof.Overhead += computeBufGB + draftComputeGB
 	prof.Overhead += in.MmprojGB // "-vision" projector weights + CLIP compute reserve
 
+	// Everything charged so far lands on --main-gpu alone, so this is the figure
+	// the spawn guard re-derives the ratio from (FixedGB below). Every device
+	// past the main one pays its own runtime context on top; that part is not
+	// splittable either, but it belongs to the POOLED budget rather than to the
+	// main card, so it is added after FixedGB is taken. Generate does the same,
+	// and the two must agree or a spawn-time retune moves the split for no reason
+	// other than which code path computed it.
+	mainFixedGB := prof.Overhead
+	if gpus := s.GpuSetOrEmpty(); gpus.Multi() {
+		prof.Overhead += gpus.ExtraDeviceOverheadGB()
+	}
+
 	ctx, plan, kvReserve, planCkptGB, err := sizeProfile(meta, s, prof, perTokGB, kvConstGB, modelMax, in.KvInRam)
 	if err != nil {
 		return EstimateResult{}, err
@@ -229,7 +241,7 @@ func EstimatePlan(s Settings, meta Metadata, in EstimateInput) (EstimateResult, 
 		ComputeBufGB: computeBufGB,
 		MmprojGB:     in.MmprojGB,
 		OverheadGB:   s.VramOverheadGB,
-		FixedGB:      prof.Overhead,
+		FixedGB:      mainFixedGB,
 		RamExceeded:  plan.RamExceeded,
 		IsMoE:        meta.IsMoE,
 	}, nil

--- a/internal/autogen/generate.go
+++ b/internal/autogen/generate.go
@@ -492,8 +492,15 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 		// and drafter-graph charges above.
 		profiles[i].MainGpu = -1
 		if gpus.Multi() {
+			// The main device's fixed cost is the overhead as it stands HERE.
+			// ExtraDeviceOverheadGB is the OTHER devices' runtime contexts, which
+			// splitBy already charges to each of them individually; folding it in
+			// as well billed the secondary card's runtime twice, once to the main
+			// card's side of the ratio, and pushed layers off the main GPU onto a
+			// card that had no room for them.
+			mainFixedGB := profiles[i].Overhead
 			profiles[i].Overhead += gpus.ExtraDeviceOverheadGB()
-			profiles[i].TensorSplit = gpus.PlanTensorSplit(profiles[i].Overhead)
+			profiles[i].TensorSplit = gpus.PlanTensorSplit(mainFixedGB)
 			if profiles[i].TensorSplit != nil {
 				profiles[i].MainGpu = gpus.PlanMainIndex()
 			}

--- a/internal/autogen/generate_cmd.go
+++ b/internal/autogen/generate_cmd.go
@@ -361,6 +361,17 @@ func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ng
 	// per layer and is a loss on consumer boards with no NVLink, which is what a
 	// mismatched desktop pair is.
 	if len(prof.TensorSplit) > 1 && ngl > 0 {
+		// --main-gpu is INERT under -sm layer. llama-server --help documents -mg
+		// as "the GPU to use for the model (with split-mode = none), or for
+		// intermediate results and KV (with split-mode = row)"; layer split is
+		// not in that list, and layer split is what we always emit. It is kept
+		// because it costs nothing and is the correct pin for anyone who puts
+		// -sm none or -sm row in extraArgs, but nothing here should be read as
+		// controlling placement: under -sm layer llama.cpp decides for itself
+		// which device carries the non-splittable buffers, and the sizer's
+		// choice of main device (gpuset.go) is an assumption about that, not an
+		// instruction to it.
+		//
 		// Name the devices when the backend can be asked what it calls them.
 		// --main-gpu and --tensor-split are positions in the backend's device
 		// list, not telemetry ordinals: an adapter we filtered out is still

--- a/internal/autogen/generate_cmd.go
+++ b/internal/autogen/generate_cmd.go
@@ -244,6 +244,21 @@ func effectiveUb(meta Metadata, prof profile, ov *Override, ctx int, budgetGB fl
 // indentation), shared by emitProfile (which writes them as a YAML `cmd: >`
 // block) and RenderSoloCmd (which joins them for the editor preview). Any
 // Override.ExtraArgs are appended verbatim as a final line.
+// pinsOwnSplit reports whether the user hand-wrote the --tensor-split vector for
+// this model, in which case we must NOT emit --device.
+//
+// A hand-written ratio is positional against whatever list the backend would
+// have enumerated on its own, which is what it meant when the user typed it.
+// --device replaces that list with ours, in main-last order, so the same string
+// would silently start addressing a different pair of cards. The override is
+// appended after the generated flags and wins on the last-flag-parsed rule, so
+// it survives either way: the choice here is only whether it lands on the cards
+// the user meant. Same refusal contract as everywhere else in this path, a split
+// that cannot be mapped is not rearranged.
+func pinsOwnSplit(ov *Override) bool {
+	return ov != nil && strings.TrimSpace(ov.TensorSplit) != ""
+}
+
 func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ngl, ncpuMoe int, kvK, kvV string, kvInRam bool, ov *Override) []string {
 	// extraArgs is appended verbatim at the end, so anything in it that we also
 	// emit ourselves lands on the line TWICE. -cms is the one that actually
@@ -382,7 +397,7 @@ func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ng
 		// issue #4 was tested on.
 		split := fmt.Sprintf("-sm layer --main-gpu %d", prof.MainGpu)
 		ts := prof.TensorSplit
-		if devs, order := DeviceFlagFor(s.ServerExe, s.GpuSetOrEmpty(), prof.MainGpu); devs != "" {
+		if devs, order := DeviceFlagFor(s.ServerExe, s.GpuSetOrEmpty(), prof.MainGpu); devs != "" && !pinsOwnSplit(ov) {
 			ts = PermuteSplit(ts, order)
 			split = fmt.Sprintf("--device %s -sm layer --main-gpu %d", devs, len(order)-1)
 		}

--- a/internal/autogen/generate_cmd.go
+++ b/internal/autogen/generate_cmd.go
@@ -361,8 +361,19 @@ func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ng
 	// per layer and is a loss on consumer boards with no NVLink, which is what a
 	// mismatched desktop pair is.
 	if len(prof.TensorSplit) > 1 && ngl > 0 {
+		// Name the devices when the backend can be asked what it calls them.
+		// --main-gpu and --tensor-split are positions in the backend's device
+		// list, not telemetry ordinals: an adapter we filtered out is still
+		// counted there, and Vulkan/ROCm have no CUDA_DEVICE_ORDER to pin the
+		// order with. --device replaces that list with ours, so the positions
+		// mean what the plan meant. When it cannot be resolved the flags stay as
+		// they were, which is what shipped and what issue #4 was tested on.
+		split := fmt.Sprintf("-sm layer --main-gpu %d", prof.MainGpu)
+		if devs, mainPos := DeviceFlagFor(s.ServerExe, s.GpuSetOrEmpty(), prof.MainGpu); devs != "" {
+			split = fmt.Sprintf("--device %s -sm layer --main-gpu %d", devs, mainPos)
+		}
 		lines = append(lines,
-			fmt.Sprintf("-sm layer --main-gpu %d", prof.MainGpu),
+			split,
 			fmt.Sprintf("--tensor-split %s", FormatSplit(prof.TensorSplit)),
 		)
 	}

--- a/internal/autogen/generate_cmd.go
+++ b/internal/autogen/generate_cmd.go
@@ -361,31 +361,34 @@ func buildCmdLines(s Settings, meta Metadata, row GgufRow, prof profile, ctx, ng
 	// per layer and is a loss on consumer boards with no NVLink, which is what a
 	// mismatched desktop pair is.
 	if len(prof.TensorSplit) > 1 && ngl > 0 {
-		// --main-gpu is INERT under -sm layer. llama-server --help documents -mg
-		// as "the GPU to use for the model (with split-mode = none), or for
-		// intermediate results and KV (with split-mode = row)"; layer split is
-		// not in that list, and layer split is what we always emit. It is kept
-		// because it costs nothing and is the correct pin for anyone who puts
-		// -sm none or -sm row in extraArgs, but nothing here should be read as
-		// controlling placement: under -sm layer llama.cpp decides for itself
-		// which device carries the non-splittable buffers, and the sizer's
-		// choice of main device (gpuset.go) is an assumption about that, not an
-		// instruction to it.
+		// --main-gpu is INERT under -sm layer. Measured, not inferred: at a fixed
+		// --device list, --main-gpu 0 and --main-gpu 1 produced byte-identical
+		// model, KV and compute buffer lines. It is kept because it costs nothing
+		// and is the correct pin for anyone who puts -sm none or -sm row in
+		// extraArgs, but nothing here should be read as controlling placement.
 		//
-		// Name the devices when the backend can be asked what it calls them.
-		// --main-gpu and --tensor-split are positions in the backend's device
-		// list, not telemetry ordinals: an adapter we filtered out is still
-		// counted there, and Vulkan/ROCm have no CUDA_DEVICE_ORDER to pin the
-		// order with. --device replaces that list with ours, so the positions
-		// mean what the plan meant. When it cannot be resolved the flags stay as
-		// they were, which is what shipped and what issue #4 was tested on.
+		// What DOES control placement under layer split is the ORDER of the device
+		// list: llama.cpp puts the non-splittable output weight on the device
+		// listed last. MainLastOrder puts the plan's main device there, and
+		// PermuteSplit moves --tensor-split with it so both flags still address the
+		// same cards. That is what makes the main device's larger fixed budget
+		// (mainFixedGB, see splitBy) land on the card that was charged for it.
+		//
+		// Naming the devices is also what makes the positions mean anything:
+		// without --device they are positions in the BACKEND's list, which counts
+		// adapters we filtered out and need not be in our order, and Vulkan/ROCm
+		// have no CUDA_DEVICE_ORDER to pin it with. When the list cannot be
+		// resolved the flags stay as they were, which is what shipped and what
+		// issue #4 was tested on.
 		split := fmt.Sprintf("-sm layer --main-gpu %d", prof.MainGpu)
-		if devs, mainPos := DeviceFlagFor(s.ServerExe, s.GpuSetOrEmpty(), prof.MainGpu); devs != "" {
-			split = fmt.Sprintf("--device %s -sm layer --main-gpu %d", devs, mainPos)
+		ts := prof.TensorSplit
+		if devs, order := DeviceFlagFor(s.ServerExe, s.GpuSetOrEmpty(), prof.MainGpu); devs != "" {
+			ts = PermuteSplit(ts, order)
+			split = fmt.Sprintf("--device %s -sm layer --main-gpu %d", devs, len(order)-1)
 		}
 		lines = append(lines,
 			split,
-			fmt.Sprintf("--tensor-split %s", FormatSplit(prof.TensorSplit)),
+			fmt.Sprintf("--tensor-split %s", FormatSplit(ts)),
 		)
 	}
 	// Vision twin loads the projector for image input. --no-mmproj-offload keeps

--- a/internal/autogen/gpuset.go
+++ b/internal/autogen/gpuset.go
@@ -268,6 +268,57 @@ func (g GpuSet) splitBy(capOf func(GpuDevice) float64, main int, mainFixedGB flo
 	return out
 }
 
+// MainLastOrder returns the positions of g in the order the devices must be
+// handed to llama.cpp: every other device first, in their existing relative
+// order, and the main device LAST. Returns nil when mainIndex names no device
+// in g.
+//
+// Last is not arbitrary. Measured on a Vulkan build (llama-server -lv 10,
+// -sm layer, -ts 0.5,0.5, two devices): the device listed LAST carries the
+// non-splittable output weight on top of its layer share, and the surplus moves
+// with the list rather than with --main-gpu. Reversing --device swapped a
+// ~146MiB surplus from one card's model buffer to the other's, while
+// --main-gpu 0 and --main-gpu 1 at a fixed list produced byte-identical model,
+// KV and compute buffers.
+//
+// So the ordering IS the placement instruction, and mainFixedGB is only charged
+// to the right card if that card is last. See splitBy, which prices the main
+// device differently from the rest.
+func (g GpuSet) MainLastOrder(mainIndex int) []int {
+	pos := -1
+	for i, d := range g {
+		if d.Index == mainIndex {
+			pos = i
+			break
+		}
+	}
+	if pos < 0 {
+		return nil
+	}
+	out := make([]int, 0, len(g))
+	for i := range g {
+		if i != pos {
+			out = append(out, i)
+		}
+	}
+	return append(out, pos)
+}
+
+// PermuteSplit reorders a ratio vector to match an order from MainLastOrder, so
+// --tensor-split keeps addressing the same devices as the --device list beside
+// it. A mismatched length is returned unchanged: a split that cannot be mapped
+// must not be silently rearranged onto the wrong cards.
+func PermuteSplit(split []float64, order []int) []float64 {
+	if len(order) != len(split) {
+		return split
+	}
+	out := make([]float64, len(split))
+	for i, p := range order {
+		out[i] = split[p]
+	}
+	return out
+}
+
 // FormatSplit renders a ratio vector as llama.cpp's comma-separated argument.
 func FormatSplit(split []float64) string {
 	parts := make([]string, len(split))

--- a/internal/autogen/gpuset.go
+++ b/internal/autogen/gpuset.go
@@ -522,17 +522,86 @@ func LiveGpuSet(stats []perf.GpuStat, multi bool) GpuSet {
 // split pins to, enumerated by PCI bus so the ordinal means here what it means
 // in nvidia-smi.
 //
-// A no-op on a single-GPU box (nothing to disambiguate), on a non-CUDA GPU
-// (these variables mean nothing to Vulkan or ROCm), and when the device set was
-// never resolved.
-func writeSingleDeviceEnv(b *strings.Builder, s Settings) {
-	if !usingCudaGPU() {
-		return
-	}
+// Vulkan and ROCm have the same problem and their own variables for it, but the
+// ordinal those take is the BACKEND's, which telemetry does not supply: it used
+// to be a no-op there, leaving a two-card Vulkan box to whichever adapter ggml
+// enumerated first. singleDeviceEnvFor asks the binary instead, so the pin is
+// derived rather than assumed.
+//
+// A no-op on a single-GPU box (nothing to disambiguate), when the device set was
+// never resolved, and when neither the probe nor the CUDA fallback can name the
+// device.
+func writeSingleDeviceEnv(b *strings.Builder, s Settings, exe string) {
 	set := s.GpuSetOrEmpty()
 	if !set.Multi() {
 		return
 	}
-	fmt.Fprintf(b, "    env:\n      - %q\n      - %q\n",
-		cudaOrderEnv, fmt.Sprintf("CUDA_VISIBLE_DEVICES=%d", set.PlanMainIndex()))
+	pin, isCuda := singleDeviceEnvFor(exe, set)
+	if pin == "" {
+		return
+	}
+	b.WriteString("    env:\n")
+	// CUDA_DEVICE_ORDER only means anything alongside CUDA_VISIBLE_DEVICES, and
+	// it is what makes the ordinal in it mean what nvidia-smi means.
+	if isCuda {
+		fmt.Fprintf(b, "      - %q\n", cudaOrderEnv)
+	}
+	fmt.Fprintf(b, "      - %q\n", pin)
+}
+
+// singleDeviceEnvFor returns the NAME=VALUE pin for the plan's main device as
+// this backend enumerates it, and whether it is the CUDA one.
+//
+// Preferred path: ask the binary what it calls its devices and read the ordinal
+// off the id it gives the main card ("Vulkan1" -> 1). That is the only way to
+// get a Vulkan or ROCm ordinal right, because the telemetry index is a different
+// enumeration and using it directly would pin the wrong adapter, silently.
+//
+// Fallback: CUDA alone, where CUDA_DEVICE_ORDER=PCI_BUS_ID makes the runtime's
+// ordinal agree with nvidia-smi's, so the telemetry index IS the right value.
+// Everything else refuses, which is the behaviour that shipped.
+func singleDeviceEnvFor(exe string, set GpuSet) (string, bool) {
+	main := set.PlanMainIndex()
+	if devs, err := ListBackendDevices(exe); err == nil {
+		if ids := set.BackendIDs(devs); len(ids) == len(set) {
+			for i, d := range set {
+				if d.Index != main {
+					continue
+				}
+				if name, ord, ok := visibleDevicesEnvFor(ids[i]); ok {
+					return name + "=" + ord, name == "CUDA_VISIBLE_DEVICES"
+				}
+				break
+			}
+		}
+	}
+	if usingCudaGPU() {
+		return fmt.Sprintf("CUDA_VISIBLE_DEVICES=%d", main), true
+	}
+	return "", false
+}
+
+// visibleDevicesEnvFor splits a backend device id into the variable that filters
+// that backend's device list and the ordinal to give it. The id carries both:
+// ggml names devices "<backend><ordinal>", and each backend's filter variable
+// indexes the same enumeration the id was numbered from.
+//
+// An unrecognised backend gets nothing rather than a guess. A filter variable
+// aimed at the wrong enumeration does not fail loudly, it just runs the model on
+// a card the sizer did not budget.
+func visibleDevicesEnvFor(id string) (string, string, bool) {
+	cut := strings.IndexFunc(id, func(r rune) bool { return r >= '0' && r <= '9' })
+	if cut <= 0 {
+		return "", "", false
+	}
+	ord := id[cut:]
+	switch strings.ToLower(id[:cut]) {
+	case "cuda":
+		return "CUDA_VISIBLE_DEVICES", ord, true
+	case "vulkan", "vk":
+		return "GGML_VK_VISIBLE_DEVICES", ord, true
+	case "rocm", "hip":
+		return "HIP_VISIBLE_DEVICES", ord, true
+	}
+	return "", "", false
 }

--- a/internal/autogen/gpuset.go
+++ b/internal/autogen/gpuset.go
@@ -182,10 +182,12 @@ func (g GpuSet) ExtraDeviceOverheadGB() float64 {
 
 // TensorSplit is the --tensor-split ratio, one entry per device in Index order.
 //
-// mainFixedGB is the whole non-splittable footprint the main device carries
-// (prof.Overhead, which by this point already folds in the compute buffer, the
-// spec/draft overhead and the projector). Each other device is charged
-// perDeviceFixedGB. The remainder is what layers and KV may occupy, and the
+// mainFixedGB is the non-splittable footprint the MAIN device carries: the
+// compute buffer, the runtime context, the spec/draft overhead and the
+// projector. Each other device is charged perDeviceFixedGB here, so mainFixedGB
+// must NOT include ExtraDeviceOverheadGB: that term is the other devices'
+// runtime seen from the pooled budget's side, and passing it in bills the same
+// bytes to both cards, shifting layers off the main GPU onto one with no room. The remainder is what layers and KV may occupy, and the
 // ratio is that remainder normalised, which is precisely the ratio under which
 // the pooled budget is reachable without any single card going over.
 //

--- a/internal/autogen/gpuset.go
+++ b/internal/autogen/gpuset.go
@@ -187,9 +187,11 @@ func (g GpuSet) ExtraDeviceOverheadGB() float64 {
 // projector. Each other device is charged perDeviceFixedGB here, so mainFixedGB
 // must NOT include ExtraDeviceOverheadGB: that term is the other devices'
 // runtime seen from the pooled budget's side, and passing it in bills the same
-// bytes to both cards, shifting layers off the main GPU onto one with no room. The remainder is what layers and KV may occupy, and the
-// ratio is that remainder normalised, which is precisely the ratio under which
-// the pooled budget is reachable without any single card going over.
+// bytes to both cards, shifting layers off the main GPU onto one with no room.
+//
+// The remainder is what layers and KV may occupy, and the ratio is that
+// remainder normalised, which is precisely the ratio under which the pooled
+// budget is reachable without any single card going over.
 //
 // A device with no room left after its fixed cost gets 0, and llama.cpp will
 // place nothing on it. Returns nil for a set that isn't worth splitting or when

--- a/internal/autogen/gpuset_test.go
+++ b/internal/autogen/gpuset_test.go
@@ -295,3 +295,36 @@ func TestAutogen_retuneTensorSplit(t *testing.T) {
 		t.Fatalf("single-GPU argv changed: %v", got)
 	}
 }
+
+// The extra devices' runtime context must never reach splitBy as part of the
+// MAIN device's fixed cost: splitBy already charges perDeviceFixedGB to each
+// non-main device, so folding ExtraDeviceOverheadGB in bills the secondary
+// card's runtime twice, and both charges land on the main card's side of the
+// ratio. Issue #4's box is the shape it hurts: a 16 GB main card beside a 12 GB
+// one, where every point of ratio shifted off the main GPU lands on the card
+// that ran out of memory.
+func TestAutogen_TensorSplit_ExcludesExtraDeviceOverhead(t *testing.T) {
+	setCudaGPU(t, false)
+
+	set := GpuSet{
+		{Index: 0, TotalGB: 12, FreeGB: 11}, // RTX 3060
+		{Index: 1, TotalGB: 16, FreeGB: 15}, // RTX 4070 Ti SUPER, the main device
+	}
+	const overhead = 2.0
+
+	// Correct: 15-2 = 13 on main, 11-0.4 = 10.6 on the other, 23.6 total.
+	want := set.TensorSplit(overhead)
+	if len(want) != 2 || want[0] != 0.45 || want[1] != 0.55 {
+		t.Fatalf("TensorSplit(%.1f) = %v, want [0.45 0.55]", overhead, want)
+	}
+
+	// What the generate path used to pass. The second card's 0.4 GB is deducted
+	// from the main card as well as from itself, so the ratio tips toward the
+	// smaller card by exactly the amount that was double-counted.
+	doubled := set.TensorSplit(overhead + set.ExtraDeviceOverheadGB())
+	if doubled[0] <= want[0] {
+		t.Fatalf("double-charged split %v is not biased toward the secondary card vs %v; "+
+			"the regression this guards is no longer observable and the test needs new numbers",
+			doubled, want)
+	}
+}

--- a/internal/autogen/gpuset_test.go
+++ b/internal/autogen/gpuset_test.go
@@ -1,6 +1,7 @@
 package autogen
 
 import (
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -326,5 +327,80 @@ func TestAutogen_TensorSplit_ExcludesExtraDeviceOverhead(t *testing.T) {
 		t.Fatalf("double-charged split %v is not biased toward the secondary card vs %v; "+
 			"the regression this guards is no longer observable and the test needs new numbers",
 			doubled, want)
+	}
+}
+
+// Once generate pins the device list with --device, --main-gpu is a position in
+// THAT list. The spawn-time retune rewrites --main-gpu, so it has to follow the
+// same rule or it puts back the telemetry ordinal the naming was meant to
+// replace: here main is telemetry index 3, which is position 1 of the pinned
+// pair.
+func TestAutogen_retuneTensorSplit_PinnedDeviceList(t *testing.T) {
+	setCudaGPU(t, false)
+	s := Settings{Gpus: GpuSet{
+		{Index: 0, TotalGB: 12, FreeGB: 1},
+		{Index: 3, TotalGB: 16, FreeGB: 15},
+	}}
+	named := []string{"llama-server", "-m", "/m.gguf", "--device", "Vulkan1,Vulkan0",
+		"-sm", "layer", "--main-gpu", "1", "--tensor-split", "0.5,0.5"}
+	got := retuneTensorSplit(s, named, 5, nil)
+	if got[8] != "1" {
+		t.Fatalf("--main-gpu = %q, want the position 1, not the telemetry index 3", got[8])
+	}
+	if got[4] != "Vulkan1,Vulkan0" {
+		t.Fatalf("retune touched --device: %q", got[4])
+	}
+
+	// Same set, no --device: the telemetry index is still the best stand-in for
+	// the backend's own ordinal.
+	unnamed := []string{"llama-server", "-m", "/m.gguf", "-sm", "layer", "--main-gpu", "0", "--tensor-split", "0.5,0.5"}
+	if got := retuneTensorSplit(s, unnamed, 5, nil); got[6] != "3" {
+		t.Fatalf("unnamed --main-gpu = %q, want the telemetry index 3", got[6])
+	}
+}
+
+// A backend device id carries both halves of the pin: which enumeration to
+// filter, and which ordinal in it. Getting the pairing wrong does not fail
+// loudly, it silently runs the model on a card the sizer did not budget.
+func TestAutogen_visibleDevicesEnvFor(t *testing.T) {
+	want := map[string][2]string{
+		"CUDA0":   {"CUDA_VISIBLE_DEVICES", "0"},
+		"Vulkan1": {"GGML_VK_VISIBLE_DEVICES", "1"},
+		"ROCm2":   {"HIP_VISIBLE_DEVICES", "2"},
+	}
+	for id, w := range want {
+		name, ord, ok := visibleDevicesEnvFor(id)
+		if !ok || name != w[0] || ord != w[1] {
+			t.Errorf("visibleDevicesEnvFor(%q) = %q,%q,%v; want %q,%q,true", id, name, ord, ok, w[0], w[1])
+		}
+	}
+	// An unrecognised backend, and an id with no ordinal at all, get nothing
+	// rather than a guess.
+	for _, id := range []string{"SYCL0", "Metal0", "Vulkan", "0"} {
+		if _, _, ok := visibleDevicesEnvFor(id); ok {
+			t.Errorf("visibleDevicesEnvFor(%q) claimed a pin", id)
+		}
+	}
+}
+
+// With no probe to go on, CUDA still pins from the telemetry index (PCI bus
+// order makes the two agree) and everything else emits nothing, which is what
+// shipped.
+func TestAutogen_singleDeviceEnvFor_NoProbe(t *testing.T) {
+	set := GpuSet{
+		{Index: 0, TotalGB: 12, FreeGB: 11},
+		{Index: 1, TotalGB: 16, FreeGB: 15},
+	}
+	missing := filepath.Join(t.TempDir(), "not-a-backend")
+
+	setCudaGPU(t, true)
+	pin, isCuda := singleDeviceEnvFor(missing, set)
+	if pin != "CUDA_VISIBLE_DEVICES=1" || !isCuda {
+		t.Fatalf("CUDA fallback = %q,%v; want CUDA_VISIBLE_DEVICES=1,true", pin, isCuda)
+	}
+
+	setCudaGPU(t, false)
+	if pin, _ := singleDeviceEnvFor(missing, set); pin != "" {
+		t.Fatalf("non-CUDA with no probe = %q, want no pin", pin)
 	}
 }

--- a/internal/autogen/gpuset_test.go
+++ b/internal/autogen/gpuset_test.go
@@ -341,21 +341,26 @@ func TestAutogen_retuneTensorSplit_PinnedDeviceList(t *testing.T) {
 		{Index: 0, TotalGB: 12, FreeGB: 1},
 		{Index: 3, TotalGB: 16, FreeGB: 15},
 	}}
+	// A pinned list whose order cannot be re-derived (no probeable backend exe
+	// here) is left completely alone. Rewriting --tensor-split in SET order
+	// against a list written in main-last order would hand each card the other's
+	// ratio, which is worse than the stale ratio it replaced.
 	named := []string{"llama-server", "-m", "/m.gguf", "--device", "Vulkan1,Vulkan0",
 		"-sm", "layer", "--main-gpu", "1", "--tensor-split", "0.5,0.5"}
 	got := retuneTensorSplit(s, named, 5, nil)
-	if got[8] != "1" {
-		t.Fatalf("--main-gpu = %q, want the position 1, not the telemetry index 3", got[8])
-	}
-	if got[4] != "Vulkan1,Vulkan0" {
-		t.Fatalf("retune touched --device: %q", got[4])
+	if got[10] != "0.5,0.5" || got[8] != "1" || got[4] != "Vulkan1,Vulkan0" {
+		t.Fatalf("retune rewrote an unmappable pinned launch: %v", got[4:])
 	}
 
 	// Same set, no --device: the telemetry index is still the best stand-in for
-	// the backend's own ordinal.
+	// the backend's own ordinal, and the split is already in set order.
 	unnamed := []string{"llama-server", "-m", "/m.gguf", "-sm", "layer", "--main-gpu", "0", "--tensor-split", "0.5,0.5"}
-	if got := retuneTensorSplit(s, unnamed, 5, nil); got[6] != "3" {
-		t.Fatalf("unnamed --main-gpu = %q, want the telemetry index 3", got[6])
+	reg := retuneTensorSplit(s, unnamed, 5, nil)
+	if reg[6] != "3" {
+		t.Fatalf("unnamed --main-gpu = %q, want the telemetry index 3", reg[6])
+	}
+	if reg[8] == "0.5,0.5" {
+		t.Fatalf("unnamed --tensor-split was not retuned: %q", reg[8])
 	}
 }
 

--- a/internal/autogen/hash.go
+++ b/internal/autogen/hash.go
@@ -187,7 +187,7 @@ const hashCacheSuffix = ".modelhash"
 //	     for that one sample used to bake a single-device plan that spawn time
 //	     could not repair, since the live retune rewrites an existing
 //	     --tensor-split and cannot add one.
-const genVersion = "v63"
+const genVersion = "v64"
 
 // InputsHash digests everything that can change the generated config: the set of
 // gguf files under modelsRoot (path + size + mtime) plus the raw bytes of the

--- a/internal/autogen/hash.go
+++ b/internal/autogen/hash.go
@@ -187,7 +187,7 @@ const hashCacheSuffix = ".modelhash"
 //	     for that one sample used to bake a single-device plan that spawn time
 //	     could not repair, since the live retune rewrites an existing
 //	     --tensor-split and cannot add one.
-const genVersion = "v64"
+const genVersion = "v65"
 
 // InputsHash digests everything that can change the generated config: the set of
 // gguf files under modelsRoot (path + size + mtime) plus the raw bytes of the

--- a/internal/autogen/image.go
+++ b/internal/autogen/image.go
@@ -759,7 +759,7 @@ func emitExtraImageModels(b *strings.Builder, s Settings, overrides []Override, 
 			fmt.Fprintf(b, "      %s\n", line)
 		}
 		fmt.Fprintf(b, "    ttl: %d\n", s.TtlSec)
-		writeSingleDeviceEnv(b, s)
+		writeSingleDeviceEnv(b, s, s.SdServerExe)
 		writeEstVram(b, extraImageBudget(s, m))
 		b.WriteString("    checkEndpoint: /\n")
 		if m.Unlisted {
@@ -794,7 +794,7 @@ func emitImageModel(b *strings.Builder, s Settings, row GgufRow, ov *Override, n
 		fmt.Fprintf(b, "      %s\n", line)
 	}
 	fmt.Fprintf(b, "    ttl: %d\n", s.TtlSec)
-	writeSingleDeviceEnv(b, s)
+	writeSingleDeviceEnv(b, s, s.SdServerExe)
 	// Admission estimate = the --max-vram cap sd-server is told to stay inside.
 	// True peak during sampling/VAE decode runs above it, which is why the
 	// scheduler additionally refuses to spawn anything while a render is in

--- a/internal/autogen/liveoffload.go
+++ b/internal/autogen/liveoffload.go
@@ -271,23 +271,34 @@ func retuneTensorSplit(s Settings, args []string, mainFixedGB float64, logf func
 	if len(split) < 2 {
 		return args
 	}
-	next := FormatSplit(split)
 	main := set.MainIndex()
 	out := append([]string(nil), args...)
-	out[idx] = next
-	// --main-gpu is a position in whatever device list the launch runs with. If
-	// generate pinned that list with --device, it is a position in OUR set; with
-	// no --device it is the backend's own ordinal, which is what the telemetry
-	// index has always stood in for. Rewriting it as an index under a pinned
-	// list would point at a device the list may not even contain.
+	// --main-gpu and --tensor-split are positions in whatever device list the
+	// launch runs with. With no --device that list is the backend's own, which
+	// the telemetry index has always stood in for, and the split is already in
+	// set order.
+	//
+	// With --device, generate pinned the list AND its order: main last, because
+	// that is the position llama.cpp gives the non-splittable output weight
+	// under -sm layer (see GpuSet.MainLastOrder). The live main device need not
+	// be the one generate picked, so the list is re-derived here rather than
+	// trusted, and the freshly computed split is permuted to match it.
+	//
+	// If the devices cannot be named now (a probe that worked at generate time
+	// and not at spawn), the baked list stays and NOTHING is rewritten: a split
+	// written in set order against a list in main-last order would hand each
+	// card the other's ratio, which is worse than the stale ratio it replaced.
 	if _, dev := argVal(out, "--device", "-dev"); dev >= 0 {
-		for i, d := range set {
-			if d.Index == main {
-				main = i
-				break
-			}
+		devs, order := DeviceFlagFor(s.ServerExe, set, main)
+		if devs == "" {
+			return args
 		}
+		out[dev] = devs
+		split = PermuteSplit(split, order)
+		main = len(order) - 1
 	}
+	next := FormatSplit(split)
+	out[idx] = next
 	if _, mi := argVal(out, "--main-gpu", "-mg"); mi >= 0 {
 		out[mi] = strconv.Itoa(main)
 	}

--- a/internal/autogen/liveoffload.go
+++ b/internal/autogen/liveoffload.go
@@ -275,6 +275,19 @@ func retuneTensorSplit(s Settings, args []string, mainFixedGB float64, logf func
 	main := set.MainIndex()
 	out := append([]string(nil), args...)
 	out[idx] = next
+	// --main-gpu is a position in whatever device list the launch runs with. If
+	// generate pinned that list with --device, it is a position in OUR set; with
+	// no --device it is the backend's own ordinal, which is what the telemetry
+	// index has always stood in for. Rewriting it as an index under a pinned
+	// list would point at a device the list may not even contain.
+	if _, dev := argVal(out, "--device", "-dev"); dev >= 0 {
+		for i, d := range set {
+			if d.Index == main {
+				main = i
+				break
+			}
+		}
+	}
 	if _, mi := argVal(out, "--main-gpu", "-mg"); mi >= 0 {
 		out[mi] = strconv.Itoa(main)
 	}

--- a/ui-svelte/src/components/ModelConfigModal.svelte
+++ b/ui-svelte/src/components/ModelConfigModal.svelte
@@ -2556,7 +2556,7 @@
               <input type="number" min="0" max="1" step="0.05" bind:value={adv.slotPromptSimilarity} use:wheelAdjust class="cfg-input w-20 ml-auto" placeholder="off" />
             </label>
             <label class="flex items-center gap-2">
-              <span class="text-txtsecondary flex items-center gap-1">Main GPU {@render hint("-mg. Primary GPU index. Empty = the device quartermaster picked (the one with the most capacity), not GPU 0.")}</span>
+              <span class="text-txtsecondary flex items-center gap-1">Main GPU {@render hint("-mg. Primary GPU index. Applies only with split mode none or row; the default layer split ignores it. Empty = the device quartermaster picked (the one with the most capacity), not GPU 0.")}</span>
               <input type="number" min="0" step="1" bind:value={adv.mainGpu} use:wheelAdjust class="cfg-input w-20 ml-auto" placeholder="auto" />
             </label>
             <label class="flex items-center gap-2">

--- a/ui-svelte/src/components/ModelConfigModal.svelte
+++ b/ui-svelte/src/components/ModelConfigModal.svelte
@@ -2556,8 +2556,8 @@
               <input type="number" min="0" max="1" step="0.05" bind:value={adv.slotPromptSimilarity} use:wheelAdjust class="cfg-input w-20 ml-auto" placeholder="off" />
             </label>
             <label class="flex items-center gap-2">
-              <span class="text-txtsecondary flex items-center gap-1">Main GPU {@render hint("-mg. Primary GPU index. 0 = GPU 0.")}</span>
-              <input type="number" min="0" step="1" bind:value={adv.mainGpu} use:wheelAdjust class="cfg-input w-20 ml-auto" placeholder="0" />
+              <span class="text-txtsecondary flex items-center gap-1">Main GPU {@render hint("-mg. Primary GPU index. Empty = the device quartermaster picked (the one with the most capacity), not GPU 0.")}</span>
+              <input type="number" min="0" step="1" bind:value={adv.mainGpu} use:wheelAdjust class="cfg-input w-20 ml-auto" placeholder="auto" />
             </label>
             <label class="flex items-center gap-2">
               <span class="text-txtsecondary flex items-center gap-1">Draft KV-K {@render hint("-ctkd. Draft/spec context K cache type, including a baked-in MTP head. Empty = match KV-K.")}</span>
@@ -2596,8 +2596,8 @@
               <input type="number" min="0" step="1024" bind:value={adv.yarnOrigCtx} use:wheelAdjust class="cfg-input w-24 ml-auto" placeholder="auto" />
             </label>
             <label class="flex items-center gap-2">
-              <span class="text-txtsecondary flex items-center gap-1">Tensor split {@render hint("-ts. Per-GPU proportion, comma list e.g. 3,1. Empty = omit.")}</span>
-              <input type="text" bind:value={adv.tensorSplit} class="cfg-input w-24 ml-auto" placeholder="3,1" />
+              <span class="text-txtsecondary flex items-center gap-1">Tensor split {@render hint("-ts. Per-GPU proportion, comma list e.g. 3,1. Empty = the split quartermaster generated across your GPUs.")}</span>
+              <input type="text" bind:value={adv.tensorSplit} class="cfg-input w-24 ml-auto" placeholder="auto" />
             </label>
             <label class="flex items-center gap-2 col-span-2">
               <span class="text-txtsecondary flex items-center gap-1 shrink-0">Override tensor {@render hint("-ot. Manual tensor→buffer placement pattern, e.g. exps=CPU. Empty = omit.")}</span>


### PR DESCRIPTION
Three follow-ups from the multi-GPU report in #4, plus the placement rule measured out of a real llama.cpp load.

- UI: the GPU index/split placeholders no longer assert a value that is not in effect. Empty main-gpu means the device quartermaster picked, not GPU 0.
- autogen: probe `--list-devices` and emit `--device CUDA1,CUDA0` (etc.) so our order is authoritative, instead of trusting a telemetry ordinal to line up with the backend's enumeration. Refuses entirely when any planned card cannot be matched, so an old build's argv is byte-identical to what shipped. The single-device pin is derived the same way, which makes it work on Vulkan and ROCm rather than CUDA only.
- autogen: stop billing the second GPU's runtime context twice. `splitBy` already charges `perDeviceFixedGB()` to every non-main device; `generate.go` also folded `ExtraDeviceOverheadGB()` into the `mainFixedGB` it passed in, tipping `--tensor-split` off the main GPU. `EstimatePlan` now applies the same pooled overhead so generate and `retuneTensorSplit` agree on one ratio.
- autogen: order the device list so the plan's main GPU is last. Measured on a Vulkan build (`-lv 10 -sm layer -ts 0.5,0.5`, two adapters): `--device` order is the split order, the non-splittable output weight lands on the device listed LAST (reversing the list moved a ~146 MiB surplus between cards), and `--main-gpu` is inert under layer split (`--main-gpu 0` and `--main-gpu 1` gave byte-identical buffer lines). `MainLastOrder` + `PermuteSplit` keep `--tensor-split` addressing the same cards, so the main device's larger fixed budget lands on the card charged for it.

Refs #4