### PR TITLE
ui: stop the managed-backends section popping in, collapse the registry

### DIFF
--- a/ui-svelte/src/components/ManagedBackends.svelte
+++ b/ui-svelte/src/components/ManagedBackends.svelte
@@ -713,4 +713,26 @@
     <h6>Install a backend</h6>
     <p class="mt-1 font-mono text-[0.65rem] text-error">{err}</p>
   </div>
+{:else if available}
+  <!-- First paint, catalog still in flight. Rendering nothing here let the
+       registry below sit at the top of the tab and then get shoved down when
+       the fetch landed; a skeleton of the same shape holds the space so the
+       section fades in instead of pushing the page around. -->
+  <div class="mb-6" aria-busy="true">
+    <div class="flex items-baseline gap-2 mb-1">
+      <h6>Install a backend</h6>
+    </div>
+    <p class="text-[0.7rem] text-txtsecondary mb-3">
+      Downloads the build from its upstream release and registers it below. Every version you install is kept, so you
+      can switch back at any time.
+    </p>
+    <div class="animate-pulse">
+      <div class="h-8 mb-3 border-b border-card-border"></div>
+      <div class="flex flex-col gap-3">
+        {#each [0, 1, 2] as i (i)}
+          <div class="h-[5.5rem] rounded-md border border-card-border bg-surface/40"></div>
+        {/each}
+      </div>
+    </div>
+  </div>
 {/if}

--- a/ui-svelte/src/routes/Settings.svelte
+++ b/ui-svelte/src/routes/Settings.svelte
@@ -374,6 +374,9 @@
   // context ladder that regenerates the config on a 900ms timer is exactly the
   // failure mode the warning above them is about. They get an explicit Apply.
   let advOpen = $state(false);
+  // The hand-editable backend registry. Collapsed by default: it is the
+  // low-level view of what the managed installs above already write for you.
+  let backendRegOpen = $state(false);
   let aCompute = $state(1);
   let aVisionOverhead = $state(1);
   let aMinGpuVram = $state(3);
@@ -1437,9 +1440,19 @@
       <ManagedBackends onchanged={loadSettings} />
 
       <div class="flex items-baseline gap-2 mb-1">
-        <h6 >Backends</h6>
-        {@render hint("Inference server binaries Quartermaster can spawn, grouped by the kind of model they serve. On AMD/Intel GPUs point a row at a Vulkan (or ROCm/HIP) build - a CUDA build silently falls back to CPU. The ★ entry of a group is the auto-pick; a model can be pinned to any other entry of its group from its config editor.")}
+        <button
+          class="flex items-baseline gap-2 text-txtsecondary hover:text-txtmain"
+          onclick={() => (backendRegOpen = !backendRegOpen)}
+          aria-expanded={backendRegOpen}
+        >
+          <h6 class="!m-0">Registered binaries</h6>
+          <span class="text-micro">{backendRegOpen ? "▾" : "▸"}</span>
+          <span class="text-micro font-mono text-txtsecondary">{backends.length}</span>
+        </button>
+        {@render hint("Every inference server binary Quartermaster can spawn, grouped by the kind of model it serves - the installs above plus any path you enter by hand. On AMD/Intel GPUs point a row at a Vulkan (or ROCm/HIP) build - a CUDA build silently falls back to CPU. The ★ entry of a group is the auto-pick; a model can be pinned to any other entry of its group from its config editor.")}
       </div>
+
+      {#if backendRegOpen}
       <p class="text-[0.7rem] text-txtsecondary mb-4">
         Blank groups fall back to the built-in defaults (llama-server on PATH, sd/tts as siblings).
       </p>
@@ -1525,6 +1538,7 @@
           <span class="text-micro text-error">{backendsErr}</span>
         {/if}
       </div>
+      {/if}
 
       <div class="mt-6">
         <div class="flex items-baseline gap-2 mb-1">


### PR DESCRIPTION
The backends settings tab rendered nothing where the managed installs go until the catalog fetch landed, so the hand-entered registry drew at the top of the tab and was then shoved down.

- ManagedBackends: loading skeleton branch (heading, blurb, tab bar, three card placeholders), ordered after the error branch so it cannot swallow it
- Settings: the "Backends" list is now a collapsible "Registered binaries" section with a count, collapsed by default, matching the Advanced toggle
- reword its hint to say it holds the managed installs plus hand-entered paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)