### PR TITLE
autogen: load the image projector on every served id, in RAM

### DIFF
--- a/internal/autogen/CLAUDE.md
+++ b/internal/autogen/CLAUDE.md
@@ -32,7 +32,7 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
 | `kvcost.go` | KV-cache cost model (`GetKvCostModel`) + context-budget math (`MaxCtxForBudget`, `KvReserveGB`, `RoundedCtx`, `GetDenseCtx`, `defaultKvQuant`). → `sizing.md` |
 | `plan.go` | VRAM budget → placement: `-ngl`/`--n-cpu-moe` for dense and MoE (`GetLoadPlan`, `densePlacement`); MoE expert-share table + `effectiveShare`. → `sizing.md` |
 | `generate.go` | Top-level orchestration (`Generate`): builds per-model profiles (solo, ctx tiers, named variants), sizes each, emits the YAML. `emitModel`/`RenderSoloCmd` **dispatch by model class** (SAM → image → embedding → TTS → ASR → LLM). This file is the profile loop; the three phases live in the siblings below. |
-| `generate_sizing.go` | Phase 1 — sizing math: `sizeProfile`, `--ctx-checkpoints` count + `checkpointReserveGB`, `forceLowActiveMoE`/`applyForcedOffload`/`estForOffload`, `computeBufferGB`, `MmprojVramGB`, `cpuMmprojWins`, `draftOverheadGB`. Pure arithmetic over `Metadata` + `Settings`. → `sizing.md` |
+| `generate_sizing.go` | Phase 1 — sizing math: `sizeProfile`, `--ctx-checkpoints` count + `checkpointReserveGB`, `forceLowActiveMoE`/`applyForcedOffload`/`estForOffload`, `computeBufferGB`, `MmprojVramGB`, `draftOverheadGB`. Pure arithmetic over `Metadata` + `Settings`. → `sizing.md` |
 | `generate_cmd.go` | Phase 2 — command rendering: `buildCmdLines` (the per-class argv builder) and `RenderSoloCmd` (same with a `${PORT}` placeholder, for the UI preview + ad-hoc commands), plus `effectiveUb`, `effectiveSpec`/`specHas`, `cmdPath`, `needsQwenFixedChatTemplate`, `defaultSamplerFor`/`samplerLines`. |
 | `generate_emit.go` | Phase 3 — YAML emission: non-model sections (`emitSlotCache`, `emitAPIKeys`, `emitGroupsAndListeners`, `writeGroup`) and per-model bits (`emitProfile`, `writeDisplayName`, `writeEstVram`/`writeEstRam`, `effortLevels`, `formatCtxTag`, `slugify`). |
 | `estimate.go` | One-shot preview (`EstimatePlan`) of a candidate tuning for the web editor; reuses the solo-profile sizing path without writing config. |
@@ -79,23 +79,27 @@ pre-generating config variants by hand. Kept deliberately separable for clean up
   sidecar or DFlash drafter, `MmprojPath` a same-dir clip projector. When a dir ships neither,
   `inheritSidecars` (`family.go`) borrows one from a compatible family member — see the gotcha
   below.
-- Vision twin projector placement (`generate.go` profile loop + `cpuMmprojWins`) — every
-  `-vision` twin is sized TWICE: once with the CLIP projector resident in VRAM (`MmprojGB`
-  charged to `Overhead`) and once with it on the CPU. The CPU sizing wins, and the twin emits
-  `--no-mmproj-offload`, when the GPU-resident projector displaced text layers (lower `-ngl` /
-  more `--n-cpu-moe`) or cost more than a quarter of the context window. Placement first: that
-  tax is per token, the CPU encode is a one-off per image. `LiveOffloadArgs` and the editor
-  preview (`configapi_estimate.go`) both skip the `MmprojGB` charge when the argv carries the
-  flag, so all three price the same launch. `Override.Mmproj` pins the decision per model —
-  `gpu` / `ram` skip the dual sizing, `none` emits no twin at all (unlike an unlisted twin,
-  which still builds). Surfaced as the "Image projector" dropdown on the model config modal's
-  Default tab, shown only when the model resolves to a projector at all (discovered, or named
-  by `mmprojFile` below). `VariantSpec.Mmproj` repeats the knob
-  on the reserved `vision` variant and OUTRANKS the model-wide pin there (blank = inherit); it
-  is deliberately absent from every other variant tab, because no other variant's profile loads
-  a projector at all. Careful: an image-class model routes through `emitImageModel` before the
-  twin gate, so a variant literally named `vision` is an ordinary image variant for those —
-  assert on `--mmproj`, not on the `-vision` id.
+- Projector placement (`generate.go` profile loop) — if a model resolves to a projector, EVERY
+  profile of it loads one (`prof.Vision`), not just the `-vision` twin. llama-server reads
+  `--mmproj` at spawn and nowhere else, so a served id launched without it answers every image
+  with `image input is not supported` for the life of the process: a text id that silently
+  rejects images is a trap, and the router never inspects the body to route around it. What
+  differs is placement. Default profile, ctx tiers and named variants get the projector in RAM
+  (`CpuMmproj` → `--no-mmproj-offload`): zero VRAM, so the window and the layer placement are
+  exactly what they would have been without it, at the cost of a one-off host-side encode on
+  the requests that actually carry an image. The `-vision` twin is the id that pays VRAM for it
+  (`MmprojGB` charged to `Overhead`), which is what it exists for. `LiveOffloadArgs` and the
+  editor preview (`configapi_estimate.go`) both skip the `MmprojGB` charge when the argv
+  carries the flag, so all three price the same launch. Two pins, two audiences:
+  `Override.Mmproj` (the "Image projector" dropdown on the model config modal's Default tab,
+  shown only when a projector resolves at all) places it on the non-twin profiles — `gpu` buys
+  VRAM residency there too, `none` opts the whole model out of vision including the twin.
+  `VariantSpec.Mmproj` on the reserved `vision` variant places the TWIN's, and is the only
+  thing that does; blank keeps the GPU default, `none` there drops the twin alone and leaves
+  the text ids taking images. It is deliberately absent from every other variant tab, since
+  those inherit the model-wide pin. Careful: an image-class model routes through
+  `emitImageModel` before the twin gate, so a variant literally named `vision` is an ordinary
+  image variant for those — assert on `--mmproj`, not on the `-vision` id.
 - `GetLoadPlan` (`plan.go`) — `-ngl`/`--n-cpu-moe` from a VRAM budget; MoE path uses a 0.5
   PCIe-thrash crossover, falling back to naive `-ngl` (`densePlacement`) past it.
 - `Generate` (`generate.go`) — discover → per-model `emitModel` → `emitGroupsAndListeners`.

--- a/internal/autogen/generate.go
+++ b/internal/autogen/generate.go
@@ -70,15 +70,22 @@ type profile struct {
 	// layer over the model-wide override at emit so a variant carries the full
 	// launch shape. Solo/ctx-tier profiles leave this nil and use the override.
 	Variant *VariantSpec
-	// Vision marks the auto-generated "-vision" twin: emits --mmproj <projector>
-	// and an image-input capabilities block so the playground can attach images.
+	// Vision marks a profile that loads the CLIP projector: emits --mmproj
+	// <projector> and an image-input capabilities block so a client can send
+	// images. EVERY profile of a model with a projector carries this, not just
+	// the "-vision" twin — a served id that silently rejects images is a trap,
+	// since llama-server can only load a projector at spawn time and answers an
+	// image with "image input is not supported" for the life of the process.
+	// The twin remains as the id whose projector is GPU-resident.
 	Vision bool
 	// MmprojGB is the projector footprint (weights + CLIP compute reserve) this
-	// vision twin charges as VRAM overhead. Kept separate from Overhead so the
-	// sizer can price the twin a second time with the projector on the CPU.
+	// profile charges as VRAM overhead. Zero when CpuMmproj puts it in RAM.
 	MmprojGB float64
-	// MmprojPin is the model override's explicit placement for the projector
-	// ("gpu"/"ram"); "" leaves the sizer's auto fallback in charge.
+	// MmprojPin is the resolved projector placement for this profile, "gpu" or
+	// "ram". Defaults differ by profile: the "-vision" twin is GPU-resident (it
+	// exists to encode images fast), every other profile keeps it in RAM (vision
+	// is the exception there, and the text side must not pay for it). The Default
+	// tab's mmproj override sets the former, the "vision" variant's the latter.
 	MmprojPin string
 	// TensorSplit is the resolved per-device layer ratio for a multi-GPU plan,
 	// one entry per eligible device in Index order, or nil for a single-GPU box
@@ -90,10 +97,11 @@ type profile struct {
 	// -1 when there is nothing to pin (single GPU / no telemetry).
 	MainGpu int
 	// CpuMmproj emits --no-mmproj-offload: the CLIP projector runs on the CPU, so
-	// it costs no VRAM and the twin keeps the ctx/layer placement it would have
-	// had without vision, at the price of a slow (host-side) image encode. Set by
-	// the sizer only when the GPU-resident projector actually costs placement or
-	// a quarter of the context window (see cpuMmprojWins).
+	// it costs no VRAM and the profile keeps the ctx/layer placement it would
+	// have had without vision, at the price of a slow (host-side) image encode.
+	// That trade is why it is the default everywhere except the "-vision" twin:
+	// the encode is a one-off per image, while VRAM spent on a projector is paid
+	// by every token of every request, image or not.
 	CpuMmproj bool
 }
 
@@ -400,14 +408,42 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 		mmprojFile = inheritStr(v.MmprojFile, mmprojFile)
 	}
 	mmprojPath, mmprojSizeGB := mmprojFor(row, mmprojFile)
-	if mmprojPath != "" && !strings.EqualFold(override.Mmproj, "none") {
+	modelPin := strings.ToLower(strings.TrimSpace(override.Mmproj))
+	if mmprojPath != "" && modelPin != "none" {
 		mmprojOh := MmprojVramGB(mmprojPath, mmprojSizeGB, s)
+		// Every OTHER profile of this model loads the projector too, in RAM
+		// (--no-mmproj-offload). A projector on the CPU costs no VRAM and so
+		// changes neither the context window nor the layer placement these
+		// profiles would have had without it — the only cost is a one-off encode
+		// per image, on the requests that actually carry one. That makes "wire it
+		// everywhere" strictly better than the alternative, which was a default id
+		// that 500s on an image for the life of the process. The Default tab's
+		// mmproj pin overrides the placement ("gpu" to pay VRAM for a fast encode
+		// here too); "none" above opts the model out of vision entirely.
+		defPin := modelPin
+		if defPin == "" {
+			defPin = "ram"
+		}
+		for i := range profiles {
+			p := &profiles[i]
+			p.Vision = true
+			p.MmprojPin = defPin
+			if defPin == "ram" {
+				p.CpuMmproj = true
+			} else {
+				p.MmprojGB = mmprojOh
+				p.Overhead += mmprojOh
+			}
+		}
+		// The twin is the id that pays VRAM for the projector, so its default is
+		// the opposite: GPU-resident, for an image encode an order of magnitude
+		// faster than the host-side one. The reserved "vision" variant re-pins it.
 		vp := profile{
 			Name:              fmt.Sprintf("%s-vision", name),
 			Target:            soloTarget,
 			Overhead:          s.VramOverheadGB + specOh + mmprojOh,
 			MmprojGB:          mmprojOh,
-			MmprojPin:         strings.ToLower(strings.TrimSpace(override.Mmproj)),
+			MmprojPin:         "gpu",
 			Ctx:               override.Ctx,
 			CheckpointMinStep: override.CheckpointMinStep,
 			Vision:            true,
@@ -448,17 +484,19 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 				vp.CheckpointMinStep = v.CheckpointMinStep
 			}
 			vp.Variant = v
-			// The vision variant IS the twin, so its pin outranks the model-wide
-			// one; blank keeps whatever Default set.
+			// The vision variant IS the twin, so it is the only thing that repins
+			// the twin's projector; blank keeps the GPU default above. The Default
+			// tab's pin governs the other profiles and never reaches here.
 			if p := strings.ToLower(strings.TrimSpace(v.Mmproj)); p != "" {
 				vp.MmprojPin = p
 			}
 		}
-		// A "ram" pin is applied here rather than in the sizing loop so the
-		// variant re-charge above (which rebuilds Overhead from scratch for a
-		// vision variant with its own spec) can't hand the projector back.
+		// A "ram" pin is applied here rather than at construction so the variant
+		// re-charge above (which rebuilds Overhead from scratch for a vision
+		// variant with its own spec) can't hand the projector back.
 		if vp.MmprojPin == "ram" {
 			vp.Overhead -= mmprojOh
+			vp.MmprojGB = 0
 			vp.CpuMmproj = true
 		}
 		// "none" from the vision variant lands here rather than at the gate above,
@@ -573,24 +611,6 @@ func emitModel(b *strings.Builder, s Settings, gf GenerateFile, row GgufRow, ov 
 		ctx, plan, kvReserve, planCkptGB, err := sizeProfile(meta, s, prof, ptg, kcg, pModelMax, pkvInRam)
 		if err != nil {
 			return err
-		}
-		// A "-vision" twin holds the CLIP projector in VRAM by default, and the
-		// sizer pays for it out of the same budget as the text model: fewer GPU
-		// layers, or a smaller window. llama-server's --no-mmproj-offload moves the
-		// projector to the CPU, which costs image-encode latency ONCE per image but
-		// nothing per token. So price the twin both ways and keep the projector on
-		// the GPU only while it is affordable — the fallback is what lets any model
-		// with a compatible projector carry a vision twin without the text side
-		// paying for it.
-		if prof.Vision && prof.MmprojGB > 0 && prof.MmprojPin == "" {
-			cpuProf := prof
-			cpuProf.Overhead -= prof.MmprojGB
-			cpuProf.CpuMmproj = true
-			cCtx, cPlan, cKvReserve, cCkptGB, cErr := sizeProfile(meta, s, cpuProf, ptg, kcg, pModelMax, pkvInRam)
-			if cErr == nil && cpuMmprojWins(plan, ctx, cPlan, cCtx) {
-				prof = cpuProf
-				ctx, plan, kvReserve, planCkptGB = cCtx, cPlan, cKvReserve, cCkptGB
-			}
 		}
 		ngl, ncpuMoe := forceLowActiveMoE(meta, plan, prof, kvReserve)
 		if prof.CpuOffload > 0 {

--- a/internal/autogen/generate_sizing.go
+++ b/internal/autogen/generate_sizing.go
@@ -548,36 +548,6 @@ func MmprojVramGB(mmprojPath string, fileSizeGB float64, s Settings) float64 {
 	return fileSizeGB + buf
 }
 
-// cpuMmprojGainCtx is the share of the projector-free context window a vision
-// twin must keep before the projector is worth its VRAM. Below it, the CLIP
-// buffer has eaten a quarter of the window and the CPU encode is the better
-// trade — a one-off cost per image against a window that shrinks every request.
-const cpuMmprojGainCtx = 0.75
-
-// cpuMmprojWins compares a vision twin sized with the CLIP projector resident in
-// VRAM against the same twin sized with it on the CPU (--no-mmproj-offload), and
-// reports whether the CPU placement is the better deal.
-//
-// Two things make it better, in order of weight:
-//
-//  1. PLACEMENT. The projector displaced text layers onto the CPU (a lower -ngl,
-//     or more --n-cpu-moe experts). That tax is paid on every token of every
-//     request, image or not, so trading it for a slower image encode is always
-//     right.
-//  2. WINDOW. Placement is unchanged but the projector cost more than a quarter
-//     of the context window it could otherwise have had.
-//
-// Neither firing means the projector fits in the slack and belongs on the GPU,
-// where the image encode is an order of magnitude faster.
-func cpuMmprojWins(gpuPlan LoadPlan, gpuCtx int, cpuPlan LoadPlan, cpuCtx int) bool {
-	if cpuPlan.Ngl > gpuPlan.Ngl || cpuPlan.NCpuMoe < gpuPlan.NCpuMoe {
-		return true
-	}
-	// Only ever move the projector for a window the GPU placement cannot match;
-	// an equal (or larger) window means the projector was free.
-	return cpuCtx > gpuCtx && float64(gpuCtx) < cpuMmprojGainCtx*float64(cpuCtx)
-}
-
 // mtpDraftPadGB is what is left of a baked-in MTP drafter's footprint once the
 // two modeled parts are taken out: its KV is ctx-scaled by mtpDraftSlopeGB and
 // carried in profile.DraftSlopeGB, its compute graph is modeled from the gguf

--- a/internal/autogen/hash.go
+++ b/internal/autogen/hash.go
@@ -187,7 +187,7 @@ const hashCacheSuffix = ".modelhash"
 //	     for that one sample used to bake a single-device plan that spawn time
 //	     could not repair, since the live retune rewrites an existing
 //	     --tensor-split and cannot add one.
-const genVersion = "v65"
+const genVersion = "v66"
 
 // InputsHash digests everything that can change the generated config: the set of
 // gguf files under modelsRoot (path + size + mtime) plus the raw bytes of the

--- a/internal/autogen/mmprojfile_test.go
+++ b/internal/autogen/mmprojfile_test.go
@@ -136,7 +136,9 @@ func TestAutogen_Generate_MmprojFileCreatesTwin(t *testing.T) {
 	if got, want := twins(set), twins(base)+1; got != want {
 		t.Errorf("explicit mmprojFile: %d vision twins, want %d (the override must create one)", got, want)
 	}
-	if got, want := strings.Count(set, flag), strings.Count(base, flag)+1; got != want {
+	// The projector lands on EVERY profile of the target, not just the twin, so
+	// the delta is the target's whole block count rather than a flat +1.
+	if got, want := strings.Count(set, flag), strings.Count(base, flag)+len(blocksFor(set, target.FullPath)); got != want {
 		t.Errorf("explicit mmprojFile: %d uses of %q, want %d", got, flag, want)
 	}
 
@@ -198,10 +200,13 @@ func TestAutogen_Generate_MmprojFileBeatsDirLocal(t *testing.T) {
 	base := gen()
 	out := gen(Override{Match: "*" + filepath.Base(withProj.FullPath), MmprojFile: other})
 
-	if got, want := strings.Count(out, otherFlag), strings.Count(base, otherFlag)+1; got != want {
+	// Every profile of the target carries a projector, so the swap moves n uses
+	// at once, where n is how many blocks that gguf emits.
+	n := len(blocksFor(out, withProj.FullPath))
+	if got, want := strings.Count(out, otherFlag), strings.Count(base, otherFlag)+n; got != want {
 		t.Errorf("explicit %q: %d uses, want %d", other, got, want)
 	}
-	if got, want := strings.Count(out, localFlag), strings.Count(base, localFlag)-1; got != want {
+	if got, want := strings.Count(out, localFlag), strings.Count(base, localFlag)-n; got != want {
 		t.Errorf("dir-local %q: %d uses, want %d (the override must replace it)", withProj.MmprojPath, got, want)
 	}
 }

--- a/internal/autogen/overrides.go
+++ b/internal/autogen/overrides.go
@@ -510,18 +510,21 @@ type Override struct {
 	// sizer. 0 => auto. MoE models offload expert layers (--n-cpu-moe N); dense
 	// models drop GPU layers (-ngl = blocks-N).
 	CpuOffload int `yaml:"cpuOffload"`
-	// Mmproj places the CLIP image projector behind the auto-generated "-vision"
-	// twin. Only meaningful for a model that has a projector (own or inherited):
+	// Mmproj places the CLIP image projector on this model's DEFAULT profile and
+	// its ctx tiers / named variants (the "-vision" twin has its own pin, on the
+	// reserved vision variant). Only meaningful for a model that has a projector
+	// (own or inherited):
 	//
-	//	""     auto - sized both ways, GPU while it costs neither layer placement
-	//	       nor a quarter of the context window (see cpuMmprojWins)
-	//	"gpu"  pin the projector in VRAM: fastest image encode, and the twin pays
-	//	       for it in ctx/offload
-	//	"ram"  pin it in RAM (--no-mmproj-offload): free VRAM, slow image encode
-	//	"none" emit no vision twin at all
+	//	""     RAM (--no-mmproj-offload): images work everywhere at no VRAM cost,
+	//	       paid as a one-off host-side encode per image
+	//	"ram"  the same, said out loud
+	//	"gpu"  pin the projector in VRAM here too: fastest image encode, and every
+	//	       profile pays for it in ctx/offload on every request, image or not
+	//	"none" wire no projector at all - no image input, and no vision twin
 	//
-	// "none" is not the same as marking the twin unlisted: unlisted still builds
-	// and can still be loaded by id, this removes the profile.
+	// Note "none" is the only value that removes the twin, and it is not the same
+	// as marking the twin unlisted: unlisted still builds and can still be loaded
+	// by id, this removes the profile.
 	Mmproj string `yaml:"mmproj"`
 	// Engine knobs surfaced from llama-server. Zero/empty => the generator's
 	// default (shown in parentheses):

--- a/internal/autogen/vision_test.go
+++ b/internal/autogen/vision_test.go
@@ -2,6 +2,7 @@ package autogen
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -31,36 +32,105 @@ func TestClipComputeBufferGB(t *testing.T) {
 	}
 }
 
-// The vision twin's projector is only worth its VRAM while it costs neither
-// layer placement nor a meaningful slice of the context window; otherwise the
-// sizer parks the CLIP tower on the CPU (--no-mmproj-offload).
-func TestCpuMmprojWins(t *testing.T) {
-	full := LoadPlan{Ngl: 99}
-	spilled := LoadPlan{Ngl: 60}
-	moeFull := LoadPlan{Ngl: 99, NCpuMoe: 0}
-	moeSpilled := LoadPlan{Ngl: 99, NCpuMoe: 12}
-
-	tests := []struct {
-		name             string
-		gpuPlan, cpuPlan LoadPlan
-		gpuCtx, cpuCtx   int
-		want             bool
-	}{
-		// Placement: the projector pushed dense layers / MoE experts off the GPU.
-		// That tax is per token, so the CPU encode always wins — even at equal ctx.
-		{"dense layers displaced", spilled, full, 32768, 32768, true},
-		{"moe experts displaced", moeSpilled, moeFull, 32768, 32768, true},
-		// Window: same placement, but the projector ate more than a quarter of it.
-		{"window halved", full, full, 16384, 32768, true},
-		{"window barely dented", full, full, 28672, 32768, false},
-		// The projector fit in the slack — keep the fast GPU encode.
-		{"projector free", full, full, 32768, 32768, false},
+// A served id that cannot take an image is a trap: llama-server loads the CLIP
+// projector at spawn and nowhere else, so a process launched without --mmproj
+// answers every image with "image input is not supported" until it is evicted.
+// Every profile of a model that HAS a projector therefore loads one. Placement
+// is what differs: the default and its tiers keep it in RAM, where it costs no
+// VRAM and so cannot shrink the window or push layers off the GPU, while the
+// "-vision" twin pays for GPU residency to encode fast.
+func TestAutogen_Generate_ProjectorOnEveryProfile(t *testing.T) {
+	if _, err := os.Stat(realModelsRoot); err != nil {
+		t.Skipf("models root %s absent", realModelsRoot)
 	}
-	for _, tc := range tests {
-		if got := cpuMmprojWins(tc.gpuPlan, tc.gpuCtx, tc.cpuPlan, tc.cpuCtx); got != tc.want {
-			t.Errorf("%s: cpuMmprojWins = %v, want %v", tc.name, got, tc.want)
+	target := firstModelWithProjector(t)
+
+	gen := func(ov Override) map[string]string {
+		t.Helper()
+		ov.Match = "*" + filepath.Base(target.FullPath)
+		gf := GenerateFile{
+			Settings:  Settings{ModelsRoot: realModelsRoot},
+			Overrides: []Override{ov},
+		}
+		gf.Settings.applyDefaults()
+		out, err := Generate(gf, "T")
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		// Keep only the blocks launching THIS gguf; every other model in the
+		// tree is untouched by the override.
+		got := blocksFor(out, target.FullPath)
+		if len(got) == 0 {
+			t.Fatalf("no emitted block loads %s", target.FullPath)
+		}
+		return got
+	}
+
+	proj := "--mmproj " + strings.ReplaceAll(target.MmprojPath, "\\", "/")
+	blocks := gen(Override{})
+	twins := 0
+	for id, cmd := range blocks {
+		if !strings.Contains(cmd, proj) {
+			t.Errorf("%s: no %q - this id 500s on every image", id, proj)
+			continue
+		}
+		onCPU := strings.Contains(cmd, "--no-mmproj-offload")
+		if isTwin := strings.HasSuffix(id, "-vision"); isTwin {
+			twins++
+			if onCPU {
+				t.Errorf("%s: the vision twin exists to hold the projector in VRAM, got --no-mmproj-offload", id)
+			}
+		} else if !onCPU {
+			t.Errorf("%s: default/tier profiles must keep the projector in RAM, got no --no-mmproj-offload", id)
 		}
 	}
+	if twins != 1 {
+		t.Errorf("got %d vision twins, want exactly 1", twins)
+	}
+
+	// The Default tab's pin buys VRAM residency for the non-twin profiles; it
+	// never reaches the twin, which is already GPU-resident.
+	for id, cmd := range gen(Override{Mmproj: "gpu"}) {
+		if strings.Contains(cmd, "--no-mmproj-offload") {
+			t.Errorf("%s: mmproj=gpu must pin the projector in VRAM everywhere", id)
+		}
+	}
+	// "none" opts the model out of vision entirely - no projector, no twin.
+	for id, cmd := range gen(Override{Mmproj: "none"}) {
+		if strings.Contains(cmd, "--mmproj") {
+			t.Errorf("%s: mmproj=none must emit no projector", id)
+		}
+		if strings.HasSuffix(id, "-vision") {
+			t.Errorf("mmproj=none still emitted the twin %s", id)
+		}
+	}
+}
+
+// blocksFor keeps the emitted blocks that launch one gguf. The path is its own
+// folded cmd line, so the match ends at the newline: "-m <path>" is a prefix of
+// nothing else, but a bare Contains would also hit a longer sibling path.
+func blocksFor(out, ggufPath string) map[string]string {
+	want := "-m " + strings.ReplaceAll(ggufPath, "\\", "/") + "\n"
+	got := map[string]string{}
+	for id, cmd := range modelBlocks(out) {
+		if strings.Contains(cmd, want) {
+			got[id] = cmd
+		}
+	}
+	return got
+}
+
+// modelBlocks splits a generated config into served id -> cmd text.
+func modelBlocks(out string) map[string]string {
+	blocks := map[string]string{}
+	for _, chunk := range strings.Split(out, "\n  \"")[1:] {
+		id, rest, ok := strings.Cut(chunk, "\":\n")
+		if !ok {
+			continue
+		}
+		blocks[id] = rest
+	}
+	return blocks
 }
 
 // The spawn-time guard must agree with the baked plan: an argv carrying
@@ -116,19 +186,21 @@ func TestAutogen_Generate_MmprojPin(t *testing.T) {
 	}
 }
 
-// The reserved "vision" variant is the only variant whose profile carries a
-// projector, so its pin has to beat the model-wide one - including "none",
-// which is checked past the twin-construction gate.
+// Two pins, two audiences: the model-wide one (the config modal's Default tab)
+// places the projector on the default profile and its tiers, the reserved
+// "vision" variant places it on the twin. Neither reaches the other's profiles,
+// so a variant "none" drops the twin while the text ids keep image input.
 func TestAutogen_Generate_MmprojPin_VisionVariant(t *testing.T) {
 	if _, err := os.Stat(realModelsRoot); err != nil {
 		t.Skipf("models root %s absent", realModelsRoot)
 	}
-	gen := func(model, variant string) string {
+	target := firstModelWithProjector(t)
+	gen := func(model, variant string) (twin string, others map[string]string) {
 		t.Helper()
 		gf := GenerateFile{
 			Settings: Settings{ModelsRoot: realModelsRoot},
 			Overrides: []Override{{
-				Match:    "*",
+				Match:    "*" + filepath.Base(target.FullPath),
 				Mmproj:   model,
 				Variants: []VariantSpec{{Name: "vision", Mmproj: variant}},
 			}},
@@ -138,22 +210,72 @@ func TestAutogen_Generate_MmprojPin_VisionVariant(t *testing.T) {
 		if err != nil {
 			t.Fatalf("generate(%q/%q): %v", model, variant, err)
 		}
-		return out
+		others = map[string]string{}
+		for id, cmd := range blocksFor(out, target.FullPath) {
+			if strings.HasSuffix(id, "-vision") {
+				twin = cmd
+				continue
+			}
+			others[id] = cmd
+		}
+		if len(others) == 0 {
+			t.Fatalf("generate(%q/%q): no non-twin block for %s", model, variant, target.FullPath)
+		}
+		return twin, others
 	}
 
-	if auto := gen("", ""); !strings.Contains(auto, "-vision\":") {
-		t.Skip("no model in the tree ships an mmproj; nothing to pin")
+	// Model "gpu" + variant "ram": exactly inverted from the defaults.
+	twin, others := gen("gpu", "ram")
+	if !strings.Contains(twin, "--no-mmproj-offload") {
+		t.Error(`variant "ram": expected the twin's projector in RAM`)
 	}
-	if got := gen("gpu", "ram"); !strings.Contains(got, "--no-mmproj-offload") {
-		t.Error(`variant "ram" over model "gpu": expected --no-mmproj-offload`)
+	for id, cmd := range others {
+		if strings.Contains(cmd, "--no-mmproj-offload") {
+			t.Errorf(`%s: model pin "gpu" must hold the projector in VRAM`, id)
+		}
 	}
-	if got := gen("ram", "gpu"); strings.Contains(got, "--no-mmproj-offload") {
-		t.Error(`variant "gpu" over model "ram": expected the projector back in VRAM`)
+
+	twin, others = gen("ram", "gpu")
+	if strings.Contains(twin, "--no-mmproj-offload") {
+		t.Error(`variant "gpu": expected the twin's projector back in VRAM`)
 	}
-	// Checked on the flag, not the id: an image-class model treats a variant
-	// named "vision" as an ordinary image variant, so "<name>-vision" still
-	// appears for those - but only a llama twin ever emits --mmproj.
-	if got := gen("", "none"); strings.Contains(got, "--mmproj ") {
-		t.Error(`variant "none": expected no projector loaded anywhere`)
+	for id, cmd := range others {
+		if !strings.Contains(cmd, "--no-mmproj-offload") {
+			t.Errorf(`%s: model pin "ram" must keep the projector off the GPU`, id)
+		}
 	}
+
+	// A variant "none" is checked past the twin-construction gate, so it drops
+	// the twin - and only the twin. The text ids still take images.
+	twin, others = gen("", "none")
+	if twin != "" {
+		t.Error(`variant "none": expected no vision twin`)
+	}
+	for id, cmd := range others {
+		if !strings.Contains(cmd, "--mmproj ") {
+			t.Errorf(`%s: variant "none" must not disarm the other profiles`, id)
+		}
+	}
+}
+
+// firstModelWithProjector picks an ordinary text LLM that discovery paired with
+// a CLIP projector, skipping the image and SAM classes that never grow a twin.
+func firstModelWithProjector(t *testing.T) GgufRow {
+	t.Helper()
+	rows, err := DiscoverGgufModelsMulti([]string{realModelsRoot})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	for _, r := range rows {
+		if r.MmprojPath == "" || r.IsSam {
+			continue
+		}
+		meta, err := ReadGgufMetadataCached(r.FullPath)
+		if err != nil || meta.BlockCount == 0 || meta.Architecture == "clip" || isImageArch(meta.Architecture) {
+			continue
+		}
+		return r
+	}
+	t.Skip("no text model with a paired projector in the tree")
+	return GgufRow{}
 }

--- a/ui-svelte/src/components/ModelConfigModal.svelte
+++ b/ui-svelte/src/components/ModelConfigModal.svelte
@@ -112,7 +112,9 @@
   let cpuAuto = $state(true);
   let globalTargetGB = $state(0); // global VRAM budget; slider ceiling for vramTarget
   let spec = $state("");
-  // Vision-twin projector placement: "" auto | "gpu" | "ram" | "none".
+  // Projector placement for this model's TEXT ids (default + ctx tiers + named
+  // variants): "" / "ram" = host RAM, "gpu" = VRAM, "none" = no image input at
+  // all. The -vision twin has its own pin on the reserved vision variant.
   let mmprojMode = $state("");
   // Boolean toggles. Stored as strings on the override ("" = default-on, "off" =
   // forced off); surfaced here as plain on/off checkboxes (auto state dropped).
@@ -756,16 +758,18 @@
     { value: "on", label: "on" },
     { value: "off", label: "off" },
   ];
+  // Default tab: where the projector sits on the text ids (default + ctx tiers
+  // + named variants). Blank IS "ram", so the two share an entry - a stored
+  // "ram" normalises to "" on load.
   const MMPROJ_SEL: SelectOption[] = [
-    { value: "", label: "auto (sizer decides)" },
-    { value: "gpu", label: "on GPU (fast images)" },
-    { value: "ram", label: "in RAM (slow images, no VRAM)" },
-    { value: "none", label: "none (no vision twin)" },
+    { value: "", label: "in RAM (default, no VRAM cost)" },
+    { value: "gpu", label: "on GPU (fast images, costs VRAM)" },
+    { value: "none", label: "none (no image input)" },
   ];
-  // The variant copy inherits rather than autos: blank on the vision tab keeps
-  // whatever Default picked, so an untouched variant emits the same twin.
+  // The vision tab places the TWIN's projector, and only the twin's. Blank is
+  // the twin's own default (VRAM), not the Default tab's pick.
   const MMPROJ_SEL_INHERIT: SelectOption[] = [
-    { value: "", label: "inherit (Default's pick)" },
+    { value: "", label: "on GPU (twin default)" },
     { value: "gpu", label: "on GPU (fast images)" },
     { value: "ram", label: "in RAM (slow images, no VRAM)" },
     { value: "none", label: "none (no vision twin)" },
@@ -881,7 +885,8 @@
     cpuAuto = !o?.cpuOffload;
     cpuOffload = o?.cpuOffload || 0;
     spec = o?.spec ?? "";
-    mmprojMode = o?.mmproj ?? "";
+    // "ram" and blank are the same placement; collapse so the select matches.
+    mmprojMode = (o?.mmproj ?? "") === "ram" ? "" : (o?.mmproj ?? "");
     backend = o?.backend ?? "";
     vllmGpuUtil = o?.vllmGpuUtil ? o.vllmGpuUtil : "";
     vllmTensorParallel = o?.vllmTensorParallel ? o.vllmTensorParallel : "";
@@ -2304,7 +2309,7 @@
             <label class="flex flex-col gap-1 text-sm">
               <span class="text-txtsecondary flex items-center gap-1">
                 Image projector
-                {@render hint("Where the vision twin's CLIP projector lives. Auto keeps it on the GPU while it costs neither GPU layers nor a quarter of the context window, and moves it to RAM otherwise. On GPU pins it there — fastest image encode, paid for in context/offload on every request. In RAM (--no-mmproj-offload) frees that VRAM and encodes images on the CPU instead: seconds per image, but token speed is untouched. None emits no vision twin at all.")}
+                {@render hint("Where this model's CLIP projector lives on its normal ids (default, context tiers, named variants) - every one of them loads it, so any of them takes images. In RAM (--no-mmproj-offload) is the default: no VRAM at all, so the context window and layer placement are exactly what they would be without images, paid for by a one-off CPU encode of each image sent. On GPU pins it in VRAM here too: fastest encode, and every request pays for it in context/offload whether it carries an image or not. None wires no projector anywhere and drops the vision twin. The twin is pinned separately, on its own tab.")}
                 {@render borrowedMmproj()}
               </span>
               <Select bind:value={mmprojMode} options={MMPROJ_SEL} ariaLabel="Image projector placement" />
@@ -2727,7 +2732,7 @@
               <label class="flex flex-col gap-1 text-sm col-span-2">
                 <span class="text-txtsecondary flex items-center gap-1">
                   Image projector
-                  {@render hint("Where this twin's CLIP projector lives. Inherit uses the Default tab's pick (auto = on the GPU while it costs neither GPU layers nor a quarter of the context window). On GPU pins it there - fastest image encode, paid for in context/offload on every request. In RAM (--no-mmproj-offload) frees that VRAM and encodes on the CPU: seconds per image, token speed untouched. None emits no vision twin at all.")}
+                  {@render hint("Where THIS twin's CLIP projector lives, and only this twin's: the Default tab pins the other ids. Blank keeps the twin on the GPU, which is what it exists for - the fastest image encode, paid for in context/offload on every request. In RAM (--no-mmproj-offload) frees that VRAM and encodes on the CPU: seconds per image, token speed untouched. None drops the twin; the other ids keep taking images.")}
                 </span>
                 <Select bind:value={sv.mmproj} options={MMPROJ_SEL_INHERIT} ariaLabel="Image projector placement" />
               </label>


### PR DESCRIPTION
A served id launched without `--mmproj` answers every image with "image input is not supported" for the life of the process: llama-server reads the projector at spawn and nowhere else, and the router never inspects a request body, so the id the caller names decides the argv. Only the `-vision` twin carried the flag, which made the default id of a vision-capable model a trap. Worse, the Default tab's "Image projector" dropdown reads like it puts a projector on the default profile; it only ever tuned the twin's placement.

Every profile of a model that resolves to a projector now loads one. The default, its context tiers and its named variants keep it in RAM (`--no-mmproj-offload`): no VRAM, so the window and the layer placement are exactly what they would have been without it, at the cost of a one-off host-side encode per image actually sent. The twin still pays for GPU residency, which is what it is for.

- `Override.Mmproj` places the projector on the text ids: blank/`ram` in RAM, `gpu` in VRAM there too, `none` opts the model out of vision entirely
- `VariantSpec.Mmproj` on the reserved `vision` variant places the twin's, and is the only thing that does; `none` there drops the twin alone
- drop `cpuMmprojWins` and the twin's dual sizing, unreachable under explicit defaults
- `genVersion` v65 -> v66; the emitted YAML changes for identical inputs
- config modal copy follows the split; a stored `ram` normalises to blank on the Default tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
