### PR TITLE
ui: measure "System" VRAM live instead of from a stale idle floor

### DIFF
--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -213,6 +213,16 @@ export interface PerformanceResponse {
   // Idle system-VRAM floor (MiB) sampled server-side (min used while no model
   // running). 0 = not observed yet. Preferred over the browser-only baseline.
   system_mb?: number;
+  // The OOM guard's live view: foreign_mb is VRAM held by everything that is NOT
+  // one of our children, measured per-process on EVERY sample (unlike system_mb,
+  // which freezes for as long as a model is resident). null/absent = no
+  // trustworthy per-process attribution, or a server too old to send it.
+  guard?: {
+    foreign_mb: number;
+    floor_mb: number;
+    total_mb: number;
+    ceiling_gb?: number;
+  } | null;
 }
 
 export interface APIEventEnvelope {

--- a/ui-svelte/src/stores/perf.ts
+++ b/ui-svelte/src/stores/perf.ts
@@ -42,6 +42,17 @@ export const foreignVram = writable<{ mb: number; procs?: { pid: number; name: s
 // observed. The VRAM gauge prefers this over its own browser-only baseline.
 export const systemVram = writable<number>(0);
 
+// GPU memory (MiB) held by everything that is NOT one of our children, measured
+// per-process on every server sample and published by the OOM guard. This is the
+// LIVE answer to "what are the OS and other apps using", where systemVram above
+// is only a floor sampled while no model was loaded - it freezes for as long as a
+// model stays resident, so a game or a Blender/Unity session opened afterwards
+// never moves it and its VRAM leaks into the gauge's model slice (and from there
+// into the "Overhead" residual). null = the guard has no trustworthy reading (no
+// per-process source, or one of our children not yet visible to it), which is the
+// gauge's cue to fall back to the idle floor.
+export const guardForeignVram = writable<number | null>(null);
+
 let timer: ReturnType<typeof setInterval> | null = null;
 let lastTs: string | undefined;
 
@@ -54,6 +65,9 @@ export function startPerfPolling(intervalMs = 2000): () => void {
     // reading"; vramTotals falls back to the single device for either.
     pooledVram.set(data.gpu_pooled ?? null);
     if (typeof data.system_mb === "number") systemVram.set(data.system_mb);
+    guardForeignVram.set(
+      typeof data.guard?.foreign_mb === "number" ? data.guard.foreign_mb : null,
+    );
     if (data.gpu_stats?.length) {
       const g = data.gpu_stats[data.gpu_stats.length - 1];
       latestGpu.set(g);

--- a/ui-svelte/src/stores/vram.test.ts
+++ b/ui-svelte/src/stores/vram.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { loadedSegments } from "./vram";
+import { loadedSegments, systemFloorMb, systemDetail } from "./vram";
 import type { PlanEstimate } from "./api";
 
 // A plausible estimate: 10 GB total = 6 weights + 2 KV + 0.5 draft + 0.5
@@ -57,5 +57,64 @@ describe("loadedSegments", () => {
   it("gives up when any loaded model has no estimate", () => {
     expect(loadedSegments([{ id: "a" }, { id: "b" }], { a: est() }, 15 * 1024)).toBeNull();
     expect(loadedSegments([], {}, 0)).toBeNull();
+  });
+});
+
+describe("systemFloorMb", () => {
+  const base = {
+    usedMb: 20 * 1024,
+    strayForeignMb: 0,
+    guardForeignMb: null as number | null,
+    serverIdleMb: 0,
+    browserBaselineMb: null as number | null,
+    estTotalMb: null as number | null,
+  };
+
+  // The bug: the idle floor is sampled only while nothing is loaded, so an app
+  // that claims VRAM after a model went resident (a game, Blender, Unity) never
+  // moved it. Its 6 GB was counted as model usage and surfaced as "Overhead".
+  it("prefers the live per-process reading over a stale idle floor", () => {
+    const { mb, source } = systemFloorMb({
+      ...base,
+      guardForeignMb: 7 * 1024, // desktop 0.9 GB at sample time + 6 GB since
+      serverIdleMb: 0.9 * 1024,
+    });
+    expect(mb).toBe(7 * 1024);
+    expect(source).toBe("live");
+    expect(systemDetail(source)).toContain("live");
+  });
+
+  // The stray llama-server already has its own red segment; counting it in
+  // System as well would draw the same VRAM twice.
+  it("subtracts the stray-inference slice from the live reading", () => {
+    const { mb } = systemFloorMb({
+      ...base,
+      usedMb: 18 * 1024, // stray already carved out by the caller
+      guardForeignMb: 5 * 1024,
+      strayForeignMb: 2 * 1024,
+    });
+    expect(mb).toBe(3 * 1024);
+  });
+
+  it("falls back to the server idle floor, then the tab baseline, then the estimate", () => {
+    expect(systemFloorMb({ ...base, serverIdleMb: 2048, browserBaselineMb: 4096 })).toEqual({
+      mb: 2048,
+      source: "idle",
+    });
+    expect(systemFloorMb({ ...base, browserBaselineMb: 4096 })).toEqual({
+      mb: 4096,
+      source: "baseline",
+    });
+    expect(systemFloorMb({ ...base, estTotalMb: 12 * 1024 })).toEqual({
+      mb: 8 * 1024,
+      source: "estimate",
+    });
+    // Nothing to go on: attribute it all to System rather than invent a model slice.
+    expect(systemFloorMb(base)).toEqual({ mb: 20 * 1024, source: "unknown" });
+  });
+
+  it("clamps to the used total and to zero", () => {
+    expect(systemFloorMb({ ...base, guardForeignMb: 99 * 1024 }).mb).toBe(20 * 1024);
+    expect(systemFloorMb({ ...base, guardForeignMb: 100, strayForeignMb: 900 }).mb).toBe(0);
   });
 });

--- a/ui-svelte/src/stores/vram.ts
+++ b/ui-svelte/src/stores/vram.ts
@@ -1,12 +1,16 @@
 import { derived, writable } from "svelte/store";
-import { vramTotals, foreignVram, systemVram } from "./perf";
+import { vramTotals, foreignVram, systemVram, guardForeignVram } from "./perf";
 import { models, estimatePlan, type PlanEstimate } from "./api";
 
-// VRAM split: "system" (OS + other apps + game) vs the loaded llama-server. We
-// can't query per-process VRAM portably, so we sample an idle baseline: whenever
-// no model is loaded, the live used VRAM IS the system floor. Once a model loads,
-// model usage ≈ live used − baseline. Before the first idle sample the baseline
-// is unknown, so everything is attributed to system (safe under-report).
+// VRAM split: "system" (OS + other apps + game) vs the loaded llama-server.
+// Where per-process attribution exists (nvidia-smi, or the Windows PDH counter on
+// AMD/Intel) the server measures the split directly and the gauge just uses it -
+// see systemFloorMb. Where it does not, we fall back to sampling an idle
+// baseline: whenever no model is loaded, the live used VRAM IS the system floor,
+// and once a model loads model usage ≈ live used − baseline. That fallback goes
+// stale the moment another app claims VRAM while a model is resident, which is
+// why it is the fallback and not the primary. Before the first idle sample the
+// baseline is unknown, so everything is attributed to system (safe under-report).
 //
 // Whenever we hold a load-plan estimate for EVERY loaded model we further break
 // their slice into model weights / KV cache / runtime overhead (the estimate is
@@ -184,6 +188,68 @@ export function loadedSegments(
   return segments;
 }
 
+/** Where the "System" figure came from, which decides how the hover explains it. */
+export type SystemFloorSource = "live" | "idle" | "baseline" | "estimate" | "unknown";
+
+export interface SystemFloorInput {
+  /** Used VRAM with the stray-inference slice already carved out. */
+  usedMb: number;
+  /** The stray llama-server/sd-server slice, which gets its own segment. */
+  strayForeignMb: number;
+  /** Live per-process "not ours" measurement from the OOM guard; null if untrusted. */
+  guardForeignMb: number | null;
+  /** Server-sampled idle floor; 0 = never observed a long enough idle stretch. */
+  serverIdleMb: number;
+  /** This tab's own idle baseline; null before it ever saw an idle sample. */
+  browserBaselineMb: number | null;
+  /** Summed load-plan estimate for the loaded models; null if any is missing. */
+  estTotalMb: number | null;
+}
+
+// systemFloorMb decides how much of the card belongs to the OS and other apps.
+//
+// The preference order matters, and the live reading has to come first. The idle
+// floors below it are sampled ONLY while no model is loaded, so they freeze for
+// as long as one stays resident: an app that claims VRAM afterwards (a game,
+// Blender, Unity) never moves them, and every MiB it takes is misread as model
+// usage - which then lands in the "Overhead" residual, since that segment is just
+// measured-minus-estimated. The guard's figure is a per-process attribution
+// recomputed on every sample, so it tracks those apps as they come and go.
+//
+// The guard counts stray llama-servers as foreign too, but the gauge already
+// draws those as their own red segment, so they are subtracted out rather than
+// counted twice.
+export function systemFloorMb(i: SystemFloorInput): { mb: number; source: SystemFloorSource } {
+  const clamp = (mb: number) => Math.min(Math.max(0, mb), Math.max(0, i.usedMb));
+  if (i.guardForeignMb !== null) {
+    return { mb: clamp(i.guardForeignMb - i.strayForeignMb), source: "live" };
+  }
+  if (i.serverIdleMb > 0) return { mb: clamp(i.serverIdleMb), source: "idle" };
+  if (i.browserBaselineMb !== null) return { mb: clamp(i.browserBaselineMb), source: "baseline" };
+  // No idle sample anywhere (a model was already resident at page load). Back
+  // out the model slice from its estimate so it still shows, instead of painting
+  // the whole card as System.
+  if (i.estTotalMb !== null) return { mb: clamp(i.usedMb - i.estTotalMb), source: "estimate" };
+  return { mb: clamp(i.usedMb), source: "unknown" };
+}
+
+// systemDetail is the hover text for the System segment, naming how the figure
+// was arrived at so a surprising number is debuggable from the UI alone.
+export function systemDetail(source: SystemFloorSource): string {
+  switch (source) {
+    case "live":
+      return "OS, other apps (live per-process measurement)";
+    case "idle":
+      return "OS, other apps (idle floor - apps started since a model loaded may show under Overhead)";
+    case "baseline":
+      return "OS, other apps (this tab's idle baseline)";
+    case "estimate":
+      return "OS, other apps (estimated - no idle baseline yet)";
+    default:
+      return "OS, other apps";
+  }
+}
+
 // foreignSeg builds the red "Foreign" segment for VRAM held by a llama-server
 // we didn't spawn. Returns [] when none detected.
 function foreignSeg(mb: number, procs?: { name: string }[]): VramSegment[] {
@@ -200,8 +266,8 @@ function foreignSeg(mb: number, procs?: { name: string }[]): VramSegment[] {
 }
 
 export const vramBreakdown = derived(
-  [vramTotals, models, activeEstimates, foreignVram, systemVram],
-  ([$gpu, $models, $ests, $foreign, $sysVram]): VramBreakdown | null => {
+  [vramTotals, models, activeEstimates, foreignVram, systemVram, guardForeignVram],
+  ([$gpu, $models, $ests, $foreign, $sysVram, $guardForeign]): VramBreakdown | null => {
     if (!$gpu) return null;
 
     const live = $models.filter(
@@ -240,32 +306,21 @@ export const vramBreakdown = derived(
       ? live.reduce((a, m) => a + $ests[m.id].estVramGB * 1024, 0)
       : null;
 
-    // System floor. Prefer the server-measured idle floor (sampled even with no
-    // dashboard open), then the browser's own idle baseline. If neither caught an
-    // idle sample (e.g. a model was already resident at page load) but we have
-    // load-plan estimates for everything loaded, fall back to
-    // used − estimated-model-VRAM so the model slice still shows instead of
-    // being attributed entirely to "System".
-    let sysFloor: number;
-    let measured = true;
-    if ($sysVram > 0) {
-      sysFloor = Math.min($sysVram, used);
-    } else if (baselineMb !== null) {
-      sysFloor = Math.min(baselineMb, used);
-    } else if (estTotalMb !== null) {
-      sysFloor = Math.max(0, used - estTotalMb);
-      measured = false;
-    } else {
-      sysFloor = used;
-      measured = false;
-    }
+    const { mb: sysFloor, source } = systemFloorMb({
+      usedMb: used,
+      strayForeignMb: foreignMb,
+      guardForeignMb: $guardForeign,
+      serverIdleMb: $sysVram,
+      browserBaselineMb: baselineMb,
+      estTotalMb,
+    });
     const modelMb = Math.max(0, used - sysFloor);
 
     const systemSeg: VramSegment = {
       label: "System",
       mb: sysFloor,
       class: "bg-info",
-      detail: "OS, other apps" + (measured ? "" : " (estimated - no idle baseline yet)"),
+      detail: systemDetail(source),
     };
 
     // Component split whenever every loaded model has a fresh estimate, however


### PR DESCRIPTION
The status rail's System segment came from an idle floor sampled only while zero models are running, so it freezes for as long as a model stays resident. VRAM claimed afterwards (a game, Blender, Unity) never moved it and was counted as model usage, landing in the Overhead residual. Reported: 0.9 GB System with two GPU apps open, everything else as Overhead.

The OOM guard already publishes the right number in the same `/api/performance` payload: `guard.foreign_mb`, a per-process attribution of everything that is not one of our children, recomputed every sample. The gauge now prefers it; the idle floors stay as fallbacks for when no trustworthy per-process source exists.

- `systemFloorMb`: pure, tested resolver for the live -> server idle -> tab baseline -> estimate chain
- subtracts the stray-inference slice, which already has its own red segment
- the System hover names which source the figure came from

🤖 Generated with [Claude Code](https://claude.com/claude-code)