### PR TITLE
tools: stop ParseMediaTarget test needing live DNS

### DIFF
--- a/internal/tools/youtube.go
+++ b/internal/tools/youtube.go
@@ -205,6 +205,14 @@ func ParseMediaTarget(ctx context.Context, s string) (MediaTarget, error) {
 	return MediaTarget{URL: u.String(), Site: strings.TrimPrefix(host, "www.")}, nil
 }
 
+// lookupIPAddr is the DNS seam guardMediaHost resolves through. It is a var so
+// tests can vet the guard's decisions without a working resolver: CI sandboxes
+// have no outbound DNS, and a real lookup there failed the guard for a reason
+// (no answer) that the test was not trying to exercise.
+var lookupIPAddr = func(ctx context.Context, host string) ([]net.IPAddr, error) {
+	return net.DefaultResolver.LookupIPAddr(ctx, host)
+}
+
 // guardMediaHost rejects a host that points anywhere but the public internet.
 // See the package comment: this is a front-door check because yt-dlp dials for
 // itself, so a public name that redirects to a private one still gets through.
@@ -219,7 +227,7 @@ func guardMediaHost(ctx context.Context, host string) error {
 	}
 	rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	ips, err := net.DefaultResolver.LookupIPAddr(rctx, host)
+	ips, err := lookupIPAddr(rctx, host)
 	if err != nil {
 		return fmt.Errorf("could not resolve %s", host)
 	}

--- a/internal/tools/youtube_test.go
+++ b/internal/tools/youtube_test.go
@@ -1,6 +1,9 @@
 package tools
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"strings"
 	"testing"
 )
@@ -133,6 +136,18 @@ func TestTools_FormatTranscriptOffYouTube(t *testing.T) {
 // Everything handed to yt-dlp is vetted first: the target by ParseMediaTarget,
 // the language code by a strict regex.
 func TestTools_ParseMediaTarget(t *testing.T) {
+	// Stub DNS: the guard's job under test is the decision it makes about an
+	// address, not whether this machine can reach a resolver. CI has no
+	// outbound DNS, so a real lookup rejected vimeo.com for the wrong reason.
+	restore := lookupIPAddr
+	lookupIPAddr = func(_ context.Context, host string) ([]net.IPAddr, error) {
+		if host == "vimeo.com" {
+			return []net.IPAddr{{IP: net.ParseIP("151.101.128.1")}}, nil
+		}
+		return nil, fmt.Errorf("no such host: %s", host)
+	}
+	t.Cleanup(func() { lookupIPAddr = restore })
+
 	// A bare id and every YouTube URL shape canonicalise to one watch URL, so
 	// the cache keys on it and two spellings of the same video hit once.
 	for _, in := range []string{"dQw4w9WgXcQ", "https://youtu.be/dQw4w9WgXcQ", "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=x"} {


### PR DESCRIPTION
Linux CI failed on `TestTools_ParseMediaTarget`: the SSRF guard in `guardMediaHost` resolves the host, and the runner had no outbound DNS, so `vimeo.com` was rejected for "could not resolve" rather than for anything the test asserts. It passed on the PR run for #31 and failed on the merge push, so it was already flaky rather than newly broken.

- `guardMediaHost` resolves through a `lookupIPAddr` var
- the test stubs it, so it vets the guard's decision instead of the network

🤖 Generated with [Claude Code](https://claude.com/claude-code)