### PR TITLE
slotcache: only persist KV on teardowns nobody asked for

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -32,8 +32,14 @@ type Process interface {
 	WaitReady(context.Context) error
 
 	// Stop blocks until the process has terminated. It returns nil when
-	// the process terminated as expected (exit 0)
+	// the process terminated as expected (exit 0). Equivalent to
+	// StopWithReason(StopManual, timeout).
 	Stop(timeout time.Duration) error
+
+	// StopWithReason is Stop, tagged with WHY the teardown is happening. The
+	// reason is handed to the pre-stop hook, which uses it to decide whether
+	// the shutdown is worth spending time on (see StopReason).
+	StopWithReason(reason StopReason, timeout time.Duration) error
 
 	// State returns the current state of the process
 	// Note: this is a snapshot of the state at the time of the call
@@ -62,8 +68,10 @@ type Process interface {
 	// SetPreStop installs a hook run once just before the process is torn down
 	// (by TTL, eviction, or explicit Stop), while it is still serving. Used to
 	// snapshot live state — e.g. persist the slot KV — before the upstream dies.
+	// It is passed the reason for the teardown so it can skip work that is not
+	// worth the delay (a hand-unloaded model nobody is waiting for).
 	// Call once before serving; safe for concurrent set via atomic store.
-	SetPreStop(fn func())
+	SetPreStop(fn func(StopReason))
 
 	// SetPostStart installs a hook run once each time the process becomes Ready,
 	// before any queued request is granted. Used to prime live state — e.g.
@@ -89,3 +97,27 @@ type Process interface {
 	// spawn-time offload rewrite, differs from the current config command.
 	LaunchedCmd() string
 }
+
+// StopReason says why a process is being torn down. It exists so the pre-stop
+// hook can tell a teardown the user is WAITING ON from one they will come back
+// from: persisting a multi-gigabyte slot KV is worth a few seconds when the
+// model is going to be needed again, and is pure dead time when the operator
+// just pressed Unload.
+type StopReason uint8
+
+const (
+	// StopManual is an operator-initiated unload (the Unload button / API), and
+	// the zero value, so any caller that does not care gets the conservative
+	// "somebody is watching this, don't dawdle" behaviour.
+	StopManual StopReason = iota
+	// StopTTL is the idle timer expiring on a model that was left loaded.
+	StopTTL
+	// StopEvict is an eviction to make room for a different model. The evicted
+	// model did not choose to go: whoever was using it will be back, and will
+	// pay a cold prefill for it.
+	StopEvict
+	// StopShutdown is the whole app going away.
+	StopShutdown
+	// StopConfig is a config reload dropping a model that no longer exists.
+	StopConfig
+)

--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -103,6 +103,7 @@ type runReq struct {
 }
 
 type stopReq struct {
+	reason  StopReason
 	timeout time.Duration
 	respond chan error
 }
@@ -163,7 +164,7 @@ type ProcessCommand struct {
 	// Stop (TTL idle, eviction, or explicit). Fired while still StateReady so it
 	// can reach the live upstream (e.g. save its slot KV). Atomic: set from another
 	// goroutine at startup, read by run().
-	preStop atomic.Pointer[func()]
+	preStop atomic.Pointer[func(StopReason)]
 
 	// postStart, when set, runs once each time the process reaches StateReady,
 	// before WaitReady callers are woken - so it can prime the upstream (e.g.
@@ -226,7 +227,7 @@ func (p *ProcessCommand) LaunchedCmd() string {
 }
 
 // SetPreStop installs the pre-teardown hook. See Process.SetPreStop.
-func (p *ProcessCommand) SetPreStop(fn func()) { p.preStop.Store(&fn) }
+func (p *ProcessCommand) SetPreStop(fn func(StopReason)) { p.preStop.Store(&fn) }
 
 // SetPostStart installs the post-ready hook. See Process.SetPostStart.
 func (p *ProcessCommand) SetPostStart(fn func()) { p.postStart.Store(&fn) }
@@ -410,7 +411,7 @@ func (p *ProcessCommand) run() {
 								}
 								if time.Since(time.Unix(0, p.lastUse.Load())) > ttlDuration {
 									p.proxyLogger.Infof("<%s> Unloading model, TTL of %ds reached", p.id, unloadAfter)
-									p.Stop(10 * time.Second)
+									p.StopWithReason(StopTTL, 10*time.Second)
 									return
 								}
 							}
@@ -477,7 +478,7 @@ func (p *ProcessCommand) run() {
 				// Fire the pre-stop hook while still StateReady so it can reach the
 				// live upstream (e.g. save slot KV) before we kill it.
 				if fp := p.preStop.Load(); fp != nil {
-					(*fp)()
+					(*fp)(stop.reason)
 				}
 				// Counterpart to the "starting"/"ready" pair: without this the
 				// only unload the log ever mentioned was the TTL one, so a model
@@ -879,7 +880,13 @@ func (p *ProcessCommand) WaitReady(ctx context.Context) error {
 }
 
 func (p *ProcessCommand) Stop(timeout time.Duration) error {
+	return p.StopWithReason(StopManual, timeout)
+}
+
+// StopWithReason implements Process.StopWithReason.
+func (p *ProcessCommand) StopWithReason(reason StopReason, timeout time.Duration) error {
 	req := stopReq{
+		reason:  reason,
 		timeout: timeout,
 		respond: make(chan error, 1),
 	}

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -61,7 +61,7 @@ type baseRouter struct {
 	// it newly creates for added models. Set once (before serving) via SetPreEvict
 	// /SetPostLoad/SetSpawnArgs; stored atomically since ApplyConfig reads them on
 	// the run goroutine while Set* writes from the constructing goroutine.
-	preEvictFn  atomic.Pointer[func(string)]
+	preEvictFn  atomic.Pointer[func(string, process.StopReason)]
 	postLoadFn  atomic.Pointer[func(string)]
 	spawnArgsFn atomic.Pointer[func(string, []string) ([]string, error)]
 
@@ -156,14 +156,16 @@ func (b *baseRouter) procs() map[string]process.Process { return *b.processes.Lo
 
 // SetPreEvict installs a save-before-stop hook on every managed process. The
 // process fires it (with its model ID bound) just before tearing down for ANY
-// reason — TTL idle unload, eviction, or explicit Stop — so the slot KV cache
-// can snapshot the conversation before the upstream dies. Call once before
-// serving; the process map is fixed at construction.
-func (b *baseRouter) SetPreEvict(fn func(modelID string)) {
+// reason — TTL idle unload, eviction, shutdown, or an explicit Stop — so the
+// slot KV cache can snapshot the conversation before the upstream dies. The
+// reason comes with it: the hook, not this layer, decides which teardowns are
+// worth the delay. Call once before serving; the process map is fixed at
+// construction.
+func (b *baseRouter) SetPreEvict(fn func(modelID string, reason process.StopReason)) {
 	b.preEvictFn.Store(&fn)
 	for id, p := range b.procs() {
 		id := id
-		p.SetPreStop(func() { fn(id) })
+		p.SetPreStop(func(r process.StopReason) { fn(id, r) })
 	}
 }
 
@@ -202,7 +204,7 @@ func (b *baseRouter) SetLiveVramBudget(fn LiveVramFn) { b.liveVram.set(fn) }
 func (b *baseRouter) applyHooks(id string, p process.Process) {
 	if fp := b.preEvictFn.Load(); fp != nil {
 		fn := *fp
-		p.SetPreStop(func() { fn(id) })
+		p.SetPreStop(func(r process.StopReason) { fn(id, r) })
 	}
 	if fp := b.postLoadFn.Load(); fp != nil {
 		fn := *fp
@@ -419,7 +421,9 @@ func (b *baseRouter) doSwap(modelID string, toStop []string) {
 		wg.Add(1)
 		go func(p process.Process, id string) {
 			defer wg.Done()
-			if err := p.Stop(timeout); err != nil {
+			// StopEvict, not a plain Stop: an evicted model is coming back, so
+			// the pre-stop hook snapshots its KV. A hand-pressed Unload does not.
+			if err := p.StopWithReason(process.StopEvict, timeout); err != nil {
 				b.logger.Warnf("%s: stopping %s failed: %v", b.name, id, err)
 			}
 		}(p, mID)
@@ -476,7 +480,7 @@ func (b *baseRouter) handleShutdown(req shutdownReq) {
 		wg.Add(1)
 		go func(id string, p process.Process) {
 			defer wg.Done()
-			if err := p.Stop(stopTimeout); err != nil {
+			if err := p.StopWithReason(process.StopShutdown, stopTimeout); err != nil {
 				b.logger.Warnf("%s failed to stop process %s: %v", b.name, id, err)
 			}
 		}(i, p)
@@ -679,7 +683,7 @@ func (b *baseRouter) handleApplyConfig(newCfg config.Config) error {
 				wg.Add(1)
 				go func(p process.Process) {
 					defer wg.Done()
-					if err := p.Stop(timeout); err != nil {
+					if err := p.StopWithReason(process.StopConfig, timeout); err != nil {
 						b.logger.Warnf("%s: stopping removed process failed: %v", b.name, err)
 					}
 				}(p)

--- a/internal/router/base_test.go
+++ b/internal/router/base_test.go
@@ -54,12 +54,20 @@ func TestBaseRouter_SetPreEvict(t *testing.T) {
 	b := newTestBase(t, map[string]process.Process{"a": a}, &stubPlanner{})
 
 	var got atomic.Pointer[string]
-	b.SetPreEvict(func(id string) { got.Store(&id) })
+	var gotReason atomic.Uint32
+	b.SetPreEvict(func(id string, r process.StopReason) {
+		got.Store(&id)
+		gotReason.Store(uint32(r))
+	})
 
 	b.Unload(time.Second, "a")
 
 	if p := got.Load(); p == nil || *p != "a" {
 		t.Fatalf("preEvict hook not fired with model id; got %v", p)
+	}
+	// An operator-driven Unload is the reason that must NOT trigger a KV save.
+	if r := process.StopReason(gotReason.Load()); r != process.StopManual {
+		t.Errorf("Unload reported reason %d, want StopManual", r)
 	}
 }
 

--- a/internal/router/helpers_test.go
+++ b/internal/router/helpers_test.go
@@ -55,13 +55,14 @@ type fakeProcess struct {
 	// Stop calls can be in flight simultaneously.
 	stopBlock chan struct{}
 
-	preStop    atomic.Pointer[func()]
+	preStop    atomic.Pointer[func(process.StopReason)]
 	postStart  atomic.Pointer[func()]
 	lastConfig atomic.Pointer[config.ModelConfig] // last SetConfig, for ApplyConfig tests
 
-	runCalls   atomic.Int32
-	stopCalls  atomic.Int32
-	serveCalls atomic.Int32
+	runCalls       atomic.Int32
+	stopCalls      atomic.Int32
+	lastStopReason atomic.Uint32
+	serveCalls     atomic.Int32
 
 	// inFlightServe counts ServeHTTP calls currently inside the handler.
 	// stoppedWhileServing flips true if Stop is ever called while that
@@ -139,17 +140,22 @@ func (f *fakeProcess) Run(_ time.Duration) error {
 	return nil
 }
 
-func (f *fakeProcess) SetPreStop(fn func())   { f.preStop.Store(&fn) }
-func (f *fakeProcess) SetPostStart(fn func()) { f.postStart.Store(&fn) }
+func (f *fakeProcess) SetPreStop(fn func(process.StopReason)) { f.preStop.Store(&fn) }
+func (f *fakeProcess) SetPostStart(fn func())                 { f.postStart.Store(&fn) }
 
 func (f *fakeProcess) SetSpawnArgs(_ func([]string) ([]string, error)) {}
 func (f *fakeProcess) SetConfig(c config.ModelConfig)                  { f.lastConfig.Store(&c) }
 func (f *fakeProcess) LaunchedCmd() string                             { return "" }
 
-func (f *fakeProcess) Stop(_ time.Duration) error {
+func (f *fakeProcess) Stop(timeout time.Duration) error {
+	return f.StopWithReason(process.StopManual, timeout)
+}
+
+func (f *fakeProcess) StopWithReason(reason process.StopReason, _ time.Duration) error {
 	f.stopCalls.Add(1)
+	f.lastStopReason.Store(uint32(reason))
 	if fp := f.preStop.Load(); fp != nil {
-		(*fp)()
+		(*fp)(reason)
 	}
 	if f.inFlightServe.Load() > 0 {
 		f.stoppedWhileServing.Store(true)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -68,7 +68,7 @@ type LocalRouter interface {
 
 	// SetPreEvict installs a hook called with a model ID just before its process
 	// is stopped for eviction/unload, while still Ready. Call once before serving.
-	SetPreEvict(fn func(modelID string))
+	SetPreEvict(fn func(modelID string, reason process.StopReason))
 
 	// SetPostLoad installs a hook called with a model ID each time its process
 	// becomes Ready, before the triggering request is served. Call once before

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -316,7 +316,7 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 	}
 	s.slotCache = newSlotCache(cfg.SlotCache, s.runningProxies, slotParticipates, slotSlots, slotRecurrent, slotPreamble, proxylog)
 	s.promptCanon = newPromptCanon()
-	local.SetPreEvict(s.slotCache.saveOnEvict)    // save slot KV before a swap/unload kills the process
+	local.SetPreEvict(s.slotCache.saveOnEvict)    // save slot KV before a swap/TTL unload kills the process
 	local.SetPostLoad(s.slotCache.restoreOnLoad)  // restore slot KV after a cold load, before serving
 	s.metrics.onRecord = s.slotCache.confirmReuse // confirm restores actually reused KV (cached_tokens)
 	// The backend manager installs beside the running executable and calls back

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -48,7 +48,7 @@ func (s *stubRouter) RunningModels() map[string]process.ProcessState          { 
 func (s *stubRouter) RunningPIDs() []int                                      { return nil }
 func (s *stubRouter) SetLiveVramBudget(fn router.LiveVramFn)                  {}
 func (s *stubRouter) Unload(_ time.Duration, _ ...string)                     { s.unloadCalls.Add(1) }
-func (s *stubRouter) SetPreEvict(_ func(string))                              {}
+func (s *stubRouter) SetPreEvict(_ func(string, process.StopReason))          {}
 func (s *stubRouter) SetPostLoad(_ func(string))                              {}
 func (s *stubRouter) SetSpawnArgs(_ func(string, []string) ([]string, error)) {}
 func (s *stubRouter) ApplyConfig(_ config.Config) error                       { return nil }

--- a/internal/server/slotcache.go
+++ b/internal/server/slotcache.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/quartermaster-labs/quartermaster/internal/config"
 	"github.com/quartermaster-labs/quartermaster/internal/logmon"
+	"github.com/quartermaster-labs/quartermaster/internal/process"
 	"github.com/quartermaster-labs/quartermaster/internal/shared"
 )
 
@@ -709,6 +710,29 @@ func (sc *slotCache) synthPrefill(ctx context.Context, base, model string, idx i
 // shrink it.
 var hookLockWait = 10 * time.Second
 
+// worthSavingOn reports whether a teardown for this reason justifies the seconds
+// a multi-gigabyte KV snapshot costs. The test is not "will the snapshot ever be
+// useful" — it nearly always would be — but "is somebody sitting there waiting
+// for this teardown to finish, with nothing to show for the wait".
+//
+//   - TTL: the model went idle on its own; nobody is watching the clock, and the
+//     next request for it is a cold load that the snapshot turns into a restore.
+//   - Eviction: the model did not choose to leave, and whoever was using it will
+//     be back. This is the hand-off case — two people sharing one GPU, each
+//     evicting the other's model between turns — and it is the reason this cache
+//     exists: seconds of snapshot against a full cold reprefill on the way back.
+//   - Manual unload, shutdown, config-reload removal: somebody is standing there
+//     watching the model refuse to go away, for a snapshot that may never be read
+//     back. Those are pure dead time.
+func worthSavingOn(reason process.StopReason) bool {
+	switch reason {
+	case process.StopTTL, process.StopEvict:
+		return true
+	default:
+		return false
+	}
+}
+
 // saveOnEvict persists a model's live slot KV just before its process is stopped
 // for eviction/unload. This is the path that handles a model SWAP — the common
 // case onSwitch misses: onSwitch only fires when a new request arrives for the
@@ -722,7 +746,10 @@ var hookLockWait = 10 * time.Second
 // Gated on cost only (per-slot tokens >= minTokens): an expensive-to-reprefill
 // conversation is worth saving regardless of whether it's an interactive chat or
 // an agentic run with a single user turn. (onSwitch uses the same cost-only gate.)
-func (sc *slotCache) saveOnEvict(model string) {
+// It is also gated on WHY the process is stopping — see worthSavingOn. When the
+// save is skipped the bookkeeping still runs: the process dies either way, so the
+// occupants and pending restores it owned have to go with it.
+func (sc *slotCache) saveOnEvict(model string, reason process.StopReason) {
 	if sc == nil || !sc.enabled || model == "" {
 		return
 	}
@@ -734,6 +761,10 @@ func (sc *slotCache) saveOnEvict(model string) {
 	// would confirm the DEAD process's restore, and the event that actually earned
 	// the reuse would sit "pending" forever.
 	defer sc.dropAwait(model)
+	if !worthSavingOn(reason) {
+		sc.dropOccupants(model)
+		return
+	}
 	base, running := sc.running()[model]
 	if !running {
 		return
@@ -779,6 +810,20 @@ func (sc *slotCache) saveSlotOnEvict(ctx context.Context, base, model string, id
 	sc.stateMu.Lock()
 	delete(sc.occupant, sk(model, idx))
 	sc.stateMu.Unlock()
+}
+
+// dropOccupants forgets every slot this model owned, without saving them. Used
+// when a teardown is not worth a snapshot: the slots die with the process, and a
+// stale occupant would otherwise make the next load think a conversation is
+// still resident.
+func (sc *slotCache) dropOccupants(model string) {
+	sc.stateMu.Lock()
+	defer sc.stateMu.Unlock()
+	for k := range sc.occupant {
+		if modelOf(k) == model {
+			delete(sc.occupant, k)
+		}
+	}
 }
 
 // markResident records that `key` now holds one of the model's slots and has run.

--- a/internal/server/slotcache.md
+++ b/internal/server/slotcache.md
@@ -59,8 +59,27 @@ if restore never fires, check they're called.
 - **COLD** (`saveOnEvict`): evicting A to load B kills A's process with no A request to trigger a
   save — the pre-stop hook snapshots it.
 
-"Worth saving" = live KV ≥ `minSaveTokens`. **Cost is the only gate**, with no turn-count gate: a
-single-turn chat with a long answer is still expensive to reprefill.
+"Worth saving" = live KV ≥ `minSaveTokens`. **Cost is the only gate** on WHAT is saved, with no
+turn-count gate: a single-turn chat with a long answer is still expensive to reprefill.
+
+**WHEN it saves is gated separately** (`worthSavingOn`), on the `process.StopReason` the router
+tags the teardown with. A snapshot is multi-gigabyte and sits on the critical path, so it only
+runs for teardowns nobody is waiting through:
+
+| Reason | Saves | Why |
+|---|---|---|
+| `StopTTL` | yes | The model went idle on its own; nobody is watching, and the next request for it is a cold load the snapshot turns into a restore. |
+| `StopEvict` | yes | The model did not choose to leave. This is the **hand-off** case this cache exists for: two people sharing one GPU, each evicting the other's model between turns. Seconds of snapshot against a full cold reprefill on the way back. |
+| `StopManual` | no | The operator pressed Unload and is watching the model refuse to go away. |
+| `StopShutdown` / `StopConfig` | no | The app is quitting, or the model is gone from the config — a person is waiting on a snapshot that may never be read. |
+
+The split is "did somebody ASK for this teardown". A swap and a TTL expiry both end with the model
+being wanted again; an Unload, a quit and a config removal end with a person watching a progress
+bar for a cache they did not request.
+
+When a save is skipped the bookkeeping still runs: pending restores are resolved (`dropAwait`) and
+the model's occupants are forgotten (`dropOccupants`), because the slots die with the process
+either way.
 
 ## Restore / seed path (preamble caches + Tier-1)
 

--- a/internal/server/slotcache_test.go
+++ b/internal/server/slotcache_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/quartermaster-labs/quartermaster/internal/logmon"
+	"github.com/quartermaster-labs/quartermaster/internal/process"
 	"github.com/tidwall/gjson"
 )
 
@@ -188,7 +189,7 @@ func TestSlotCache_SaveOnEvict(t *testing.T) {
 	sc := newEvictTestCache(dir, srv.URL)
 	sc.occupant["m"] = &occInfo{key: "abc", dirty: true} // 1-user-turn pi run
 
-	sc.saveOnEvict("m")
+	sc.saveOnEvict("m", process.StopTTL)
 
 	if _, err := os.Stat(filepath.Join(dir, fileName("m", "abc"))); err != nil {
 		t.Fatalf("expected KV snapshot written on evict, got %v", err)
@@ -259,7 +260,7 @@ func TestSlotCache_SaveOnEvict_BelowThresholdSkips(t *testing.T) {
 	sc := newEvictTestCache(dir, srv.URL)
 	sc.occupant["m"] = &occInfo{key: "abc", dirty: true}
 
-	sc.saveOnEvict("m")
+	sc.saveOnEvict("m", process.StopTTL)
 
 	if entries, _ := os.ReadDir(dir); len(entries) != 0 {
 		t.Errorf("cheap conversation must not be saved, got %d files", len(entries))
@@ -430,7 +431,7 @@ func TestSlotCache_EvictDropsPendingConfirms(t *testing.T) {
 	sc.running = func() map[string]string { return map[string]string{} } // process already gone
 
 	orphan := sc.await("m", "restore-hit")
-	sc.saveOnEvict("m")
+	sc.saveOnEvict("m", process.StopTTL)
 	if got := sc.outcomeOf(orphan); got != outcomeUnconfirmed {
 		t.Errorf("restore on a dying process must resolve to %q, got %q", outcomeUnconfirmed, got)
 	}
@@ -842,7 +843,7 @@ func TestSlotCache_MultiSlot_SaveOnEvictAllSlots(t *testing.T) {
 
 	sc.markResident("m", 0, "convA", "", 0)
 	sc.markResident("m", 1, "convB", "", 0)
-	sc.saveOnEvict("m")
+	sc.saveOnEvict("m", process.StopTTL)
 
 	for _, k := range []string{"convA", "convB"} {
 		if _, err := os.Stat(filepath.Join(dir, fileName("m", k))); err != nil {
@@ -1005,5 +1006,44 @@ func TestSlotCache_RestoreOnLoad_GivesUpOnHeldGate(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("restoreOnLoad blocked on a held slot gate - the model would never ready")
+	}
+}
+
+// A hand-pressed Unload must not spend seconds writing a snapshot: the operator
+// is standing there waiting for the model to go away. The occupant must still be
+// forgotten, because the slot dies with the process either way.
+func TestSlotCache_ManualUnloadSkipsSave(t *testing.T) {
+	for _, reason := range []process.StopReason{process.StopManual, process.StopShutdown, process.StopConfig} {
+		dir := t.TempDir()
+		srv := fakeBackend(t, 35000, dir) // well above the save threshold
+		sc := newEvictTestCache(dir, srv.URL)
+		sc.occupant["m"] = &occInfo{key: "abc", dirty: true}
+
+		sc.saveOnEvict("m", reason)
+
+		if _, err := os.Stat(filepath.Join(dir, fileName("m", "abc"))); err == nil {
+			t.Errorf("reason %d: wrote a KV snapshot; only TTL and eviction should", reason)
+		}
+		if sc.occupant["m"] != nil {
+			t.Errorf("reason %d: occupant survived a teardown", reason)
+		}
+	}
+}
+
+// The two teardowns worth waiting for: an idle TTL unload (nobody is watching)
+// and an eviction (the evicted model did not choose to go, and whoever was using
+// it will be back to a full cold prefill without this).
+func TestSlotCache_TTLAndEvictSave(t *testing.T) {
+	for _, reason := range []process.StopReason{process.StopTTL, process.StopEvict} {
+		dir := t.TempDir()
+		srv := fakeBackend(t, 35000, dir)
+		sc := newEvictTestCache(dir, srv.URL)
+		sc.occupant["m"] = &occInfo{key: "abc", dirty: true}
+
+		sc.saveOnEvict("m", reason)
+
+		if _, err := os.Stat(filepath.Join(dir, fileName("m", "abc"))); err != nil {
+			t.Errorf("reason %d: expected a KV snapshot, got %v", reason, err)
+		}
 	}
 }


### PR DESCRIPTION
The pre-stop hook snapshotted the slot KV on EVERY teardown, so pressing Unload made the operator sit through a multi-gigabyte write for a cache nobody had asked to keep.

Teardowns now carry a reason, and the hook decides.

- `process.StopReason` tags each stop (manual, TTL, evict, shutdown, config-reload); plain `Stop()` stays manual, so a caller that does not think about it gets the conservative behaviour
- slotcache saves on `StopTTL` and `StopEvict`, the two teardowns that end with the model being wanted again
- manual unload, shutdown and config removal skip the save and just drop their occupants and pending restores, because the slots die with the process either way

The split is "did a human ask for this teardown". A swap and a TTL expiry both end with the model coming back; an Unload, a quit and a config removal end with a person watching a wait they get nothing from. The eviction save is what makes a two-user hand-off (one GPU, each evicting the other's model between turns) cost seconds of snapshot instead of a full cold reprefill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)