### PR TITLE
packaging: stamp the Windows version resource from the tag

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -81,6 +81,19 @@ ships would be the one nobody tested. Everything cross-compiles from one Windows
 runner (CGO is off project-wide), so the Windows wizard, `linux/amd64`,
 `linux/arm64` and `darwin/arm64` all come out of a single job.
 
+The Windows version resources are stamped from the tag, not from a file anyone
+remembers to bump. `cmd/*/resource_windows_amd64.syso` is committed and `go
+build` links whichever copy is on disk, so every release up to `v1.0.5` shipped
+the `1.0.0.0` placeholder its `versioninfo.json` carries -- in Explorer's
+Properties tab, in Task Manager, and to anything that reads a PE. The script now
+regenerates both resources with `goversioninfo`'s `-ver-*` overrides before
+building and restores the committed bytes afterwards (`Restore-Versioninfo`,
+which `Die` also calls), because a leftover stamped `.syso` is a dirty tree the
+next release refuses to start from. A prerelease suffix lives only in the
+`ProductVersion` string: `FixedFileInfo` is four integers, so `v1.0.4-rc1` is
+`1.0.4.0` there. Dev and `make package-windows` builds get the same treatment
+from the Makefile, using the newest existing tag.
+
 The tag is created on the dispatched ref's HEAD, and the script refuses to
 continue if the tag is not HEAD or origin already has it elsewhere.
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ internal/server/assets/*.gguf
 # Stray go build output at the repo root (the real binaries go to build/).
 /quartermaster.exe
 /quartermaster
+
+# Committed VERSIONINFO resources are regenerated from the tag for a release
+# build and restored afterwards; this is the copy held while that runs. It only
+# survives a run killed between the two (packaging/windows/build-release.ps1).
+*.release-backup

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,12 @@ linux-arm64: ui
 
 # Windows VERSIONINFO resource. cmd/quartermaster/resource_windows_amd64.syso is
 # committed (Go links any .syso in the main package automatically, which is why it
-# and favicon.ico live beside the main package rather than at the repo root), and packaging/windows/build-release.ps1
-# calls `go build` directly -- so the committed file, not this rule, is what a
-# release actually ships. Commit it after it regenerates.
+# and favicon.ico live beside the main package rather than at the repo root), and
+# `go build` links whatever copy is on disk. A RELEASE does not use the committed
+# one: packaging/windows/build-release.ps1 regenerates both resources from the tag
+# it is releasing and puts the committed bytes back afterwards. This rule is what
+# dev and packaging builds get, so it stamps the newest existing tag instead.
+# Commit the .syso after it regenerates.
 #
 # These are FILE targets, not phony ones, so make rebuilds them exactly when
 # favicon.ico or versioninfo.json is newer and skips the tool otherwise. The
@@ -79,11 +82,40 @@ linux-arm64: ui
 # -icon embeds favicon.ico as the exe's application icon (resource ID 1). Without
 # it the exe has no icon at all, so Explorer, the taskbar, and the Startup apps
 # list all fall back to the blank generic-executable glyph.
+# The version stamped into both Windows VERSIONINFO resources. The two
+# versioninfo.json files carry 1.0.0.0 as a placeholder and nothing bumps them by
+# hand: the number comes from the newest release tag, via goversioninfo's
+# -ver-*/-product-ver-* overrides, which beat the JSON without touching it.
+# packaging/windows/build-release.ps1 does the same thing from the tag it is
+# releasing, so a release exe is stamped even when its tag does not exist yet.
+#
+# Prerelease tags (v1.0.4-rc1) are filtered out: FixedFileInfo is four integers
+# with nowhere to put a suffix, and a dev build should not claim to BE the rc.
+# With no tags at all VI_FLAGS is empty and the JSON's own values are used --
+# note a 0.0.0.0 FixedFileInfo makes Windows drop the whole string table, which
+# is why the placeholder in the JSON is not zero.
+VI_TAG := $(firstword $(filter-out %-%,$(shell git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname)))
+VI_VER := $(patsubst v%,%,$(VI_TAG))
+VI_PARTS := $(subst ., ,$(VI_VER))
+ifneq ($(VI_VER),)
+VI_FLAGS := -ver-major $(word 1,$(VI_PARTS)) -ver-minor $(word 2,$(VI_PARTS)) -ver-patch $(word 3,$(VI_PARTS)) -ver-build 0 	-product-ver-major $(word 1,$(VI_PARTS)) -product-ver-minor $(word 2,$(VI_PARTS)) -product-ver-patch $(word 3,$(VI_PARTS)) -product-ver-build 0 	-file-version $(VI_VER).0 -product-version $(VI_VER)
+endif
+
+# A file target cannot see that `git tag` moved, so the version is carried in a
+# stamp FILENAME: a new tag names a file that does not exist, the rule runs, and
+# its fresh mtime pulls both .syso files with it. Without this the resources
+# would keep whatever version they were generated at until the JSON or the icon
+# happened to change.
+VI_STAMP = $(BUILD_DIR)/versioninfo-$(VI_VER).stamp
+
+$(VI_STAMP):
+	@mkdir -p $(BUILD_DIR) && rm -f $(BUILD_DIR)/versioninfo-*.stamp && touch $@
+
 QM_SYSO = cmd/quartermaster/resource_windows_amd64.syso
 SETUP_SYSO = cmd/quartermaster-setup/resource_windows_amd64.syso
 
-$(QM_SYSO): cmd/quartermaster/favicon.ico cmd/quartermaster/versioninfo.json
-	go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.7.0 -icon cmd/quartermaster/favicon.ico -o $@ cmd/quartermaster/versioninfo.json
+$(QM_SYSO): cmd/quartermaster/favicon.ico cmd/quartermaster/versioninfo.json $(VI_STAMP)
+	go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.7.0 -icon cmd/quartermaster/favicon.ico $(VI_FLAGS) -o $@ cmd/quartermaster/versioninfo.json
 
 versioninfo: $(QM_SYSO)
 
@@ -92,8 +124,8 @@ versioninfo: $(QM_SYSO)
 # one reaches the server binary and nothing else. Without this the wizard's exe has
 # the blank generic-executable glyph in Explorer AND in the taskbar, which is
 # the first thing a user sees of the app.
-$(SETUP_SYSO): cmd/quartermaster/favicon.ico cmd/quartermaster-setup/versioninfo.json
-	go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.7.0 -icon cmd/quartermaster/favicon.ico -o $@ cmd/quartermaster-setup/versioninfo.json
+$(SETUP_SYSO): cmd/quartermaster/favicon.ico cmd/quartermaster-setup/versioninfo.json $(VI_STAMP)
+	go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.7.0 -icon cmd/quartermaster/favicon.ico $(VI_FLAGS) -o $@ cmd/quartermaster-setup/versioninfo.json
 
 versioninfo-setup: $(SETUP_SYSO)
 

--- a/packaging/windows/build-release.ps1
+++ b/packaging/windows/build-release.ps1
@@ -102,7 +102,22 @@ if (-not $SkipBinaries) { $PublishBinaries = $true }
 $root = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 Set-Location $root
 
-function Die($m) { Write-Error $m; exit 1 }
+# The Windows VERSIONINFO resources are regenerated in place for the build (step
+# 1b) and put back afterwards, so every exit path has to restore them: a leftover
+# stamped .syso is both a lie for the next dev build and a dirty working tree the
+# next release refuses to start from. Defined above Die because Die calls it, and
+# a Die that dies on CommandNotFoundException reports the wrong failure.
+$script:sysoBackup = @{}
+function Restore-Versioninfo {
+    foreach ($path in @($script:sysoBackup.Keys)) {
+        $bak = $script:sysoBackup[$path]
+        if ($bak) { Move-Item -Force -LiteralPath $bak -Destination $path }
+        else { Remove-Item -Force -ErrorAction SilentlyContinue -LiteralPath $path }
+    }
+    $script:sysoBackup = @{}
+}
+
+function Die($m) { Restore-Versioninfo; Write-Error $m; exit 1 }
 
 # The tag is never inferred. Defaulting to the highest existing tag built
 # whatever HEAD happened to be and published it under a version that tag may
@@ -176,6 +191,50 @@ if (-not $SkipUi) {
     npm run build:setup
     if ($LASTEXITCODE -ne 0) { Pop-Location; Die "npm run build:setup failed" }
     Pop-Location
+}
+
+# 1b. Windows VERSIONINFO resources, stamped with $Tag.
+#
+# cmd/*/resource_windows_amd64.syso is committed and `go build` links whatever
+# copy is on disk, so a release that did not regenerate them shipped the number
+# the JSON happened to carry: every release up to v1.0.5 called itself 1.0.0.0 in
+# Explorer's Properties tab, in Task Manager, and to anything that inspects a PE.
+# goversioninfo's -ver-*/-product-ver- flags override the JSON without editing it,
+# so nothing has to be bumped by hand and no file is left modified for the tag.
+#
+# FixedFileInfo is four integers with nowhere to put a prerelease suffix, so
+# v1.0.4-rc1 stamps 1.0.4.0 there and keeps the full string in ProductVersion,
+# which is free text. The Makefile does the same from the newest existing tag;
+# here the tag is usually one that does not exist yet, which is why the version
+# comes from the parameter rather than from git.
+#
+# This runs before anything sets GOOS/GOARCH: `go run` of a build tool with those
+# set cross-compiles the tool and then cannot execute it.
+$null = $Tag -match '^v([0-9]+)\.([0-9]+)\.([0-9]+)'
+$viMajor, $viMinor, $viPatch = $Matches[1], $Matches[2], $Matches[3]
+# The four-integer FixedFileInfo and the free-text string table, respectively.
+$viFixed = "$viMajor.$viMinor.$viPatch.0"
+$viString = $Tag.TrimStart('v')
+Write-Host "  stamping version resources $viFixed / $viString" -ForegroundColor DarkGray
+foreach ($vi in @(
+    @{ json = 'cmd\quartermaster\versioninfo.json'; syso = 'cmd\quartermaster\resource_windows_amd64.syso' }
+    @{ json = 'cmd\quartermaster-setup\versioninfo.json'; syso = 'cmd\quartermaster-setup\resource_windows_amd64.syso' }
+)) {
+    # Registered BEFORE the tool runs, so a failure half way through the second
+    # resource still restores the first one Die put back.
+    $bak = $null
+    if (Test-Path $vi.syso) {
+        $bak = "$($vi.syso).release-backup"
+        Copy-Item -Force -LiteralPath $vi.syso -Destination $bak
+    }
+    $script:sysoBackup[$vi.syso] = $bak
+    go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.7.0 `
+        -icon cmd\quartermaster\favicon.ico `
+        -ver-major $viMajor -ver-minor $viMinor -ver-patch $viPatch -ver-build 0 `
+        -product-ver-major $viMajor -product-ver-minor $viMinor -product-ver-patch $viPatch -product-ver-build 0 `
+        -file-version $viFixed -product-version $viString `
+        -o $vi.syso $vi.json
+    if ($LASTEXITCODE -ne 0) { Die "goversioninfo failed for $($vi.json)" }
 }
 
 # 2. Binaries. One staging dir for everything: the Windows binary the installer
@@ -359,6 +418,11 @@ $sumLines = foreach ($f in $uploads) {
 Write-Host "SHA256SUMS:" -ForegroundColor DarkGray
 $sumLines | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
 $uploads += $sumsPath
+
+# Every binary is built; the stamped resources have done their job. Put the
+# committed ones back before the tree is read again, so a local `make release`
+# ends where it started.
+Restore-Versioninfo
 
 # 6. Push the tag, create the release if missing, upload everything.
 #


### PR DESCRIPTION
Every release up to v1.0.5 shipped `1.0.0.0` in Explorer's Properties tab and Task Manager: `cmd/*/resource_windows_amd64.syso` is committed, `go build` links whatever is on disk, and nothing regenerated it. `goversioninfo`'s `-ver-*`/`-product-ver-*` flags override the JSON without editing it, so the number comes from the tag.

- `build-release.ps1` regenerates both resources from `$Tag` before building and restores the committed bytes afterwards; `Restore-Versioninfo` also runs from `Die`, since a leftover stamped `.syso` is a dirty tree the next release refuses to start from
- the Makefile stamps the newest existing release tag, carried in a stamp filename so a moved tag invalidates a `.syso` that a file target would otherwise call up to date
- a prerelease suffix lives only in the `ProductVersion` string; `FixedFileInfo` is four integers, so `v1.0.4-rc1` is `1.0.4.0` there

Verified by running the stamping block verbatim with `-Tag v9.8.7-rc2`: `FixedFileInfo` decoded as `(9,8,7,0)`, the string table as `9.8.7-rc2`, string table intact, and `Restore-Versioninfo` left the tree clean with no leftover backups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)