### PR TITLE
playground: drag and drop files onto the chat and image panes

### DIFF
--- a/ui-svelte/playground-tools.md
+++ b/ui-svelte/playground-tools.md
@@ -198,7 +198,8 @@ goes *beside* the page's own price, never in place of it.
 
 ## File attachments (`lib/attachments.ts` + the composer's doc chips)
 
-The paperclip takes text/code, PDF, DOCX and audio, not just images.
+The paperclip takes text/code, PDF, DOCX and audio, not just images. Files can also be **pasted** or
+**dragged onto the pane** (see below).
 
 **Extraction runs in the browser and the result is folded into the user's own message** as a
 `<file name="…" note="…">…</file>` block (`buildFileBlock`/`splitFileBlocks`, `</file>` in the body
@@ -225,6 +226,32 @@ string and would dump raw document text into the textarea).
 - **Audio** posts to `/v1/audio/transcriptions` via `pickTranscribeModel`, which prefers an
   **already-ready** ASR model and toasts before swapping, since loading one evicts the chat model.
 
+### Drag-and-drop (`lib/dropZone.ts`)
+
+Files can be dropped anywhere in the **chat pane** or the **image pane**, not just on the composer:
+the transcript is most of the surface, and a drag shouldn't have to hit a 3rem textarea. The drop
+feeds the same `processFiles` the picker and paste already use, so every rule above (classification,
+vision swap, budget, chips) applies unchanged.
+
+The action exists because three things break a naive `ondrop`:
+
+- **`dragover` must `preventDefault()`** or `drop` never fires — the default for a drag over a page
+  is "not a drop target".
+- **`dragenter`/`dragleave` fire per child element**, so a boolean flickers off as the cursor crosses
+  a bubble. A depth counter fixes it, reset on `drop` and on a window `dragend` (a drag ending
+  outside the node sends no final `dragleave`). The overlay is `pointer-events-none` for the same
+  reason: one that took pointer events would become the drag target itself and flicker off.
+- **An unhandled drop NAVIGATES the browser to the file**, discarding the open chat and aborting a
+  streaming turn. `guardWindowDrop()` (called once from `PlaygroundApp`, before login) makes a miss a
+  no-op; both its handlers bail on `defaultPrevented`, which a real zone has already set by the time
+  the event bubbles up, so it never steals a drop the composer wanted.
+
+A dropped **folder** is named and rejected rather than half-attached: it arrives in
+`dataTransfer.files` as a zero-type File that throws on read, and only `dataTransfer.items` +
+`webkitGetAsEntry()` tell it from a real file. The image pane additionally takes **images only** —
+its `attachFiles` data-URLs whatever it is handed, so a dropped PDF would become a silently broken
+base image.
+
 ### Size is checked at attach time, not at send
 
 `estimateTokens` (~4 chars/token) against `docBudgetTokens` = 40% of the window (live `n_ctx`, else
@@ -242,5 +269,6 @@ is still being read, so a half-extracted set can't go out.
 | `chatCompact.ts` | auto-compaction + conversation title gen |
 | `wordDiff.ts` | rewrite diff |
 | `reasoning.ts` | Harmony/reasoning parsing, `thinkSummary`, `activityLabel` |
+| `dropZone.ts` | `dropZone` action + `guardWindowDrop` — drag-and-drop file attachment; see above |
 | `inferenceAuth.ts` | `refreshInferenceKey`/`inferenceHeaders` — auto-attach API key to playground inference |
 | `modelUtils.ts` | `modelCategory`/`MODEL_CATEGORIES`, drives the Models tabs + key scoping |

--- a/ui-svelte/src/components/playground/ChatInterface.svelte
+++ b/ui-svelte/src/components/playground/ChatInterface.svelte
@@ -71,6 +71,7 @@
   import { modelCategory } from "../../lib/modelUtils";
   import { EFFORT_OFF, effortOptions, resolveEffort, requestEffort } from "../../lib/effort";
   import { scrollFade } from "../../lib/scrollFade";
+  import { dropZone } from "../../lib/dropZone";
   import Select from "../Select.svelte";
   import Toggle from "../Toggle.svelte";
   import { quotePrefix, fmtTokens, TEMP_STEPS, TEMP_LABELS, nearestTempIdx, currentDateLine, REWRITE_SYSTEM, MAX_IMAGES_PER_MESSAGE, validateImageFile, fileToDataUrl, type ToolItem } from "./chatHelpers";
@@ -328,6 +329,8 @@
   let attachedDocs = $state<AttachedDoc[]>([]);
   let fileInput = $state<HTMLInputElement | null>(null);
   let imageError = $state<string | null>(null);
+  // Painted by the dropZone action while an OS file drag hovers the pane.
+  let dropActive = $state(false);
 
   let hasModels = $derived($models.some((m) => !m.unlisted));
   // Image input needs a vision-capable model; without one the backend 500s
@@ -1403,9 +1406,38 @@
     event.preventDefault();
     await processFiles(files);
   }
+
+  // Drop anywhere in the chat pane, not just on the composer: the transcript is
+  // most of the surface, and aiming at a 2rem-tall textarea is the kind of
+  // precision a drag shouldn't need.
+  async function handleDrop(files: File[], skipped: string[]) {
+    if (files.length > 0) await processFiles(files);
+    else imageError = null;
+    // processFiles clears imageError first, so a folder can only be reported
+    // once the file half has had its say.
+    if (skipped.length > 0 && !imageError) {
+      imageError = `Can't attach ${skipped.join(", ")}: drop the files, not the folder.`;
+    }
+  }
 </script>
 
-<div class="flex flex-col h-full">
+<div
+  class="relative flex flex-col h-full"
+  use:dropZone={{ onFiles: handleDrop, onActive: (v) => (dropActive = v), enabled: hasModels }}
+>
+  <!-- Drop overlay. `pointer-events-none` is load-bearing: an overlay that took
+       pointer events would itself become the drag target the moment it appeared,
+       firing dragleave on the pane underneath and flickering itself back off. -->
+  {#if dropActive}
+    <div class="pointer-events-none absolute inset-2 z-30 flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-primary bg-surface/85 backdrop-blur-[2px]">
+      <Paperclip class="w-7 h-7 text-primary" />
+      <span class="text-sm font-medium text-txtmain">Drop to attach</span>
+      <span class="text-xs text-txtsecondary">
+        {canAttach ? "Images, text, code, PDF, Word or audio" : "Text, code, PDF, Word or audio - this model can't read images"}
+      </span>
+    </div>
+  {/if}
+
   <!-- Empty state for no models configured -->
   {#if !hasModels}
     <div class="flex-1 flex flex-col items-center justify-center gap-3 text-txtsecondary">

--- a/ui-svelte/src/components/playground/ImageInterface.svelte
+++ b/ui-svelte/src/components/playground/ImageInterface.svelte
@@ -23,6 +23,8 @@
   import Composer from "./Composer.svelte";
   import { autogrow } from "../../lib/autogrow";
   import { Image as ImageIcon, X, Download, Paperclip, Ban, Plus, Pencil, Save, Copy, Check, RefreshCw, ImageDown, Type, Paintbrush, Sparkles, Brush, Palette, Reply, Maximize2, Loader2 } from "lucide-svelte";
+  import { dropZone } from "../../lib/dropZone";
+  import { classifyAttachment } from "../../lib/attachments";
   import { scrollFade } from "../../lib/scrollFade";
   import type { ImageApiMode, SdApiLora, SdApiLoraRef } from "../../lib/types";
   import { ASPECTS, SIZE_TIERS, aspectDims, SAMPLER_OPTIONS, SCHEDULER_OPTIONS, DEFAULT_MAX_DIM, MAX_BATCH, defaultsFor, settingsFor, parseSdProgress, fmtDur } from "./imageGen";
@@ -819,6 +821,21 @@
     attachFiles(files);
   }
 
+  // Drop onto the image pane. Unlike the chat tab this takes images ONLY:
+  // attachFiles data-URLs whatever it is handed, so a dropped PDF would become
+  // a base image that is silently broken all the way to the backend.
+  let dropActive = $state(false);
+  let dropError = $state("");
+  let dropErrTimer: ReturnType<typeof setTimeout> | undefined;
+  function handleDrop(files: File[], skipped: string[]) {
+    const images = files.filter((f) => classifyAttachment(f) === "image");
+    const rejected = [...skipped, ...files.filter((f) => !images.includes(f)).map((f) => f.name)];
+    if (images.length > 0) attachFiles(images);
+    dropError = rejected.length > 0 ? `Only images can be dropped here (skipped ${rejected.join(", ")}).` : "";
+    clearTimeout(dropErrTimer);
+    if (dropError) dropErrTimer = setTimeout(() => (dropError = ""), 4000);
+  }
+
   // Copy the rendered image to the clipboard as a PNG blob. copiedIdx flashes the
   // check on the turn that was copied. Silent no-op where the browser blocks
   // image clipboard writes.
@@ -888,7 +905,20 @@
   }
 </script>
 
-<div class="flex flex-col h-full">
+<div
+  class="relative flex flex-col h-full"
+  use:dropZone={{ onFiles: handleDrop, onActive: (v) => (dropActive = v), enabled: hasModels }}
+>
+  <!-- pointer-events-none: see ChatInterface — an overlay that takes pointer
+       events becomes the drag target and flickers itself off. -->
+  {#if dropActive}
+    <div class="pointer-events-none absolute inset-2 z-30 flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-primary bg-surface/85 backdrop-blur-[2px]">
+      <Paperclip class="w-7 h-7 text-primary" />
+      <span class="text-sm font-medium text-txtmain">Drop to use as the base image</span>
+      <span class="text-xs text-txtsecondary">Images only</span>
+    </div>
+  {/if}
+
   {#if !hasModels}
     <div class="flex-1 flex flex-col items-center justify-center gap-3 text-txtsecondary">
       <ImageIcon class="w-10 h-10 opacity-40" strokeWidth={1.5} />
@@ -1347,6 +1377,12 @@
               <span>Style reference set - its look is applied to the edit</span>
               <button class="text-txtsecondary hover:text-txtmain" onclick={() => (styleRef = null)}>clear</button>
             </div>
+          </div>
+        {/if}
+
+        {#if dropError}
+          <div class="mb-2 p-2 bg-red-100 dark:bg-red-900/20 text-red-700 dark:text-red-400 rounded text-sm">
+            {dropError}
           </div>
         {/if}
 

--- a/ui-svelte/src/lib/dropZone.test.ts
+++ b/ui-svelte/src/lib/dropZone.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { collectDropFiles, dragHasFiles } from "./dropZone";
+
+function file(name: string): File {
+  return new File(["x"], name, { type: "text/plain" });
+}
+
+/** Enough of a DataTransfer for the two pure helpers. */
+function dt(opts: {
+  types?: string[];
+  items?: Array<{ kind: string; file?: File; dir?: string }>;
+  files?: File[];
+}): DataTransfer {
+  const items = opts.items?.map((i) => ({
+    kind: i.kind,
+    getAsFile: () => i.file ?? null,
+    webkitGetAsEntry: () => (i.dir ? { isDirectory: true, name: i.dir } : { isDirectory: false, name: i.file?.name }),
+  }));
+  return {
+    types: opts.types ?? ["Files"],
+    items: items as unknown as DataTransferItemList,
+    files: (opts.files ?? []) as unknown as FileList,
+  } as unknown as DataTransfer;
+}
+
+describe("dragHasFiles", () => {
+  it("is true for an OS file drag", () => {
+    expect(dragHasFiles({ dataTransfer: dt({ types: ["Files"] }) } as DragEvent)).toBe(true);
+  });
+
+  it("is false for a dragged text selection", () => {
+    expect(dragHasFiles({ dataTransfer: dt({ types: ["text/plain", "text/html"] }) } as DragEvent)).toBe(false);
+  });
+
+  it("is false with no dataTransfer at all", () => {
+    expect(dragHasFiles({ dataTransfer: null } as unknown as DragEvent)).toBe(false);
+  });
+});
+
+describe("collectDropFiles", () => {
+  it("takes the files out of items", () => {
+    const a = file("a.md");
+    const b = file("b.txt");
+    const { files, skipped } = collectDropFiles(dt({ items: [{ kind: "file", file: a }, { kind: "file", file: b }] }));
+    expect(files.map((f) => f.name)).toEqual(["a.md", "b.txt"]);
+    expect(skipped).toEqual([]);
+  });
+
+  it("names a dropped folder instead of attaching it", () => {
+    const a = file("a.md");
+    const { files, skipped } = collectDropFiles(
+      dt({ items: [{ kind: "file", dir: "notes" }, { kind: "file", file: a }] })
+    );
+    expect(files.map((f) => f.name)).toEqual(["a.md"]);
+    expect(skipped).toEqual(["notes"]);
+  });
+
+  it("ignores non-file items (a dragged string rides along with the files)", () => {
+    const a = file("a.md");
+    const { files } = collectDropFiles(dt({ items: [{ kind: "string" }, { kind: "file", file: a }] }));
+    expect(files.map((f) => f.name)).toEqual(["a.md"]);
+  });
+
+  it("falls back to dataTransfer.files when items carry no entry metadata", () => {
+    const got = collectDropFiles({
+      items: undefined,
+      files: [file("a.md")] as unknown as FileList,
+    } as unknown as DataTransfer);
+    expect(got.files.map((f) => f.name)).toEqual(["a.md"]);
+    expect(got.skipped).toEqual([]);
+  });
+});

--- a/ui-svelte/src/lib/dropZone.ts
+++ b/ui-svelte/src/lib/dropZone.ts
@@ -1,0 +1,164 @@
+// Drag-and-drop file attachment for the playground composers.
+//
+// The arriving-files pipeline already exists and is untouched by this: chat has
+// ONE entry point (`processFiles` — picker, paste and now drop), the image tab
+// has `attachFiles`. This action only delivers a `File[]` to it and paints the
+// hover state while a drag is over the node.
+//
+// It is an action rather than four inline handlers because a naive `ondrop`
+// does not work, for three separate reasons:
+//
+//  1. `dragover` MUST call `preventDefault()` or `drop` never fires at all. The
+//     default action for a drag over a page is "this is not a drop target".
+//  2. `dragenter`/`dragleave` fire for every CHILD the pointer crosses, so a
+//     boolean set on enter and cleared on leave flickers off the moment the
+//     cursor moves from the message list onto a chip inside it. A depth counter
+//     is the fix; `drop` and a window-level `dragend` reset it, because a drag
+//     that ends outside the node never sends a final `dragleave`.
+//  3. A drop the page does NOT handle makes the browser NAVIGATE to the file.
+//     In the playground that discards the open chat and aborts any turn
+//     streaming into it, and in the app window there is no back button.
+//     `guardWindowDrop()` turns a miss into a no-op.
+
+export interface DropZoneOptions {
+  /** Dropped files. `skipped` names what wasn't a file (a folder). */
+  onFiles: (files: File[], skipped: string[]) => void;
+  /** Hover state, for the "drop to attach" overlay. */
+  onActive?: (active: boolean) => void;
+  /** While false the node ignores drags (the window guard still blocks navigation). */
+  enabled?: boolean;
+}
+
+/** True only for an OS/file drag — dragging a text selection must not arm the overlay. */
+export function dragHasFiles(e: DragEvent): boolean {
+  const types = e.dataTransfer?.types;
+  return !!types && Array.from(types).includes("Files");
+}
+
+/**
+ * Split a drop into real files and things that only look like one.
+ *
+ * A dropped FOLDER appears in `dataTransfer.files` as a zero-length, empty-type
+ * File that throws on read — attaching it would produce a chip that fails after
+ * the fact. Only `dataTransfer.items` carries the entry metadata that tells the
+ * two apart, so the folder is named and rejected up front.
+ */
+export function collectDropFiles(dt: DataTransfer): { files: File[]; skipped: string[] } {
+  const files: File[] = [];
+  const skipped: string[] = [];
+  const items = dt.items;
+  if (items && items.length > 0 && typeof items[0]?.webkitGetAsEntry === "function") {
+    for (const it of Array.from(items)) {
+      if (it.kind !== "file") continue;
+      const entry = it.webkitGetAsEntry();
+      if (entry?.isDirectory) {
+        skipped.push(entry.name);
+        continue;
+      }
+      const f = it.getAsFile();
+      if (f) files.push(f);
+    }
+    return { files, skipped };
+  }
+  return { files: Array.from(dt.files ?? []), skipped };
+}
+
+export function dropZone(node: HTMLElement, options: DropZoneOptions) {
+  let opts = options;
+  let depth = 0;
+  let active = false;
+
+  function setActive(v: boolean) {
+    if (active === v) return;
+    active = v;
+    opts.onActive?.(v);
+  }
+
+  function reset() {
+    depth = 0;
+    setActive(false);
+  }
+
+  function live(e: DragEvent): boolean {
+    return opts.enabled !== false && dragHasFiles(e);
+  }
+
+  function onEnter(e: DragEvent) {
+    if (!live(e)) return;
+    e.preventDefault();
+    depth++;
+    setActive(true);
+  }
+
+  function onOver(e: DragEvent) {
+    if (!live(e)) return;
+    // Claims the drop AND tells the window guard below to stand down
+    // (it checks `defaultPrevented`).
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+  }
+
+  function onLeave(e: DragEvent) {
+    if (!live(e)) return;
+    depth = Math.max(0, depth - 1);
+    if (depth === 0) setActive(false);
+  }
+
+  function onDrop(e: DragEvent) {
+    if (!live(e)) return;
+    e.preventDefault();
+    reset();
+    if (!e.dataTransfer) return;
+    const { files, skipped } = collectDropFiles(e.dataTransfer);
+    if (files.length > 0 || skipped.length > 0) opts.onFiles(files, skipped);
+  }
+
+  node.addEventListener("dragenter", onEnter);
+  node.addEventListener("dragover", onOver);
+  node.addEventListener("dragleave", onLeave);
+  node.addEventListener("drop", onDrop);
+  // A drag released outside the node (or cancelled with Escape) sends no
+  // `dragleave`, which would leave the overlay stuck on until the next drag.
+  window.addEventListener("dragend", reset);
+  window.addEventListener("drop", reset);
+
+  return {
+    update(next: DropZoneOptions) {
+      opts = next;
+      if (next.enabled === false) reset();
+    },
+    destroy() {
+      node.removeEventListener("dragenter", onEnter);
+      node.removeEventListener("dragover", onOver);
+      node.removeEventListener("dragleave", onLeave);
+      node.removeEventListener("drop", onDrop);
+      window.removeEventListener("dragend", reset);
+      window.removeEventListener("drop", reset);
+    },
+  };
+}
+
+let guarded = false;
+
+/**
+ * Make a file dropped ANYWHERE else in the document a no-op instead of a
+ * navigation. Idempotent, and deliberately never removed: it has to outlive
+ * whichever component happened to call it.
+ *
+ * Both handlers bail on `defaultPrevented`, which a real `dropZone` has already
+ * set by the time the event bubbles up here — so the guard never steals a drop
+ * the composer wanted.
+ */
+export function guardWindowDrop(): void {
+  if (guarded || typeof window === "undefined") return;
+  guarded = true;
+  window.addEventListener("dragover", (e: DragEvent) => {
+    if (e.defaultPrevented) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "none";
+  });
+  window.addEventListener("drop", (e: DragEvent) => {
+    if (e.defaultPrevented) return;
+    e.preventDefault();
+  });
+}

--- a/ui-svelte/src/routes/PlaygroundApp.svelte
+++ b/ui-svelte/src/routes/PlaygroundApp.svelte
@@ -10,6 +10,7 @@
   import { selectedTabStore, selectedModelStore, type PlaygroundTab } from "../stores/playground";
   import { userPref } from "../stores/prefs";
   import { isEmbedded, embedTabId, postToShell } from "../lib/embed";
+  import { guardWindowDrop } from "../lib/dropZone";
   import Login from "./Login.svelte";
   import PlaygroundShell from "./PlaygroundShell.svelte";
 
@@ -52,6 +53,11 @@
   let chatsLoaded = $state(false);
 
   onMount(async () => {
+    // A file dropped anywhere OUTSIDE a composer's drop zone would otherwise
+    // navigate the page to it, discarding the open chat and any turn streaming
+    // into it. Installed once for the whole playground, before login: a stray
+    // drop on the sign-in screen is just as fatal.
+    guardWindowDrop();
     await checkMe();
     ready = true;
   });


### PR DESCRIPTION
Files can now be dropped anywhere in the chat pane or the image pane, not just picked through the paperclip. The drop feeds the same `processFiles` entry point the picker and paste already share, so classification, the vision-twin swap, the token budget and the doc chips all apply unchanged.

- `lib/dropZone.ts`: a `dropZone` action (depth-counted hover state, `dragover` preventDefault, folder rejection via `webkitGetAsEntry`) plus `guardWindowDrop()`, which stops a missed drop from navigating the page to the file and taking the open chat and any streaming turn with it
- `ChatInterface` / `ImageInterface`: pane-wide drop target with a `pointer-events-none` "drop to attach" overlay; the image pane takes images only, since `attachFiles` data-URLs whatever it is handed
- `PlaygroundApp`: installs the window guard once, before login
- colocated `dropZone.test.ts`; `playground-tools.md` documents the three reasons a naive `ondrop` does not work

🤖 Generated with [Claude Code](https://claude.com/claude-code)