### PR TITLE
make: a prerelease tag must not break the version resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,16 @@ linux-arm64: ui
 #
 # Prerelease tags (v1.0.4-rc1) are filtered out: FixedFileInfo is four integers
 # with nowhere to put a suffix, and a dev build should not claim to BE the rc.
+# The filter cannot be a make pattern: only the FIRST '%' in a pattern is a
+# wildcard and the rest are literal, so `filter-out %-%` matches nothing and the
+# prerelease tag reaches -ver-patch, which goversioninfo rejects outright (a
+# build that worked while the newest tag was a release, and stops working the
+# moment an rc is cut). findstring over the list says what it means instead.
 # With no tags at all VI_FLAGS is empty and the JSON's own values are used --
 # note a 0.0.0.0 FixedFileInfo makes Windows drop the whole string table, which
 # is why the placeholder in the JSON is not zero.
-VI_TAG := $(firstword $(filter-out %-%,$(shell git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname)))
+VI_TAGS := $(shell git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname)
+VI_TAG := $(firstword $(foreach t,$(VI_TAGS),$(if $(findstring -,$(t)),,$(t))))
 VI_VER := $(patsubst v%,%,$(VI_TAG))
 VI_PARTS := $(subst ., ,$(VI_VER))
 ifneq ($(VI_VER),)


### PR DESCRIPTION
`make windows`, `make package-windows` and `make setup-windows` all fail while the newest
tag in the repo is a prerelease:

```
invalid value "7-rc1" for flag -ver-patch: parse error
exit status 2
make: *** [Makefile:118: cmd/quartermaster/resource_windows_amd64.syso] Error 1
```

The version block intends to skip prerelease tags:

```make
VI_TAG := $(firstword $(filter-out %-%,$(shell git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname)))
```

but `%-%` does not mean "contains a dash". In a make pattern only the FIRST `%` is a
wildcard; later ones are literal, so `%-%` requires the literal text `-%` and matches
nothing. The filter silently passes every tag through, `v1.0.7-rc1` becomes
`VI_PARTS = 1 0 7-rc1`, and `goversioninfo` rejects `-ver-patch 7-rc1`.

This worked until an rc was cut, and will break again the next time one is.

Fix: drop tags containing `-` with `findstring`, which says what it means and does not
depend on pattern quirks:

```make
VI_TAGS := $(shell git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname)
VI_TAG := $(firstword $(foreach t,$(VI_TAGS),$(if $(findstring -,$(t)),,$(t))))
```

With the current tag list this resolves to `v1.0.6`, and the `.syso` rule completes.

The rule rewrites the committed `cmd/quartermaster/resource_windows_amd64.syso` on every
run (same size, different bytes), so a build still leaves that file dirty. That is
unchanged here and left out of the commit.

Also on `radu0120/trellis2` (same commit, cherry-picked) so the 3D branch builds; whichever
lands second is a no-op for this hunk.
