### PR TITLE
backends: say when a repo has no releases at all

### DIFF
--- a/internal/backends/backends_test.go
+++ b/internal/backends/backends_test.go
@@ -379,6 +379,24 @@ func TestBackends_PickRelease(t *testing.T) {
 	}
 }
 
+func TestBackends_NoReleaseError(t *testing.T) {
+	c := Component{ID: "trellis2-server", Repo: "Radu0120/trellis2.c"}
+
+	// The case a user hits with a freshly tracked repo: no releases at all. The
+	// old wording was `no release "" found in the last 30 releases`.
+	err := noReleaseError(c, nil, "")
+	if want := "trellis2-server: Radu0120/trellis2.c has no releases yet"; err.Error() != want {
+		t.Errorf("empty listing = %q, want %q", err.Error(), want)
+	}
+
+	// Releases exist but the requested tag is not among them: name the tag.
+	rels := []Release{{Tag: "server-v0.1.0"}}
+	err = noReleaseError(c, rels, "v0.9")
+	if !strings.Contains(err.Error(), `no release "v0.9" found`) {
+		t.Errorf("explicit tag = %q", err.Error())
+	}
+}
+
 func TestBackends_ValidateRepo(t *testing.T) {
 	for _, ok := range []string{"ggml-org/llama.cpp", "lemonade-sdk/llamacpp-rocm", "a_b/c-d.e"} {
 		if err := ValidateRepo(ok); err != nil {

--- a/internal/backends/github.go
+++ b/internal/backends/github.go
@@ -156,6 +156,17 @@ func (g *ghClient) Releases(ctx context.Context, repo string, force bool) ([]Rel
 	return out, nil
 }
 
+// noReleaseError explains why nothing resolved. An empty listing used to be
+// reported as `no release "" found in the last 30 releases`, which reads like a
+// bad version request when the truth is that the repo has published nothing yet
+// (a freshly tracked fork, or one whose CI has not run).
+func noReleaseError(c Component, rels []Release, version string) error {
+	if len(rels) == 0 {
+		return fmt.Errorf("%s: %s has no releases yet", c.ID, c.Repo)
+	}
+	return fmt.Errorf("%s: no release %q found in the last %d releases", c.ID, version, releasePage)
+}
+
 // pickRelease resolves a requested version: "" or "latest" => the newest
 // non-prerelease that actually carries an asset for this variant/OS, else the
 // exact tag.

--- a/internal/backends/manager.go
+++ b/internal/backends/manager.go
@@ -217,7 +217,7 @@ func (m *Manager) Resolve(ctx context.Context, comp, variant, version string) (r
 		// hint is worth the most. Fall back to the newest release so the caller
 		// gets something concrete to compare against instead of "not found".
 		if rel, ok = pickRelease(rels, version, true, nil); !ok {
-			return Release{}, "", "", 0, fmt.Errorf("no release found for %s", c.ID)
+			return Release{}, "", "", 0, noReleaseError(c, rels, version)
 		}
 	}
 	names := rel.AssetNames()
@@ -353,7 +353,7 @@ func (m *Manager) run(id string, c Component, variant, version string) {
 		return err == nil
 	})
 	if !ok {
-		fail(fmt.Errorf("%s: no release %q found in the last %d releases", c.ID, version, releasePage))
+		fail(noReleaseError(c, rels, version))
 		return
 	}
 	primary, extras, err := c.MatchAssets(variant, runtime.GOOS, rel.AssetNames())


### PR DESCRIPTION
A component whose repo has no releases at all fails with a message that points at the
wrong thing:

```
trellis2-server: no release "" found in the last 30 releases
```

The `""` is the unset version string, and the count is the page size, so the line looks
like a version lookup problem when the listing was simply empty (a freshly tracked fork,
or one whose CI has not run yet). Anyone adding their own tracked repo hits this.

`noReleaseError` keeps the tag wording for the case it describes and reports an empty
listing directly:

```
trellis2-server: Radu0120/trellis2.c has no releases yet
```

`Resolve()` now uses the same helper, so the install preview agrees with the job error
instead of `no release found for trellis2-server`.

Covered by `TestBackends_NoReleaseError` (both wordings).
