### PR TITLE
perf: tool-free sysfs/KFD GPU backend for AMD iGPUs (reference for #37)

### DIFF
--- a/internal/perf/computeapps_linux.go
+++ b/internal/perf/computeapps_linux.go
@@ -1,0 +1,210 @@
+//go:build linux
+
+package perf
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// computeAppsPlatform uses Linux DRM fdinfo to attribute GPU memory to
+// processes for AMD (amdgpu) GPUs, providing per-process GTT+VRAM totals
+// without any external tools. This fixes the VRAM gauge on AMD APUs where
+// the driver pre-allocates a large GTT pool, making the aggregate counter
+// appear flat even as model allocations grow within that pool.
+func computeAppsPlatform(_ context.Context) []GpuProc {
+	return queryDRMFdinfo()
+}
+
+// queryDRMFdinfo walks /proc/*/fdinfo/* for amdgpu DRM clients and returns
+// per-process memory (GTT + VRAM combined), deduplicated by DRM client-id so
+// that duplicated fds are not counted twice.
+func queryDRMFdinfo() []GpuProc {
+	procs, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+
+	type pidEntry struct {
+		gttMB  int
+		vramMB int
+		seen   map[int64]struct{} // drm-client-id dedup
+	}
+	byPID := make(map[int]*pidEntry)
+
+	for _, p := range procs {
+		if !p.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(p.Name())
+		if err != nil {
+			continue
+		}
+		fds, err := os.ReadDir(fmt.Sprintf("/proc/%d/fdinfo", pid))
+		if err != nil {
+			continue // permission denied or process gone
+		}
+		for _, fd := range fds {
+			gtt, vram, cid, ok := parseDRMFdinfoFile(
+				fmt.Sprintf("/proc/%d/fdinfo/%s", pid, fd.Name()),
+			)
+			if !ok {
+				continue
+			}
+			e := byPID[pid]
+			if e == nil {
+				e = &pidEntry{seen: make(map[int64]struct{})}
+				byPID[pid] = e
+			}
+			// Deduplicate by client-id when available so that dup'd fds don't
+			// double-count the same allocation. When cid < 0 (kernel didn't
+			// provide it) count every fd independently.
+			if cid >= 0 {
+				if _, dup := e.seen[cid]; dup {
+					continue
+				}
+				e.seen[cid] = struct{}{}
+			}
+			e.gttMB += gtt
+			e.vramMB += vram
+		}
+	}
+
+	// Merge KFD per-process memory so that ROCm/HIP processes that allocate
+	// fine-grained unified memory (bypassing DRM fdinfo) are still attributed.
+	// /sys/class/kfd/kfd/proc/{pid}/vram_* is the KFD-side view; take the max
+	// of DRM and KFD so coarse-grained allocations visible in both are not
+	// double-counted.
+	if kfdProcs, err := os.ReadDir("/sys/class/kfd/kfd/proc"); err == nil {
+		for _, kp := range kfdProcs {
+			if !kp.IsDir() {
+				continue
+			}
+			pid, err := strconv.Atoi(kp.Name())
+			if err != nil {
+				continue
+			}
+			kMB := kfdProcMemMB(pid)
+			if kMB <= 0 {
+				continue
+			}
+			e := byPID[pid]
+			if e == nil {
+				e = &pidEntry{seen: make(map[int64]struct{})}
+				byPID[pid] = e
+			}
+			if kMB > e.gttMB+e.vramMB {
+				e.gttMB = kMB
+				e.vramMB = 0
+			}
+		}
+	}
+
+	var out []GpuProc
+	for pid, e := range byPID {
+		memMB := e.gttMB + e.vramMB
+		if memMB <= 0 {
+			continue
+		}
+		name := ""
+		if b, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid)); err == nil {
+			name = strings.TrimSpace(string(b))
+		}
+		out = append(out, GpuProc{PID: pid, Name: name, MemMB: memMB})
+	}
+	return out
+}
+
+// kfdProcMemMB sums /sys/class/kfd/kfd/proc/{pid}/vram_* for one process and
+// returns the total in MB.  The vram_* files are named vram_{gpu_id} where
+// gpu_id comes from the KFD topology (not a DRM node index).  Returns 0 when
+// the process has no KFD entry or the path is unreadable.
+func kfdProcMemMB(pid int) int {
+	dir := fmt.Sprintf("/sys/class/kfd/kfd/proc/%d", pid)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	var total int64
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), "vram_") {
+			continue
+		}
+		b, err := os.ReadFile(dir + "/" + e.Name())
+		if err != nil {
+			continue
+		}
+		v, _ := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+		total += v
+	}
+	return int(total / (1024 * 1024))
+}
+
+// parseDRMFdinfoFile reads one /proc/{pid}/fdinfo/{fd} file and returns
+// (gttMB, vramMB, clientID, ok). ok=false when not an amdgpu DRM client or
+// when the file cannot be read.
+func parseDRMFdinfoFile(path string) (gttMB, vramMB int, clientID int64, ok bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	var isAMD bool
+	var gttKiB, vramKiB int64
+	clientID = -1
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		k, v, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		switch strings.TrimSpace(k) {
+		case "drm-driver":
+			isAMD = strings.TrimSpace(v) == "amdgpu"
+		case "drm-client-id":
+			clientID, _ = strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		case "drm-memory-gtt":
+			gttKiB = parseDRMKiB(strings.TrimSpace(v))
+		case "drm-memory-vram":
+			vramKiB = parseDRMKiB(strings.TrimSpace(v))
+		}
+	}
+	if !isAMD {
+		return
+	}
+	return int(gttKiB / 1024), int(vramKiB / 1024), clientID, true
+}
+
+// parseDRMKiB parses a DRM fdinfo memory value like "229184 KiB" and returns
+// the size in KiB. Handles KiB, MiB, GiB, and B unit suffixes.
+func parseDRMKiB(s string) int64 {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return 0
+	}
+	v, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	if len(fields) < 2 {
+		return v // assume KiB
+	}
+	switch strings.ToUpper(fields[1]) {
+	case "KIB", "KB":
+		return v
+	case "MIB", "MB":
+		return v * 1024
+	case "GIB", "GB":
+		return v * 1024 * 1024
+	case "B":
+		return v / 1024
+	}
+	return v // fallback: assume KiB
+}

--- a/internal/perf/computeapps_other.go
+++ b/internal/perf/computeapps_other.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !linux
 
 package perf
 

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -39,6 +39,13 @@ func getGpuStats(ctx context.Context, every time.Duration, logger *logmon.Monito
 		logger.Debugf("nvidia-smi: %s", err.Error())
 	}
 
+	if ch, err := tryAmdSmi(ctx, every, logger); err == nil {
+		logger.Info("using amd-smi for GPU monitoring")
+		return ch, nil
+	} else {
+		logger.Debugf("amd-smi: %s", err.Error())
+	}
+
 	if ch, err := tryRocmSmi(ctx, every, logger); err == nil {
 		logger.Info("using rocm-smi for GPU monitoring")
 		return ch, nil
@@ -247,7 +254,7 @@ func tryRocmSmi(ctx context.Context, every time.Duration, logger *logmon.Monitor
 				return
 			case <-ticker.C:
 				pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)
-				cmd := exec.CommandContext(pollCtx, "rocm-smi", "-i", "-P", "-t", "-f", "-u", "--showmemuse", "--showmeminfo", "vram", "--showproductname", "--csv")
+				cmd := exec.CommandContext(pollCtx, "rocm-smi", "-i", "-P", "-t", "-f", "-u", "--showmemuse", "--showmeminfo", "all", "--showproductname", "--csv")
 				out, err := cmd.Output()
 				timedOut := pollCtx.Err() == context.DeadlineExceeded
 				cancel()
@@ -309,6 +316,9 @@ func parseRocmSmiLine(header string, line string) *GpuStat {
 	var deviceName string
 	var cardSeries string
 	var gfxVersion string
+	var nodeID int = -1
+	var vramTotalB, vramUsedB uint64
+	var gttTotalB, gttUsedB uint64
 
 	const toMB = 1024 * 1024
 
@@ -347,11 +357,15 @@ func parseRocmSmiLine(header string, line string) *GpuStat {
 			memUtil, _ := strconv.ParseFloat(val, 64)
 			result.MemUtilPct = memUtil
 		case "VRAM Total Memory (B)":
-			memTotal, _ := strconv.ParseUint(val, 10, 64)
-			result.MemTotalMB = int(memTotal / toMB)
+			vramTotalB, _ = strconv.ParseUint(val, 10, 64)
 		case "VRAM Total Used Memory (B)":
-			memUsed, _ := strconv.ParseUint(val, 10, 64)
-			result.MemUsedMB = int(memUsed / toMB)
+			vramUsedB, _ = strconv.ParseUint(val, 10, 64)
+		case "GTT Total Memory (B)":
+			gttTotalB, _ = strconv.ParseUint(val, 10, 64)
+		case "GTT Total Used Memory (B)":
+			gttUsedB, _ = strconv.ParseUint(val, 10, 64)
+		case "Node ID":
+			nodeID, _ = strconv.Atoi(val)
 		case "Card Series":
 			cardSeries = val
 		case "GFX Version":
@@ -361,6 +375,17 @@ func parseRocmSmiLine(header string, line string) *GpuStat {
 
 	if result.ID == -1 {
 		return nil
+	}
+
+	// APUs have no dedicated local memory (KFD local_mem_size == 0) and run
+	// workloads in GTT (system RAM). Combine VRAM+GTT to report the real
+	// addressable budget; fall back to VRAM-only if KFD is unavailable.
+	if isAPU, ok := kfdIsAPU(nodeID); ok && isAPU {
+		result.MemTotalMB = int((vramTotalB + gttTotalB) / toMB)
+		result.MemUsedMB = int((vramUsedB + gttUsedB) / toMB)
+	} else {
+		result.MemTotalMB = int(vramTotalB / toMB)
+		result.MemUsedMB = int(vramUsedB / toMB)
 	}
 
 	name := device
@@ -374,8 +399,358 @@ func parseRocmSmiLine(header string, line string) *GpuStat {
 	return result
 }
 
+// kfdIsAPU reports whether the KFD topology node at nodeID has no dedicated
+// local memory (local_mem_size == 0), which is the kernel's explicit marker for
+// an APU / iGPU that uses shared system RAM rather than its own VRAM.
+// Returns (false, false) when KFD is unavailable or the field is absent.
+func kfdIsAPU(nodeID int) (bool, bool) {
+	if nodeID < 0 {
+		return false, false
+	}
+	path := fmt.Sprintf("/sys/class/kfd/kfd/topology/nodes/%d/properties", nodeID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, false
+	}
+	var localMem uint64
+	var hasLocalMem bool
+	var simdCount uint64
+	for _, line := range strings.Split(string(data), "\n") {
+		f := strings.Fields(line)
+		if len(f) != 2 {
+			continue
+		}
+		v, _ := strconv.ParseUint(f[1], 10, 64)
+		switch f[0] {
+		case "simd_count":
+			simdCount = v
+		case "local_mem_size":
+			localMem = v
+			hasLocalMem = true
+		}
+	}
+	if !hasLocalMem || simdCount == 0 {
+		return false, false
+	}
+	return localMem == 0, true
+}
+
+// kfdIsAPUByBDF looks up the KFD topology node for the GPU at the given PCIe
+// BDF (e.g. "0000:65:00.0") and returns whether it is an APU.
+// location_id in KFD properties encodes the BDF as (bus<<8)|(dev<<3)|fn.
+func kfdIsAPUByBDF(bdf string) (bool, bool) {
+	parts := strings.Split(bdf, ":")
+	if len(parts) < 2 {
+		return false, false
+	}
+	busStr := parts[len(parts)-2]
+	devFn := parts[len(parts)-1]
+	df := strings.SplitN(devFn, ".", 2)
+	if len(df) != 2 {
+		return false, false
+	}
+	bus, err1 := strconv.ParseUint(busStr, 16, 64)
+	dev, err2 := strconv.ParseUint(df[0], 16, 64)
+	fn, err3 := strconv.ParseUint(df[1], 16, 64)
+	if err1 != nil || err2 != nil || err3 != nil {
+		return false, false
+	}
+	wantLoc := (bus << 8) | (dev << 3) | fn
+
+	nodes, _ := filepath.Glob("/sys/class/kfd/kfd/topology/nodes/*/properties")
+	for _, p := range nodes {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		var locationID, simdCount, localMem uint64
+		var hasLocalMem bool
+		for _, line := range strings.Split(string(data), "\n") {
+			f := strings.Fields(line)
+			if len(f) != 2 {
+				continue
+			}
+			v, _ := strconv.ParseUint(f[1], 10, 64)
+			switch f[0] {
+			case "location_id":
+				locationID = v
+			case "simd_count":
+				simdCount = v
+			case "local_mem_size":
+				localMem = v
+				hasLocalMem = true
+			}
+		}
+		if simdCount == 0 || locationID != wantLoc || !hasLocalMem {
+			continue
+		}
+		return localMem == 0, true
+	}
+	return false, false
+}
+
+// sysfsReadInt64 reads a single integer value from a sysfs file.
+func sysfsReadInt64(path string) (int64, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	return v, err == nil
+}
+
+// sysfsReadHwmon reads a hwmon attribute (e.g. "temp1_input") for a DRM card
+// device directory. It picks the first matching hwmon instance.
+func sysfsReadHwmon(cardDevDir, attr string) (int64, bool) {
+	matches, _ := filepath.Glob(cardDevDir + "/hwmon/hwmon*/" + attr)
+	if len(matches) == 0 {
+		return 0, false
+	}
+	return sysfsReadInt64(matches[0])
+}
+
+// findDRMCardByBDF returns the sysfs device directory for the DRM card whose
+// uevent PCI_SLOT_NAME matches bdf (e.g. "0000:65:00.0"), or "" if not found.
+func findDRMCardByBDF(bdf string) string {
+	ueventPaths, _ := filepath.Glob("/sys/class/drm/card*/device/uevent")
+	for _, p := range ueventPaths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if strings.TrimSpace(line) == "PCI_SLOT_NAME="+bdf {
+				return filepath.Dir(p)
+			}
+		}
+	}
+	return ""
+}
+
+// amdSmiGPUMeta holds per-GPU static information built once at tryAmdSmi startup.
+type amdSmiGPUMeta struct {
+	index   int
+	name    string
+	uuid    string
+	isAPU   bool
+	cardDir string // /sys/class/drm/cardN/device
+}
+
+func tryAmdSmi(ctx context.Context, every time.Duration, logger *logmon.Monitor) (chan []GpuStat, error) {
+	if _, err := exec.LookPath("amd-smi"); err != nil {
+		return nil, ErrNoGpuTool
+	}
+	if every < time.Second {
+		every = time.Second
+	}
+
+	const probeTimeout = 5 * time.Second
+	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	metas, err := amdSmiEnumerate(probeCtx)
+	cancel()
+	if err != nil {
+		return nil, fmt.Errorf("amd-smi enumerate: %w", err)
+	}
+	if len(metas) == 0 {
+		return nil, fmt.Errorf("amd-smi found no GPUs")
+	}
+
+	// Verify the memory query path works before committing to this backend.
+	verifyCtx, cancel2 := context.WithTimeout(ctx, probeTimeout)
+	_, err = amdSmiQueryStats(verifyCtx, metas)
+	cancel2()
+	if err != nil {
+		return nil, fmt.Errorf("amd-smi mem query: %w", err)
+	}
+
+	const pollTimeout = 5 * time.Second
+	ch := make(chan []GpuStat, 1)
+	go func() {
+		defer close(ch)
+		ticker := time.NewTicker(every)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)
+				stats, err := amdSmiQueryStats(pollCtx, metas)
+				cancel()
+				if err != nil || len(stats) == 0 {
+					continue
+				}
+				select {
+				case ch <- stats:
+				default:
+				}
+			}
+		}
+	}()
+	return ch, nil
+}
+
+func amdSmiEnumerate(ctx context.Context) ([]amdSmiGPUMeta, error) {
+	listOut, err := exec.CommandContext(ctx, "amd-smi", "list", "--json").Output()
+	if err != nil {
+		return nil, err
+	}
+	var listEntries []struct {
+		GPU    int    `json:"gpu"`
+		BDF    string `json:"bdf"`
+		UUID   string `json:"uuid"`
+		NodeID int    `json:"node_id"`
+	}
+	if err := json.Unmarshal(listOut, &listEntries); err != nil {
+		return nil, err
+	}
+
+	// Fetch market names from the asic block; non-fatal if it fails.
+	nameMap := map[int]string{}
+	if staticOut, err := exec.CommandContext(ctx, "amd-smi", "static", "--asic", "--json").Output(); err == nil {
+		var staticResp struct {
+			GPUData []struct {
+				GPU  int `json:"gpu"`
+				ASIC struct {
+					MarketName string `json:"market_name"`
+				} `json:"asic"`
+			} `json:"gpu_data"`
+		}
+		if json.Unmarshal(staticOut, &staticResp) == nil {
+			for _, d := range staticResp.GPUData {
+				if d.ASIC.MarketName != "" && d.ASIC.MarketName != "N/A" {
+					nameMap[d.GPU] = d.ASIC.MarketName
+				}
+			}
+		}
+	}
+
+	metas := make([]amdSmiGPUMeta, 0, len(listEntries))
+	for _, e := range listEntries {
+		isAPU, _ := kfdIsAPU(e.NodeID)
+		name := nameMap[e.GPU]
+		if name == "" {
+			name = fmt.Sprintf("AMD GPU %d", e.GPU)
+		}
+		metas = append(metas, amdSmiGPUMeta{
+			index:   e.GPU,
+			name:    name,
+			uuid:    e.UUID,
+			isAPU:   isAPU,
+			cardDir: findDRMCardByBDF(e.BDF),
+		})
+	}
+	return metas, nil
+}
+
+func amdSmiQueryStats(ctx context.Context, metas []amdSmiGPUMeta) ([]GpuStat, error) {
+	out, err := exec.CommandContext(ctx, "amd-smi", "metric", "--mem-usage", "--json").Output()
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		GPUData []struct {
+			GPU      int `json:"gpu"`
+			MemUsage struct {
+				TotalVRAM struct{ Value int `json:"value"` } `json:"total_vram"`
+				UsedVRAM  struct{ Value int `json:"value"` } `json:"used_vram"`
+				TotalGTT  struct{ Value int `json:"value"` } `json:"total_gtt"`
+				UsedGTT   struct{ Value int `json:"value"` } `json:"used_gtt"`
+			} `json:"mem_usage"`
+		} `json:"gpu_data"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, err
+	}
+
+	metaByIdx := make(map[int]*amdSmiGPUMeta, len(metas))
+	for i := range metas {
+		metaByIdx[metas[i].index] = &metas[i]
+	}
+
+	stats := make([]GpuStat, 0, len(resp.GPUData))
+	for _, d := range resp.GPUData {
+		m, ok := metaByIdx[d.GPU]
+		if !ok {
+			continue
+		}
+		var totalMB, usedMB int
+		if m.isAPU {
+			totalMB = d.MemUsage.TotalVRAM.Value + d.MemUsage.TotalGTT.Value
+			usedMB = d.MemUsage.UsedVRAM.Value + d.MemUsage.UsedGTT.Value
+		} else {
+			totalMB = d.MemUsage.TotalVRAM.Value
+			usedMB = d.MemUsage.UsedVRAM.Value
+		}
+
+		var memUtil float64
+		if totalMB > 0 {
+			memUtil = float64(usedMB) / float64(totalMB) * 100
+		}
+
+		stat := GpuStat{
+			Timestamp:  time.Now(),
+			ID:         d.GPU,
+			Name:       m.name,
+			UUID:       m.uuid,
+			MemTotalMB: totalMB,
+			MemUsedMB:  usedMB,
+			MemUtilPct: memUtil,
+		}
+
+		// Supplement from sysfs: utilization, temperature, and power are not
+		// available via amd-smi on APUs (returns N/A).
+		if m.cardDir != "" {
+			if util, ok2 := sysfsReadInt64(m.cardDir + "/gpu_busy_percent"); ok2 {
+				stat.GpuUtilPct = float64(util)
+			}
+			if temp, ok2 := sysfsReadHwmon(m.cardDir, "temp1_input"); ok2 {
+				stat.TempC = int(temp / 1000)
+			}
+			if pwr, ok2 := sysfsReadHwmon(m.cardDir, "power1_average"); ok2 {
+				stat.PowerDrawW = float64(pwr) / 1_000_000
+			}
+		}
+
+		stats = append(stats, stat)
+	}
+	return stats, nil
+}
+
 func trySysfs(ctx context.Context, every time.Duration, logger *logmon.Monitor) (chan []GpuStat, error) {
-	return nil, ErrNotImplemented
+	stats, err := readSysfs()
+	if err != nil {
+		return nil, err
+	}
+	if len(stats) == 0 {
+		return nil, ErrNoGpuTool
+	}
+	if every < time.Second {
+		every = time.Second
+	}
+
+	ch := make(chan []GpuStat, 1)
+	go func() {
+		defer close(ch)
+		ticker := time.NewTicker(every)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				stats, err := readSysfs()
+				if err != nil || len(stats) == 0 {
+					continue
+				}
+				select {
+				case ch <- stats:
+				default:
+				}
+			}
+		}
+	}()
+	return ch, nil
 }
 
 func lactSocketPath() string {
@@ -566,7 +941,149 @@ func lactGetDeviceStats(conn net.Conn, id string, name string, index int) (GpuSt
 }
 
 func readSysfs() ([]GpuStat, error) {
-	return nil, ErrNotImplemented
+	ueventPaths, _ := filepath.Glob("/sys/class/drm/card*/device/uevent")
+	if len(ueventPaths) == 0 {
+		return nil, ErrNoGpuTool
+	}
+
+	var stats []GpuStat
+	for _, ueventPath := range ueventPaths {
+		data, err := os.ReadFile(ueventPath)
+		if err != nil {
+			continue
+		}
+
+		var driver, pciSlot, pciID string
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			switch {
+			case strings.HasPrefix(line, "DRIVER="):
+				driver = strings.TrimPrefix(line, "DRIVER=")
+			case strings.HasPrefix(line, "PCI_SLOT_NAME="):
+				pciSlot = strings.TrimPrefix(line, "PCI_SLOT_NAME=")
+			case strings.HasPrefix(line, "PCI_ID="):
+				pciID = strings.TrimPrefix(line, "PCI_ID=")
+			}
+		}
+		if driver != "amdgpu" {
+			continue
+		}
+
+		cardDevDir := filepath.Dir(ueventPath)
+		cardName := filepath.Base(filepath.Dir(cardDevDir))
+		cardIndex, _ := strconv.Atoi(strings.TrimPrefix(cardName, "card"))
+
+		vramTotal, _ := sysfsReadInt64(cardDevDir + "/mem_info_vram_total")
+		vramUsed, _ := sysfsReadInt64(cardDevDir + "/mem_info_vram_used")
+		gttTotal, _ := sysfsReadInt64(cardDevDir + "/mem_info_gtt_total")
+		gttUsed, _ := sysfsReadInt64(cardDevDir + "/mem_info_gtt_used")
+		if vramTotal == 0 && gttTotal == 0 {
+			continue
+		}
+
+		isAPU, _ := kfdIsAPUByBDF(pciSlot)
+
+		const toMB = 1024 * 1024
+		var totalMB, usedMB int
+		if isAPU {
+			totalMB = int((vramTotal + gttTotal) / toMB)
+			usedMB = int((vramUsed + gttUsed) / toMB)
+			// On AMD APU, ROCm/HIP can allocate "fine-grained unified memory"
+			// via KFD that bypasses DRM TTM entirely, leaving mem_info_gtt_used
+			// flat even as the model occupies gigabytes.  Add whatever the KFD
+			// per-process totals show beyond what gtt_used already accounts for.
+			usedMB += kfdExtraMemMB(gttUsed)
+		} else {
+			totalMB = int(vramTotal / toMB)
+			usedMB = int(vramUsed / toMB)
+		}
+
+		var memUtil float64
+		if totalMB > 0 {
+			memUtil = float64(usedMB) / float64(totalMB) * 100
+		}
+
+		var gpuUtil float64
+		if util, ok := sysfsReadInt64(cardDevDir + "/gpu_busy_percent"); ok {
+			gpuUtil = float64(util)
+		}
+
+		var tempC int
+		if t, ok := sysfsReadHwmon(cardDevDir, "temp1_input"); ok {
+			tempC = int(t / 1000)
+		}
+
+		var powerW float64
+		if p, ok := sysfsReadHwmon(cardDevDir, "power1_average"); ok {
+			powerW = float64(p) / 1_000_000
+		}
+
+		name := "amdgpu"
+		if pciID != "" {
+			name = "amdgpu [" + pciID + "]"
+		}
+
+		stats = append(stats, GpuStat{
+			Timestamp:  time.Now(),
+			ID:         cardIndex,
+			Name:       name,
+			TempC:      tempC,
+			GpuUtilPct: gpuUtil,
+			MemUtilPct: memUtil,
+			MemUsedMB:  usedMB,
+			MemTotalMB: totalMB,
+			PowerDrawW: powerW,
+		})
+	}
+
+	if len(stats) == 0 {
+		return nil, ErrNoGpuTool
+	}
+	return stats, nil
+}
+
+// kfdExtraMemMB returns the KFD fine-grained unified memory (in MB) that is
+// NOT already counted in the DRM gtt_used counter.  On AMD APU with ROCm, the
+// HIP runtime can allocate model weights through the KFD HSA driver using
+// fine-grained system memory that bypasses DRM TTM — those bytes never appear
+// in mem_info_gtt_used.  This function reads
+// /sys/class/kfd/kfd/proc/*/vram_* (Linux KFD sysfs), sums all per-process
+// KFD allocations, then returns max(0, kfdTotal − gttUsedBytes) so that only
+// the portion that the DRM counter misses is added to usedMB.  Returns 0 on
+// any system where the KFD sysfs path is absent (BSD, no ROCm, etc.).
+func kfdExtraMemMB(gttUsedBytes int64) int {
+	entries, err := os.ReadDir("/sys/class/kfd/kfd/proc")
+	if err != nil {
+		return 0
+	}
+	var kfdTotal int64
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		procDir := "/sys/class/kfd/kfd/proc/" + e.Name()
+		fds, err := os.ReadDir(procDir)
+		if err != nil {
+			continue
+		}
+		for _, fd := range fds {
+			if !strings.HasPrefix(fd.Name(), "vram_") {
+				continue
+			}
+			b, err := os.ReadFile(procDir + "/" + fd.Name())
+			if err != nil {
+				continue
+			}
+			v, _ := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+			kfdTotal += v
+		}
+	}
+	extra := kfdTotal - gttUsedBytes
+	if extra <= 0 {
+		return 0
+	}
+	const toMB = 1024 * 1024
+	return int(extra / toMB)
 }
 
 func readSysStats() (SysStat, error) {


### PR DESCRIPTION
## Summary

Reference implementation for the Docker/container gap in #37 / #39: rocm-smi
and amd-smi based fixes still depend on a CLI tool that can actually see the
device, which is exactly what's often missing in a container (device nodes
passed through, no ROCm userspace stack in the image). This reads the
kernel's own sysfs/DRM/KFD surfaces directly as a tool-free backend of last
resort.

- `monitor_unix.go`: `trySysfs`/`readSysfs` implemented for real (was
  `ErrNotImplemented`) via `/sys/class/drm/card*/device/mem_info_{vram,gtt}_*`;
  `kfdIsAPU`/`kfdIsAPUByBDF` classify integrated vs. discrete from KFD
  topology (`local_mem_size == 0`) rather than a name/ratio guess;
  `kfdExtraMemMB` accounts for ROCm/HIP fine-grained unified-memory
  allocations that bypass the DRM GTT counter entirely; `tryAmdSmi` adds
  `amd-smi` as a second CLI backend ahead of `rocm-smi`
- `computeapps_linux.go` (new): per-process GPU memory attribution via
  `/proc/*/fdinfo` DRM counters merged with per-process KFD totals,
  replacing the `nil` stub on Linux
- `computeapps_other.go`: build tag narrowed to exclude linux now that it
  has its own implementation

## Note on base / mergeability

This was written independently, before #39's `SharedTotalMB`/`GpuPolicy`
refactor landed, so it does **not** apply cleanly on top of that branch —
it's here as reference for the sysfs/KFD approach, not a diff meant to
merge as-is. Not compiled or tested in this environment (no Go toolchain
available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPhH1r8cFK7Xt8gwGw4ZzK